### PR TITLE
fix: Problem with plexus detecting target value type for bean injection

### DIFF
--- a/jkube-kit/build/maven/src/main/java/org/eclipse/jkube/kit/build/maven/config/MavenBuildConfiguration.java
+++ b/jkube-kit/build/maven/src/main/java/org/eclipse/jkube/kit/build/maven/config/MavenBuildConfiguration.java
@@ -22,6 +22,24 @@ import org.apache.commons.lang3.SerializationUtils;
  */
 public class MavenBuildConfiguration extends BuildConfiguration<MavenAssemblyConfiguration> {
 
+    /**
+     * Explicit typed setter is required by Plexus @Parameter injection in order to compute the target value
+     * object type when reading xml tags
+     *
+     * i.e. The following xml wil be converted to a MavenAssemblyConfiguration:
+     * <pre>{@code
+     *   <assembly>
+     *     <mode>dir</mode>
+     *     <!-- ... -->
+     *   </assembly>
+     * }</pre>
+     * @param assembly to be set
+     */
+    @Override
+    public void setAssembly(MavenAssemblyConfiguration assembly) {
+        super.setAssembly(assembly);
+    }
+
     public static class Builder
             extends BuildConfiguration.TypedBuilder<MavenAssemblyConfiguration, MavenBuildConfiguration> {
 

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/BuildConfiguration.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/BuildConfiguration.java
@@ -204,6 +204,10 @@ public class BuildConfiguration<A extends AssemblyConfiguration> implements Seri
         return assembly;
     }
 
+    public void setAssembly(A assembly) {
+        this.assembly = assembly;
+    }
+
     public List<String> getPorts() {
         return removeEmptyEntries(ports);
     }


### PR DESCRIPTION
After the initial Maven decoupling commits, a bug has appeared specific to Plexus injection of generic typed bean values.

This fix allows to inject `<configuration><images><image><build><assembly> ` entries again.