### PR TITLE
chore: Update test suite to current status (before demo)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,10 +12,12 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-name: Integration Tests
+name: E2E Tests
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 1 * * *' # Everyday at 1
@@ -38,7 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v1.0.0
+        uses: manusa/actions-setup-minikube@v1.0.1
         with:
           minikube version: v1.5.1
           kubernetes version: ${{ matrix.kubernetes }}


### PR DESCRIPTION
- Changed file name and title to reflect current status of test suite
- ~Set k8s max version to 1.18.0~
- Run test on push  **only** when branch is master