### PR TITLE
fix: filtered is for variable interpolation/substitution, not for exclusion

### DIFF
--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/DockerAssemblyManager.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/DockerAssemblyManager.java
@@ -457,9 +457,6 @@ public class DockerAssemblyManager {
       JKubeProject project, JKubeAssemblyFile assemblyFile, BuildDirs buildDirs, JKubeAssemblyConfiguration assemblyConfiguration)
       throws IOException {
 
-        if (Boolean.TRUE.equals(assemblyFile.getFiltered())) {
-             return;
-        }
         final File outputDirectory;
         if (new File(assemblyFile.getOutputDirectory()).isAbsolute()) {
             outputDirectory = new File(assemblyFile.getOutputDirectory());


### PR DESCRIPTION
Relates to: #87 