### PR TITLE
fix: Disable Jolokia, missing PR port from FMP

### DIFF
--- a/jkube-kit/jkube-kit-thorntail-v2/src/main/java/org/eclipse/jkube/thorntail/v2/generator/ThorntailV2Generator.java
+++ b/jkube-kit/jkube-kit-thorntail-v2/src/main/java/org/eclipse/jkube/thorntail/v2/generator/ThorntailV2Generator.java
@@ -44,6 +44,7 @@ public class ThorntailV2Generator extends JavaExecGenerator {
         // - https://github.com/fabric8io/fabric8-maven-plugin/issues/1173
         // - https://issues.jboss.org/browse/THORN-1859
         ret.put("AB_PROMETHEUS_OFF", "true");
+        ret.put("AB_OFF", "true");
         return ret;
     }
 }

--- a/quickstarts/maven/thorntail/pom.xml
+++ b/quickstarts/maven/thorntail/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.eclipse.jkube</groupId>
   <artifactId>jkube-maven-sample-thorntail</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <name>Eclipse Jkube Maven :: Sample :: Thorntail</name>


### PR DESCRIPTION
Relates to: https://github.com/fabric8io/fabric8-maven-plugin/issues/1363

Signed-off-by: Marc Nuri <marc@marcnuri.com>