### PR TITLE
fix: dependency version convergence error for direct dependency

### DIFF
--- a/jkube-kit/common/pom.xml
+++ b/jkube-kit/common/pom.xml
@@ -47,6 +47,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
@@ -95,7 +100,7 @@
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-assembly-plugin</artifactId>
     </dependency>
-      
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/jkube-kit/config/resource/pom.xml
+++ b/jkube-kit/config/resource/pom.xml
@@ -50,6 +50,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -67,7 +73,7 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>openshift-server-mock</artifactId>

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -80,6 +80,7 @@
     <version.hamcrest-library>1.3</version.hamcrest-library>
     <version.assertj>3.11.1</version.assertj>
     <version.snakeyaml>1.25</version.snakeyaml>
+    <version.bouncycastle.bcpkix>1.61</version.bouncycastle.bcpkix>
 
     <!-- =======================================================  -->
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
@@ -333,7 +334,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.57</version>
+        <version>${version.bouncycastle.bcpkix}</version>
       </dependency>
 
       <dependency>
@@ -501,6 +502,12 @@
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-archiver</artifactId>
         <version>3.5</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
 


### PR DESCRIPTION
We have a direct dependency to `org.yaml:snakeyaml:1.25` and `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` depends on `1.23`.
This change excludes the latter.