### PR TITLE
fix: Assembly is never null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.0.0-alpha-SNAPSHOT
+* Fix #182: Assembly is never null
 
 ### 1.0.0-alpha-3 (2020-05-06)
 * Fix #167: Add CMD for wildfly based applications

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/DockerAssemblyManager.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/DockerAssemblyManager.java
@@ -149,7 +149,7 @@ public class DockerAssemblyManager {
                 builder.write(buildDirs.getOutputDirectory());
                 // Add own Dockerfile
                 final File dockerFile = new File(buildDirs.getOutputDirectory(), DOCKERFILE_NAME);
-                archiveCustomizers.add((archiver) -> {
+                archiveCustomizers.add(archiver -> {
                         archiver.includeFile(dockerFile, DOCKERFILE_NAME);
                         return archiver;
                     });
@@ -158,10 +158,10 @@ public class DockerAssemblyManager {
             if (finalCustomizer != null) {
                 archiveCustomizers.add(finalCustomizer);
             }
-            archiveCustomizers.add((archiver) -> {
+            archiveCustomizers.add(archiver -> {
                 File finalArtifactFile = JKubeProjectUtil.getFinalOutputArtifact(params.getProject());
                 if (finalArtifactFile != null) {
-                    archiver.includeFile(finalArtifactFile, (assemblyConfig != null ? assemblyConfig.getName() : "maven") + File.separator + finalArtifactFile.getName());
+                    archiver.includeFile(finalArtifactFile, assemblyConfig.getName() + File.separator + finalArtifactFile.getName());
                 }
                 return archiver;
             });

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/JKubeAssemblyConfigurationUtils.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/JKubeAssemblyConfigurationUtils.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 public class JKubeAssemblyConfigurationUtils {
 
   private static final String DEFAULT_NAME = "maven";
-  private static final String DEFAULT_TARGET_DIR = File.separator.concat(DEFAULT_NAME);
   private static final String DEFAULT_USER = "root";
 
   private JKubeAssemblyConfigurationUtils() {}
@@ -41,11 +40,15 @@ public class JKubeAssemblyConfigurationUtils {
       .map(BuildConfiguration::getAssemblyConfiguration)
       .orElse(AssemblyConfiguration.builder().user(DEFAULT_USER).build());
     final AssemblyConfiguration.AssemblyConfigurationBuilder builder = ac.toBuilder();
+    final String name;
     if (StringUtils.isBlank(ac.getName())) {
       builder.name(DEFAULT_NAME);
+      name = DEFAULT_NAME;
+    } else {
+      name = ac.getName();
     }
     if (StringUtils.isBlank(ac.getTargetDir())) {
-      builder.targetDir(DEFAULT_TARGET_DIR);
+      builder.targetDir(File.separator.concat(name));
     }
     return builder.build();
   }

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/core/assembly/JKubeAssemblyConfigurationUtilsTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/core/assembly/JKubeAssemblyConfigurationUtilsTest.java
@@ -71,7 +71,7 @@ public class JKubeAssemblyConfigurationUtilsTest {
     // Then
     assertNotNull(result);
     assertEquals("ImageName", result.getName());
-    assertEquals(File.separator + "maven", result.getTargetDir());
+    assertEquals(File.separator + "ImageName", result.getTargetDir());
     assertEquals("OtherUser", result.getUser());
   }
 

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/AssemblyConfiguration.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/AssemblyConfiguration.java
@@ -14,16 +14,15 @@
 package org.eclipse.jkube.kit.config.image.build;
 
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
+
+import org.eclipse.jkube.kit.common.Assembly;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.eclipse.jkube.kit.common.Assembly;
 
 @Builder(toBuilder = true)
 @AllArgsConstructor
@@ -94,15 +93,6 @@ public class AssemblyConfiguration implements Serializable {
 
 
     public static class AssemblyConfigurationBuilder {
-        public AssemblyConfiguration build() {
-            if (Stream.of(descriptor, descriptorRef, permissions, user, mode, tarLongFileMode,
-                dockerFileDir, exportBasedir, ignorePermissions, inline).allMatch(Objects::isNull)) {
-                return null;
-            }
-            return new AssemblyConfiguration(
-                targetDir, name, descriptor, descriptorRef, exportBasedir, dockerFileDir, ignorePermissions,
-                exportTargetDir, permissions, mode, user, tarLongFileMode, inline);
-        }
 
         public AssemblyConfigurationBuilder permissionsString(String permissionsString) {
             permissions = Optional.ofNullable(permissionsString)

--- a/quickstarts/maven/docker-file-provided/Dockerfile
+++ b/quickstarts/maven/docker-file-provided/Dockerfile
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+FROM fabric8/s2i-java:latest-java11
+LABEL location="/"
+EXPOSE 8080/tcp
+COPY target/*.jar /opt/app.jar
+ENTRYPOINT [ "java", "-jar", "/opt/app.jar" ]

--- a/quickstarts/maven/docker-file-provided/README.md
+++ b/quickstarts/maven/docker-file-provided/README.md
@@ -50,3 +50,15 @@ $ mvn clean package k8s:build -P'context-and-file'
 $ docker image inspect jkube/docker-file-provided | jq ".[].ContainerConfig.Labels" | grep location 
   "location": "src/main/docker-context-dir/other/file",
 ```
+
+## `contextDir` and customized assembly name
+Retrieves the `Dockerfile` from the provided `<contextDir>` configuration.
+
+Adds the packaged artifact file to a directory with the name provided in the `<assembly>` configuration.
+
+```shell script
+$ mvn clean package k8s:build -P'context-and-assembly'
+...
+$ docker image inspect jkube/context-and-assembly | jq ".[].ContainerConfig.Labels" | grep location 
+  "location": "/",
+```

--- a/quickstarts/maven/docker-file-provided/pom.xml
+++ b/quickstarts/maven/docker-file-provided/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.eclipse.jkube.quickstarts.maven</groupId>
     <artifactId>docker-file-provided</artifactId>
-    <version>1.0.0-alpha-3</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>Eclipse JKube :: Quickstarts :: Maven :: Docker File Provided</name>
     <packaging>jar</packaging>
 
@@ -59,7 +59,7 @@
                         <config>
                             <jkube-service>
                                 <type>NodePort</type>
-                                <name>${artifactId}</name>
+                                <name>${project.artifactId}</name>
                                 <port>8080:8080</port>
                             </jkube-service>
                         </config>
@@ -126,6 +126,30 @@
                                     <build>
                                         <contextDir>${project.basedir}/src/main/docker-context-dir</contextDir>
                                         <dockerFile>other/file/DockerfileWithChangedFileName</dockerFile>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>context-and-assembly</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.jkube</groupId>
+                        <artifactId>kubernetes-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>jkube/context-and-assembly</name>
+                                    <build>
+                                        <contextDir>${project.basedir}</contextDir>
+                                        <assembly>
+                                            <name>target</name>
+                                        </assembly>
                                     </build>
                                 </image>
                             </images>


### PR DESCRIPTION
Whenever an Assembly configuration such as:
```xml
<images>
    <image>
        <name>jkube/context-and-assembly</name>
        <build>
            <contextDir>${project.basedir}</contextDir>
            <assembly>
                <name>target</name>
            </assembly>
        </build>
    </image>
</images>
```
The built Assembly object in `DockerAssemblyManager` should not be null as all of the required values should be inferred from the `BuildConfiguration`

Relates to: #149 