### PR TITLE
Chore: Remove unused maven dependency from Jkube-Kit config/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Usage:
 * Fix #71: script to extract changelog information for notifications
 * Fix #76: Github actions checkout v2
 * Updated Kubernetes-Client Version to 4.7.1 #70
+* Fix #30: Decouple JKube-kit from maven
 
 ### 0.1.1 (14-02-2020)
 * Refactor: Add Maven Enforcer Plugin #29

--- a/jkube-kit/common-maven/pom.xml
+++ b/jkube-kit/common-maven/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>maven-common-artifact-filters</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+    </dependency>
+
     <!-- == test ====================================== -->
     <dependency>
       <groupId>junit</groupId>

--- a/jkube-kit/config/resource/pom.xml
+++ b/jkube-kit/config/resource/pom.xml
@@ -34,10 +34,6 @@
       <groupId>org.eclipse.jkube</groupId>
       <artifactId>jkube-kit-common</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven.plugin-tools</groupId>
-      <artifactId>maven-plugin-annotations</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
I think this would finally make Jkube-kit completely independent from maven.


Fix #30 
```
~/work/repos/jkube/jkube-kit : $ git grep -c "org.apache.maven" | grep -v "common-maven"
common/src/main/java/org/eclipse/jkube/kit/common/util/CommandLine.java:1
enricher/specific/src/main/java/org/eclipse/jkube/maven/enricher/specific/WebAppHealthCheckEnricher.java:1
enricher/specific/src/test/java/org/eclipse/jkube/maven/enricher/specific/WebAppHealthCeckEnricherTest.java:1
generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java:1
generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java:1
jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/generator/Constants.java:1
parent/pom.xml:24
```

The remaining references are just some references in code like you see in examples below:
[CommandLine.java](https://github.com/eclipse/jkube/blob/master/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/CommandLine.java#L21)
[WebappHealthCheckEnricher.java](https://github.com/eclipse/jkube/blob/master/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/maven/enricher/specific/WebAppHealthCheckEnricher.java#L66)
[Constants.java](https://github.com/eclipse/jkube/blob/master/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/generator/Constants.java#L20)