### PR TITLE
fix: BaseGenerator retrieves runtime mode from context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ### 1.0.0-alpha-SNAPSHOT
 * Fix #182: Assembly is never null
 * Fix #198: Wildfly works in OpenShift with S2I binary build (Docker)
+* Fix : BaseGenerator retrieves runtime mode from context (not from missing properties)
 
 ### 1.0.0-alpha-3 (2020-05-06)
 * Fix #167: Add CMD for wildfly based applications

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/RuntimeMode.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/RuntimeMode.java
@@ -71,7 +71,7 @@ public enum RuntimeMode {
      * Returns true if the given maven properties indicate running in OpenShift platform mode
      */
     public static boolean isOpenShiftMode(Properties properties) {
-        return properties == null ? false : Objects.equals(openshift.toString(), properties.getProperty(FABRIC8_EFFECTIVE_PLATFORM_MODE, ""));
+        return properties != null && Objects.equals(openshift.toString(), properties.getProperty(FABRIC8_EFFECTIVE_PLATFORM_MODE, ""));
     }
 }
 

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
@@ -117,7 +117,7 @@ public abstract class BaseGenerator implements Generator {
      * @param builder for the build image configuration to add the from to.
      */
     protected void addFrom(BuildConfiguration.BuildConfigurationBuilder builder) {
-        String fromMode = getConfigWithFallback(Config.fromMode, "jkube.generator.fromMode", getFromModeDefault(context.getRuntimeMode()));
+        String fromMode = getConfigWithFallback(Config.fromMode, "jkube.generator.fromMode", getFromModeDefault());
         String from = getConfigWithFallback(Config.from, "jkube.generator.from", null);
         if ("docker".equalsIgnoreCase(fromMode)) {
             String fromImage = from;
@@ -160,8 +160,8 @@ public abstract class BaseGenerator implements Generator {
     }
 
     // Use "istag" as default for "redhat" versions of this plugin
-    private String getFromModeDefault(RuntimeMode mode) {
-        if (mode == RuntimeMode.openshift && fromSelector != null && fromSelector.isRedHat()) {
+    private String getFromModeDefault() {
+        if (context.getRuntimeMode() == RuntimeMode.openshift && fromSelector != null && fromSelector.isRedHat()) {
             return "istag";
         } else {
             return "docker";
@@ -174,7 +174,7 @@ public abstract class BaseGenerator implements Generator {
      * @return Docker image name which is never null
      */
     protected String getImageName() {
-        if (RuntimeMode.isOpenShiftMode(getProject().getProperties())) {
+        if (getContext().getRuntimeMode() == RuntimeMode.openshift) {
             return getConfigWithFallback(Config.name, "jkube.generator.name", "%a:%l");
         } else {
             return getConfigWithFallback(Config.name, "jkube.generator.name", "%g/%a:%l");
@@ -188,11 +188,11 @@ public abstract class BaseGenerator implements Generator {
      * @return The docker registry if configured
      */
     protected String getRegistry() {
-        if (!RuntimeMode.isOpenShiftMode(getProject().getProperties())) {
-            return getConfigWithFallback(Config.registry, "jkube.generator.registry", null);
+        if (getContext().getRuntimeMode() == RuntimeMode.openshift &&
+            getContext().getStrategy() == OpenShiftBuildStrategy.s2i) {
+            return null;
         }
-
-        return null;
+        return getConfigWithFallback(Config.registry, "jkube.generator.registry", null);
     }
 
     /**


### PR DESCRIPTION
- Runtime mode was being computed from System properties that
  were never set in the first place (this is specific to ResourceMojo)
- TODO: Refactor BaseEnricher so it behaves like BaseGenerator
  (not critical because it works as the properties are there for
   enrichers)
