### PR TITLE
ci: Lowered number of parallel threads for OpenShift + disabled fail-fast

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,9 +29,10 @@ jobs:
     name: K8S
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         kubernetes: [v1.17.2,v1.12.0]
-        suite: ['quarkus','springboot','other']
+        suite: ['quarkus','quarkus-native','springboot','webapp','other']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -69,9 +70,10 @@ jobs:
     name: OpenShift
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         openshift: [v3.11.0,v3.9.0]
-        suite: ['quarkus','springboot','other']
+        suite: ['quarkus','springboot','webapp','other']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -94,7 +96,7 @@ jobs:
         run: |
           JKUBE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && cd $JKUBE_IT_DIR \
-          && ./mvnw -B -POpenShift,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=2
+          && ./mvnw -B -POpenShift,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=1
       - name: Consolidate reports
         run: |
           mkdir -p ./reports \


### PR DESCRIPTION
Seems VM machine get hogged when running OpenShift tests for Quarkus. This
will lower the amount of resources by running less tests at a time.