### PR TITLE
Restore PushMojo in Openshift Maven Plugin

### DIFF
--- a/openshift-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenshiftPushMojo.java
+++ b/openshift-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenshiftPushMojo.java
@@ -1,0 +1,30 @@
+package org.eclipse.jkube.maven.plugin.mojo.build;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.util.AnsiLogger;
+
+import static org.eclipse.jkube.maven.plugin.mojo.Openshift.DEFAULT_LOG_PREFIX;
+
+@Mojo(name = "push", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.COMPILE)
+public class OpenshiftPushMojo extends PushMojo {
+    @Override
+    protected String getLogPrefix() {
+        return DEFAULT_LOG_PREFIX;
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        log = getLogger();
+        log.warn("Image is pushed to OpenShift's internal registry during oc:build goal." +
+                " Skipping...");
+    }
+
+    private KitLogger getLogger() {
+        return new AnsiLogger(getLog(), useColorForLogging(), verbose, !settings.getInteractiveMode(), getLogPrefix() + " ");
+    }
+}


### PR DESCRIPTION
As discussed on [Gitter channel](https://gitter.im/eclipse/jkube) yesterday. I'm restoring Push goal in case of Openshift maven plugin. Right now, it doesn't do anything; it just prints a warning and skips execution. But we might add some other logic in case of other build modes (JIB, Kaniko, buildah) in future.