### PR TITLE
Ported PR https://github.com/fabric8io/fabric8-maven-plugin/pull/1711

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 ### 0.2-SNAPSHOT
 * Fix #71: script to extract changelog information for notifications
+* Fix #34: Ported OpenLiberty support: https://github.com/fabric8io/fabric8-maven-plugin/pull/1711
 * Fix #76: Github actions checkout v2
 * Updated Kubernetes-Client Version to 4.7.1 #70
 * Fix #30: Decouple JKube-kit from maven

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/FileUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/FileUtil.java
@@ -354,7 +354,7 @@ public class FileUtil {
 
     public static void createDirectory(File directory) throws IOException {
         if (!directory.exists()) {
-            boolean isCreated = directory.mkdir();
+            boolean isCreated = directory.mkdirs();
             if (!isCreated) {
                 throw new IOException("Failed to create directory: " + directory.getAbsolutePath());
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ExposeEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ExposeEnricher.java
@@ -39,7 +39,7 @@ public class ExposeEnricher extends BaseEnricher {
         super(buildContext, "jkube-openshift-service-expose");
     }
 
-    private Set<Integer> webPorts = new HashSet<>(Arrays.asList(80, 443, 8080, 9090));
+    private Set<Integer> webPorts = new HashSet<>(Arrays.asList(80, 443, 8080, 9080, 9090, 9443));
 
     public static final String EXPOSE_LABEL = "expose";
 

--- a/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
+++ b/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
@@ -49,8 +49,8 @@ public class JavaExecGenerator extends BaseGenerator {
 
     // Plugins indicating a plain java build
     private static final String[][] JAVA_EXEC_MAVEN_PLUGINS = new String[][] {
-        new String[] { "org.codehaus.mojo", "exec-maven-plugin" },
-        new String[] { "org.apache.maven.plugins", "maven-shade-plugin" }
+            new String[] { "org.codehaus.mojo", "exec-maven-plugin" },
+            new String[] { "org.apache.maven.plugins", "maven-shade-plugin" }
     };
 
     private final FatJarDetector fatJarDetector;
@@ -64,8 +64,8 @@ public class JavaExecGenerator extends BaseGenerator {
         super(context, name, new FromSelector.Default(context, "java"));
         fatJarDetector = new FatJarDetector(getProject().getBuildDirectory());
         mainClassDetector = new MainClassDetector(getConfig(Config.mainClass),
-                                                  new File(getProject().getOutputDirectory()),
-                                                  context.getLogger());
+                new File(getProject().getOutputDirectory()),
+                context.getLogger());
     }
 
     public enum Config implements Configs.Key {
@@ -81,11 +81,11 @@ public class JavaExecGenerator extends BaseGenerator {
         // Basedirectory where to put the application data into (within the Docker image
         targetDir {{d = "/deployments"; }},
 
-        // The name of the main class for non-far jars. If not speficied it is tried
+        // The name of the main class for non-fat jars. If not specified it is tried
         // to find a main class within target/classes.
         mainClass,
 
-        // Reference to a predefined assembly descriptor to use. By defult it is tried to be detected
+        // Reference to a predefined assembly descriptor to use. By default it is tried to be detected
         assemblyRef;
 
         public String def() { return d; } protected String d;
@@ -127,10 +127,10 @@ public class JavaExecGenerator extends BaseGenerator {
         buildBuilder.env(envMap);
         addLatestTagIfSnapshot(buildBuilder);
         imageBuilder
-            .name(getImageName())
-            .registry(getRegistry())
-            .alias(getAlias())
-            .buildConfig(buildBuilder.build());
+                .name(getImageName())
+                .registry(getRegistry())
+                .alias(getAlias())
+                .buildConfig(buildBuilder.build());
         configs.add(imageBuilder.build());
         return configs;
     }
@@ -197,14 +197,14 @@ public class JavaExecGenerator extends BaseGenerator {
         }
     }
 
-    private List<JKubeAssemblyFileSet> addAdditionalFiles(JKubeProject project) {
+    public List<JKubeAssemblyFileSet> addAdditionalFiles(JKubeProject project) {
         List<JKubeAssemblyFileSet> fileSets = new ArrayList<>();
-        fileSets.add(createFileSet(project, "src/main/jkube-includes/bin","0755"));
-        fileSets.add(createFileSet(project, "src/main/jkube-includes","0644"));
+        fileSets.add(createFileSet(project, "src/main/jkube-includes/bin","bin", "0755"));
+        fileSets.add(createFileSet(project, "src/main/jkube-includes",".", "0644"));
         return fileSets;
     }
 
-    private JKubeAssemblyFileSet getOutputDirectoryFileSet(FatJarDetector.Result fatJar, JKubeProject project) {
+    public JKubeAssemblyFileSet getOutputDirectoryFileSet(FatJarDetector.Result fatJar, JKubeProject project) {
         File buildDir = new File(project.getBuildDirectory());
         return new JKubeAssemblyFileSet.Builder()
                 .directory(getRelativePath(project.getBaseDirectory(), buildDir).getPath())
@@ -214,10 +214,11 @@ public class JavaExecGenerator extends BaseGenerator {
                 .build();
     }
 
-    private JKubeAssemblyFileSet createFileSet(JKubeProject project, String sourceDir, String fileMode) {
+    public JKubeAssemblyFileSet createFileSet(JKubeProject project, String sourceDir, String outputDir, String fileMode) {
         return new JKubeAssemblyFileSet.Builder()
                 .directory(project.getBaseDirectory().getAbsolutePath())
                 .includes(Collections.singletonList(sourceDir))
+                .outputDirectory(outputDir)
                 .fileMode(fileMode)
                 .build();
     }

--- a/jkube-kit/jkube-kit-openliberty/pom.xml
+++ b/jkube-kit/jkube-kit-openliberty/pom.xml
@@ -20,42 +20,32 @@
     <parent>
         <artifactId>jkube-kit-parent</artifactId>
         <groupId>org.eclipse.jkube</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>jkube-kit-openliberty</artifactId>
+    <name>JKube Kit :: Open Liberty</name>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jkube</groupId>
-            <artifactId>jkube-maven-enricher-api</artifactId>
+            <artifactId>jkube-kit-enricher-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jkube</groupId>
-            <artifactId>jkube-maven-enricher-specific</artifactId>
+            <artifactId>jkube-kit-enricher-specific</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jkube</groupId>
-            <artifactId>jkube-maven-generator-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jkube</groupId>
-            <artifactId>jkube-maven-generator-java-exec</artifactId>
+            <artifactId>jkube-kit-generator-java-exec</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jkube</groupId>
             <artifactId>jkube-kit-common</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jkube</groupId>
-            <artifactId>jkube-kit-config-image</artifactId>
         </dependency>
 
         <dependency>

--- a/jkube-kit/jkube-kit-openliberty/pom.xml
+++ b/jkube-kit/jkube-kit-openliberty/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jkube-kit-parent</artifactId>
+        <groupId>org.eclipse.jkube</groupId>
+        <version>0.1.1-SNAPSHOT</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jkube-kit-openliberty</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>jkube-maven-enricher-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>jkube-maven-enricher-specific</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>jkube-maven-generator-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>jkube-maven-generator-java-exec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>jkube-kit-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>jkube-kit-config-image</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGenerator.java
+++ b/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGenerator.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.openliberty.generator;
+
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.assembly.model.Assembly;
+import org.apache.maven.plugins.assembly.model.DependencySet;
+import org.apache.maven.plugins.assembly.model.FileSet;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.jkube.generator.api.GeneratorContext;
+import org.eclipse.jkube.generator.javaexec.FatJarDetector;
+import org.eclipse.jkube.generator.javaexec.JavaExecGenerator;
+import org.eclipse.jkube.kit.build.service.docker.ImageConfiguration;
+import org.eclipse.jkube.kit.common.util.MavenUtil;
+import org.eclipse.jkube.kit.config.image.build.AssemblyConfiguration;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.jkube.kit.common.util.FileUtil.getRelativePath;
+
+public class OpenLibertyGenerator extends JavaExecGenerator {
+
+	protected static final String LIBERTY_SELF_EXTRACTOR = "wlp.lib.extract.SelfExtractRun";
+	protected static final String LIBERTY_RUNNABLE_JAR = "LIBERTY_RUNNABLE_JAR";
+	protected static final String JAVA_APP_JAR = "JAVA_APP_JAR";
+	
+	private String runnableJarName = null;
+
+	public OpenLibertyGenerator(GeneratorContext context) {
+        super(context, "openliberty");
+    }
+
+    // Override so that the generator kicks in when the liberty-maven-plugin is used
+    @Override
+    public boolean isApplicable(List<ImageConfiguration> configs) {
+        return shouldAddImageConfiguration(configs)
+                && MavenUtil.hasPlugin(getProject(), "io.openliberty.tools", "liberty-maven-plugin");
+                
+    }
+
+    // Override extractPorts so that we default to 9080 rather than 8080 for the web port. 
+    @Override
+    protected List<String> extractPorts() {
+        List<String> ret = new ArrayList<>();
+        addPortIfValid(ret, getConfig(JavaExecGenerator.Config.webPort, "9080"));
+        addPortIfValid(ret, getConfig(JavaExecGenerator.Config.jolokiaPort));
+        addPortIfValid(ret, getConfig(JavaExecGenerator.Config.prometheusPort));
+        return ret;
+    }
+
+  
+    @Override
+    protected Map<String, String> getEnv(boolean prePackagePhase) throws MojoExecutionException {
+    	Map<String,String> ret = super.getEnv(prePackagePhase);
+    	if ( runnableJarName != null) {
+    		ret.put(LIBERTY_RUNNABLE_JAR, runnableJarName);
+    		ret.put(JAVA_APP_JAR, runnableJarName);
+    	}
+    	return ret;
+    }
+    @Override
+    protected AssemblyConfiguration createAssembly() throws MojoExecutionException {
+        AssemblyConfiguration.Builder builder = new AssemblyConfiguration.Builder().targetDir(getConfig(Config.targetDir));
+        addAssembly(builder);
+        return builder.build();
+    }
+    
+    @Override
+    protected void addAssembly(AssemblyConfiguration.Builder builder) throws MojoExecutionException {
+        String assemblyRef = getConfig(Config.assemblyRef);
+        if (assemblyRef != null) {
+            builder.descriptorRef(assemblyRef);
+        } else {
+            Assembly assembly = new Assembly();
+            addAdditionalFiles(assembly);
+            if (isFatJar()) {
+                FatJarDetector.Result fatJar = detectFatJar();
+                MavenProject project = getProject();
+                if (fatJar == null) {
+                    DependencySet dependencySet = new DependencySet();
+                    dependencySet.addInclude(project.getGroupId() + ":" + project.getArtifactId());
+                    assembly.addDependencySet(dependencySet);
+                } else {
+                    FileSet fileSet = getOutputDirectoryFileSet(fatJar, project);
+                    if ( LIBERTY_SELF_EXTRACTOR.equals(fatJar.getMainClass())) {
+                    	this.runnableJarName = fatJar.getArchiveFile().getName();
+                    }
+                    assembly.addFileSet(fileSet);
+                }
+            } else {
+                builder.descriptorRef("artifact-with-dependencies");
+            }
+            builder.assemblyDef(assembly);
+        }
+    }
+
+    private void addAdditionalFiles(Assembly assembly) {
+        assembly.addFileSet(createFileSet("src/main/fabric8-includes/bin","bin","0755","0755"));
+        assembly.addFileSet(createFileSet("src/main/fabric8-includes",".","0644","0755"));
+        // Add server.xml file
+        assembly.addFileSet(createFileSet("src/main/liberty/config","src/wlp/config","0644", "0755"));
+      
+    }
+    
+    private FileSet getOutputDirectoryFileSet(FatJarDetector.Result fatJar, MavenProject project) {
+        FileSet fileSet = new FileSet();
+        File buildDir = new File(project.getBuild().getDirectory());
+        fileSet.setDirectory(getRelativePath(project.getBasedir(), buildDir).getPath());
+        fileSet.addInclude(getRelativePath(buildDir, fatJar.getArchiveFile()).getPath());
+        fileSet.setOutputDirectory(".");
+        fileSet.setFileMode("0640");
+        return fileSet;
+    }
+
+    private FileSet createFileSet(String sourceDir, String outputDir, String fileMode, String directoryMode) {
+        FileSet fileSet = new FileSet();
+        fileSet.setDirectory(sourceDir);
+        fileSet.setOutputDirectory(outputDir);
+        fileSet.setFileMode(fileMode);
+        fileSet.setDirectoryMode(directoryMode);
+        return fileSet;
+    }
+    
+  
+  
+}

--- a/jkube-kit/jkube-kit-openliberty/src/main/resources/META-INF/jkube/generator-default
+++ b/jkube-kit/jkube-kit-openliberty/src/main/resources/META-INF/jkube/generator-default
@@ -1,0 +1,5 @@
+# The order of the generators used is defined in the active profile
+# (which is the profile "default" by default)
+# You can find the default profiles in "profiles-default.yml"
+
+org.eclipse.jkube.openliberty.generator.OpenLibertyGenerator

--- a/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
+++ b/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
@@ -1,0 +1,108 @@
+package org.eclipse.jkube.openliberty.generator;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.jar.Attributes;
+
+import org.eclipse.jkube.generator.api.GeneratorContext;
+import org.eclipse.jkube.generator.javaexec.FatJarDetector;
+import org.eclipse.jkube.kit.build.core.config.JKubeAssemblyConfiguration;
+import org.eclipse.jkube.kit.common.JKubeProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.junit.Test;
+
+import mockit.Expectations;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+
+public class OpenLibertyGeneratorTest {
+
+    @Mocked
+    KitLogger log;
+
+    @Mocked
+    private GeneratorContext context;
+
+    @Mocked
+    private JKubeProject project;
+
+    @Test
+    public void testLibertyRunnable() throws IOException {
+
+        new MockFatJarDetector(true);
+
+        OpenLibertyGenerator generator = new OpenLibertyGenerator(createGeneratorContext());
+
+        generator.addAssembly(new JKubeAssemblyConfiguration.Builder());
+        assertTrue("The LIBERTY_RUNNABLE_JAR env var should be set",
+                generator.getEnv(false).containsKey(OpenLibertyGenerator.LIBERTY_RUNNABLE_JAR));
+        assertTrue("The JAVA_APP_DIR env var should be set",
+                generator.getEnv(false).containsKey(OpenLibertyGenerator.JAVA_APP_JAR));
+
+    }
+
+    @Test
+    public void testExtractPorts() throws IOException {
+
+        OpenLibertyGenerator generator = new OpenLibertyGenerator(createGeneratorContext());
+        List<String> ports = generator.extractPorts();
+        assertNotNull(ports);
+        assertTrue("The list of ports should contain 9080", ports.contains("9080"));
+
+    }
+
+    private GeneratorContext createGeneratorContext() throws IOException {
+        new Expectations() {
+            {
+                context.getProject();
+                result = project;
+                project.getBaseDirectory();
+                minTimes = 0;
+                result = "basedirectory";
+
+                String tempDir = Files.createTempDirectory("openliberty-test-project").toFile().getAbsolutePath();
+
+                project.getBuildDirectory();
+                result = tempDir;
+                project.getOutputDirectory();
+                result = tempDir;
+                minTimes = 0;
+                project.getVersion();
+                result = "1.0.0";
+                minTimes = 0;
+            }
+        };
+        return context;
+
+    }
+
+    public static class MockFatJarDetector extends MockUp<FatJarDetector> {
+
+        private final boolean findClass;
+
+        public MockFatJarDetector(boolean findClass) {
+            this.findClass = findClass;
+        }
+
+        @Mock
+        FatJarDetector.Result scan(Invocation invocation) {
+
+            if (!findClass) {
+                return null;
+            }
+
+            FatJarDetector detector = invocation.getInvokedInstance();
+            return detector.new Result(new File("/the/archive/file"), OpenLibertyGenerator.LIBERTY_SELF_EXTRACTOR,
+                    new Attributes());
+        }
+
+    }
+
+}

--- a/jkube-kit/pom.xml
+++ b/jkube-kit/pom.xml
@@ -55,6 +55,7 @@
       <module>jkube-kit-thorntail-v2</module>
       <module>jkube-kit-vertx</module>
       <module>jkube-kit-quarkus</module>
+      <module>jkube-kit-openliberty</module>
   </modules>
 
 </project>

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_generator.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_generator.adoc
@@ -45,6 +45,11 @@ All default generators examine the build information for certain aspects and gen
 | <<generator-quarkus,Quarkus>>
 | `Quarkus`
 | Generator for Quarkus based applications
+
+
+| <<generator-openliberty,Open Liberty>>
+| `webapps`
+| Generator for Open Liberty applications
 |===
 
 include::generator/_options_common.adoc[]
@@ -57,5 +62,6 @@ include::generator/_vertx.adoc[]
 include::generator/_karaf.adoc[]
 include::generator/_webapp.adoc[]
 include::generator/_quarkus.adoc[]
+include::generator/_openliberty.adoc[]
 
 include::generator/_api.adoc[]

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_openliberty.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_openliberty.adoc
@@ -1,0 +1,8 @@
+[[generator-openliberty]]
+=== Open Liberty
+
+The Open Liberty generator runs when the Open Liberty plugin is enabled in the maven build. 
+
+The generator is similar to the <<generator-java-exec,java-exec generator>>. It supports the  <<generator-options-common, common generator options>> and the <<generator-java-exec-options, `java-exec` options>>.
+
+For Open Liberty, the default value of webPort is 9080. 

--- a/kubernetes-maven-plugin/plugin/pom.xml
+++ b/kubernetes-maven-plugin/plugin/pom.xml
@@ -105,6 +105,12 @@
             <artifactId>jkube-kit-quarkus</artifactId>
             <version>${jkube.kit.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>jkube-kit-openliberty</artifactId>
+            <version>${jkube.kit.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.jkube</groupId>

--- a/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -74,6 +74,7 @@
     - spring-boot
     - wildfly-swarm
     - thorntail-v2
+    - openliberty
     - karaf
     - vertx
     - java-exec

--- a/openshift-maven-plugin/doc/src/main/asciidoc/inc/_generator.adoc
+++ b/openshift-maven-plugin/doc/src/main/asciidoc/inc/_generator.adoc
@@ -45,6 +45,10 @@ All default generators examine the build information for certain aspects and gen
 | <<generator-quarkus,Quarkus>>
 | `Quarkus`
 | Generator for Quarkus based applications
+
+| <<generator-openliberty,Open Liberty>>
+| `webapps`
+| Generator for Open Liberty applications
 |===
 
 include::generator/_options_common.adoc[]
@@ -57,5 +61,6 @@ include::generator/_vertx.adoc[]
 include::generator/_karaf.adoc[]
 include::generator/_webapp.adoc[]
 include::generator/_quarkus.adoc[]
+include::generator/_openliberty.adoc[]
 
 include::generator/_api.adoc[]

--- a/openshift-maven-plugin/doc/src/main/asciidoc/inc/generator/_openliberty.adoc
+++ b/openshift-maven-plugin/doc/src/main/asciidoc/inc/generator/_openliberty.adoc
@@ -1,0 +1,8 @@
+[[generator-openliberty]]
+=== Open Liberty
+
+The Open Liberty generator runs when the Open Liberty plugin is enabled in the maven build. 
+
+The generator is similar to the <<generator-java-exec,java-exec generator>>. It supports the  <<generator-options-common, common generator options>> and the <<generator-java-exec-options, `java-exec` options>>.
+
+For Open Liberty, the default value of webPort is 9080. 

--- a/openshift-maven-plugin/plugin/pom.xml
+++ b/openshift-maven-plugin/plugin/pom.xml
@@ -105,6 +105,12 @@
             <artifactId>jkube-kit-quarkus</artifactId>
             <version>${jkube.kit.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>jkube-kit-openliberty</artifactId>
+            <version>${jkube.kit.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.jkube</groupId>

--- a/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -74,6 +74,7 @@
     - spring-boot
     - wildfly-swarm
     - thorntail-v2
+    - openliberty
     - karaf
     - vertx
     - java-exec

--- a/quickstarts/maven/openliberty/pom.xml
+++ b/quickstarts/maven/openliberty/pom.xml
@@ -1,0 +1,226 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jkube-sample-openliberty</artifactId>
+    <version>0.2-SNAPSHOT</version>
+    <groupId>org.eclipse.jkube</groupId>
+    <packaging>war</packaging>
+
+    <name>Eclipse JKube Maven :: Sample :: Open Liberty</name>
+
+    <properties>
+        <version.openliberty>19.0.0.9</version.openliberty>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.arquillian-cube>1.18.2</version.arquillian-cube>
+        <version.junit>4.12</version.junit>
+        <version.resteasy>3.6.2.Final</version.resteasy>
+        <version.restassured>4.1.1</version.restassured>
+        <http.port>9080</http.port>
+        <https.port>9443</https.port>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.openliberty.features</groupId>
+                <artifactId>features-bom</artifactId>
+                <version>${version.openliberty}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.4.0.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.arquillian.cube</groupId>
+                <artifactId>arquillian-cube-bom</artifactId>
+                <version>${version.arquillian-cube}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+
+    <dependencies>
+        <!-- Open Liberty Features -->
+        <dependency>
+            <groupId>io.openliberty.features</groupId>
+            <artifactId>jaxrs-2.1</artifactId>
+            <type>esa</type>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.arquillian.cube</groupId>
+            <artifactId>arquillian-cube-openshift</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.undertow</groupId>
+                    <artifactId>undertow-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.arquillian.cube</groupId>
+            <artifactId>arquillian-cube-kubernetes-fabric8</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.undertow</groupId>
+                    <artifactId>undertow-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.arquillian.cube</groupId>
+            <artifactId>arquillian-cube-requirement</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.arquillian.cube</groupId>
+            <artifactId>arquillian-cube-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.test</groupId>
+            <artifactId>arquillian-test-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${version.resteasy}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${version.restassured}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>openliberty-sample</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.2.2</version>
+            </plugin>
+
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+            <!-- Enable liberty-maven plugin -->
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>3.0.1</version>
+
+                <configuration>
+                    <assemblyArtifact>
+                        <groupId>io.openliberty</groupId>
+                        <artifactId>openliberty-runtime</artifactId>
+                        <version>[18.0.0.1,)</version>
+                        <type>zip</type>
+                    </assemblyArtifact>
+                    <bootstrapProperties>
+                        <default.http.port>${http.port}</default.http.port>
+                        <default.https.port>${https.port}</default.https.port>
+                        <app.context.root>/</app.context.root>
+                    </bootstrapProperties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>create</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>create</goal>
+                            <goal>deploy</goal>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <looseApplication>true</looseApplication>
+                            <stripVersion>true</stripVersion>
+                            <installAppPackages>project</installAppPackages>
+                            <packageName>cache-greeting-service-openliberty</packageName>
+                            <packageType>jar</packageType>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.eclipse.jkube</groupId>
+                <artifactId>k8s-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>resource</goal>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generator>
+                        <includes>
+                            <include>openliberty</include>
+                        </includes>
+                        <excludes>
+                            <exclude>webapp</exclude>
+                        </excludes>
+                    </generator>
+                    <enricher>
+                        <config>
+                            <jkube-service>
+                                <type>NodePort</type>
+                            </jkube-service>
+                        </config>
+                    </enricher>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/quickstarts/maven/openliberty/src/main/java/org/eclipse/jkube/maven/sample/openliberty/HelloWorldEndpoint.java
+++ b/quickstarts/maven/openliberty/src/main/java/org/eclipse/jkube/maven/sample/openliberty/HelloWorldEndpoint.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.eclipse.jkube.maven.sample.openliberty;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+
+
+@Path("/hello")
+public class HelloWorldEndpoint {
+
+	@GET
+	@Produces("text/plain")
+	public Response doGet() {
+		return Response.ok("Hello, World.").build();
+	}
+}
+

--- a/quickstarts/maven/openliberty/src/main/java/org/eclipse/jkube/maven/sample/openliberty/RestApplication.java
+++ b/quickstarts/maven/openliberty/src/main/java/org/eclipse/jkube/maven/sample/openliberty/RestApplication.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.eclipse.jkube.maven.sample.openliberty;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RestApplication extends Application {
+
+}

--- a/quickstarts/maven/openliberty/src/main/liberty/config/server.xml
+++ b/quickstarts/maven/openliberty/src/main/liberty/config/server.xml
@@ -1,0 +1,29 @@
+<!--
+
+    Copyright 2016 Red Hat, Inc.
+
+    Red Hat licenses this file to you under the Apache License, version
+    2.0 (the "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
+<server description="Open Liberty Fabric8 Example Server">
+
+  <featureManager>
+      <feature>jaxrs-2.1</feature>    
+  </featureManager>
+
+  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+                id="defaultHttpEndpoint" host="*" />
+
+  <webApplication location="openliberty-sample.war" contextRoot="${app.context.root}"/>
+   
+</server>

--- a/quickstarts/maven/openliberty/src/test/java/org/eclipse/jkube/itests/SampleIT.java
+++ b/quickstarts/maven/openliberty/src/test/java/org/eclipse/jkube/itests/SampleIT.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.eclipse.jkube.itests;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.startsWith;
+
+import org.arquillian.cube.openshift.impl.enricher.AwaitRoute;
+import org.arquillian.cube.openshift.impl.enricher.RouteURL;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RequiresOpenshift
+@RunWith(ArquillianConditionalRunner.class)
+public class SampleIT {
+
+	private static final String SAMPLE_APP = "fabric8-maven-sample-openliberty";
+
+	@RouteURL(SAMPLE_APP)
+	@AwaitRoute
+	private String sampleURL;
+
+	@Test
+	public void testSample() throws Exception {
+		given().baseUri(sampleURL).when().get("/hello").then().statusCode(200).body("message", startsWith("Hello"));
+
+	}
+
+}

--- a/quickstarts/maven/openliberty/src/test/resources/arquillian.xml
+++ b/quickstarts/maven/openliberty/src/test/resources/arquillian.xml
@@ -1,0 +1,30 @@
+<!--
+
+    Copyright 2016 Red Hat, Inc.
+
+    Red Hat licenses this file to you under the Apache License, version
+    2.0 (the "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.  See the License for the specific language governing
+    permissions and limitations under the License.
+
+-->
+
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <extension qualifier="openshift">
+    <property name="namespace.use.current">true</property>
+    <!-- when switching namespace.use.current to false, switch enableImageStreamDetection to true -->
+    <property name="enableImageStreamDetection">false</property>
+    <property name="env.init.enabled">true</property>
+  </extension>
+  
+</arquillian>


### PR DESCRIPTION
+ Add a generator for Open Liberty that extends the java-exec generator. It defaults webPort to the Liberty default port (9080) and adds an environment variable for use by S2I if it detects a Liberty runnable jar.
+ Add Liberty's default web ports (9080, 9443) to the ExposeEnricher so that routes get generated.

I would add the sample once #33 gets merged