### PR TITLE
Fix #138: OpenShift build requires connection to dockerd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 ### 1.0.0-SNAPSHOT
 * Fix #130: Updated HelmMojo documentation
+* Fix #138: dockerAccessRequired should be false in case of docker build strategy
 
 ### 1.0.0-alpha-1 (2020-03-27)
 * Ported PR fabric8io/fabric8-maven-plugin#1792, NullCheck in FileDataSecretEnricher

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/DockerAssemblyManager.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/DockerAssemblyManager.java
@@ -401,7 +401,7 @@ public class DockerAssemblyManager {
 
     private void setArtifactFile(JKubeProject project, File artifactFile) throws IOException {
         if (artifactFile != null) {
-            File artifact = new File(project.getBuildDirectory() + artifactFile.getName());
+            File artifact = new File(project.getBuildDirectory(), artifactFile.getName());
             Files.copy(Paths.get(artifactFile.getAbsolutePath()), Paths.get(artifact.getAbsolutePath()), StandardCopyOption.REPLACE_EXISTING);
         }
     }

--- a/openshift-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenshiftBuildMojo.java
+++ b/openshift-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenshiftBuildMojo.java
@@ -17,7 +17,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import static org.eclipse.jkube.kit.config.image.build.OpenShiftBuildStrategy.docker;
 import static org.eclipse.jkube.kit.config.resource.RuntimeMode.kubernetes;
 
 /**
@@ -34,9 +33,6 @@ public class OpenshiftBuildMojo extends BuildMojo {
         boolean ret = false;
         if (runtimeMode == kubernetes) {
              ret = true;
-        }
-        if (buildStrategy == docker) {
-            ret = true;
         }
         return ret;
     }

--- a/quickstarts/maven/webapp/pom.xml
+++ b/quickstarts/maven/webapp/pom.xml
@@ -38,6 +38,16 @@
         <artifactId>kubernetes-maven-plugin</artifactId>
         <version>${project.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>openshift-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+            <mode>openshift</mode>
+            <buildStrategy>docker</buildStrategy>
+            <verbose>true</verbose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <properties>


### PR DESCRIPTION
Fix #138
Remove check related to checking docker access in case of OpenShift builds. I also faced one minor issue related to https://github.com/eclipse/jkube/pull/126