### PR TITLE
added documentation for jkube-controller enricher

### DIFF
--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -50,7 +50,7 @@ kubernetes-maven-plugin comes with a set of enrichers which are enabled by defau
 | Add Maven SCM information as annotations to the kubernetes/openshift resources
 
 | <<jkube-controller>>
-| Create default controller (replication controller, replica set or deployment) if missing.
+| Create default controller (replication controller, replica set or deployment https://kubernetes.io/docs/concepts/workloads/controllers/[Kubernetes doc]) if missing.
 
 | <<jkube-dependency>>
 | Examine build dependencies for `kubernetes.yml` and add the objects found therein.
@@ -100,8 +100,7 @@ kubernetes-maven-plugin comes with a set of enrichers which are enabled by defau
 
 Default enrichers are used for adding missing resources or adding metadata to given resource objects. The following default enhancers are available out of the box
 
-[[jkube-controller]]
-==== jkube-controller
+include::enricher/_jkube_controller.adoc[]
 
 include::enricher/_jkube_service.adoc[]
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_controller.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_controller.adoc
@@ -1,0 +1,33 @@
+
+[[jkube-controller]]
+==== jkube-controller
+
+This enricher is used to ensure that a controller is present.
+This can be either directly configured with fragments or with the XML configuration.
+An explicit configuration always takes precedence over auto detection.
+See https://kubernetes.io/docs/concepts/workloads/controllers/[Kubernetes doc] for more information on types of controllers.
+
+The following configuration parameters can be used to influence the behaviour of this enricher:
+
+[[enricher-jkube-controller]]
+.Default controller enricher
+[cols="1,6,1"]
+|===
+| Element | Description | Default
+
+| *name*
+| Name of the Controller. Kubernetes Controller names must start with a letter. If the maven artifactId starts with a digit, `s` will be prefixed.
+| ${project.artifactId}
+
+| *pullPolicy*
+| Image pull policy to use for the container. One of: _IfNotPresent_, _Always_ 
+| IfNotPresent
+
+| *type*
+| Type of Controller to create. One of: _ReplicationController_, _ReplicaSet_, _Deployment_, _DeploymentConfig_, _StatefulSet_, _DaemonSet_, _Job_
+| Deployment
+
+| *replicaCount*
+| Number of replicas for the container	
+| 1
+|===


### PR DESCRIPTION
Added documentation to cover the defaults for the jkube-controller enricher.

I followed the jkube-service as an example but I do see some repetition in this line: 
> This can be either directly configured with fragments or with the XML configuration
In the future, it may be better to have a section that describes the general behavior of configuration options and the precedence of operations.

I supplied links to the K8s controller documentation but I could not see how to link to the list on controllers which I'm not happy about. 

https://stackoverflow.com/questions/60918319/