### PR TITLE
fix: Generated webapp war has wrong name

### DIFF
--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
@@ -77,8 +77,8 @@ public class WebAppGenerator extends BaseGenerator {
         if (getContext().getRuntimeMode() == RuntimeMode.openshift &&
             getContext().getStrategy() == OpenShiftBuildStrategy.s2i &&
             !prePackagePhase) {
-            throw new IllegalArgumentException("S2I not yet supported for the webapp-generator. Use -Dfabric8.mode=kubernetes or " +
-                                               "-Dfabric8.build.strategy=docker for OpenShift mode. Please refer to the reference manual at " +
+            throw new IllegalArgumentException("S2I not yet supported for the webapp-generator. Use -Djkube.mode=kubernetes or " +
+                                               "-Djkube.build.strategy=docker for OpenShift mode. Please refer to the reference manual at " +
                                                "https://maven.jkube.io for details about build modes.");
         }
 

--- a/jkube-kit/generator/webapp/src/main/resources/assemblies/webapp.xml
+++ b/jkube-kit/generator/webapp/src/main/resources/assemblies/webapp.xml
@@ -24,7 +24,7 @@
         <include>${project.groupId}:${project.artifactId}</include>
       </includes>
       <outputDirectory>.</outputDirectory>
-      <outputFileNameMapping>${fabric8.generator.webapp.path}.war</outputFileNameMapping>
+      <outputFileNameMapping>${jkube.generator.webapp.path}.war</outputFileNameMapping>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
There's a typo in webapp generator.

I'm currently working on Integration tests for WebApp and stumbled upon this one.