### PR TITLE
feat: Webapp-Wildfly supports S2I source builds too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@ Usage:
 # ./scripts/changelog.sh semanticVersionNumber [linkLabelStartNumber]
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
-### 1.0.0-alpha-SNAPSHOT
+### 1.0.0-SNAPSHOT
 * Fix #182: Assembly is never null
 * Fix #198: Wildfly works in OpenShift with S2I binary build (Docker)
-* Fix : BaseGenerator retrieves runtime mode from context (not from missing properties)
+* Fix #199: BaseGenerator retrieves runtime mode from context (not from missing properties)
+* Fix #201: Webapp-Wildfly supports S2I source builds too (3 modes Docker, OpenShift-Docker, OpenShift-S2I)
 
 ### 1.0.0-alpha-3 (2020-05-06)
 * Fix #167: Add CMD for wildfly based applications

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/FromSelector.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/FromSelector.java
@@ -32,7 +32,6 @@ import static org.eclipse.jkube.kit.config.image.build.OpenShiftBuildStrategy.So
  * Helper class to encapsulate the selection of a base image
  *
  * @author roland
- * @since 12/08/16
  */
 public abstract class FromSelector {
 
@@ -115,6 +114,36 @@ public abstract class FromSelector {
 
         protected String getIstagFrom() {
             return isRedHat() ? redhatIstag : upstreamIstag;
+        }
+    }
+
+    public static final class NoRedHatSupportFromSelector extends FromSelector {
+
+        private final String upstreamDocker;
+        private final String upstreamS2i;
+        private final String upstreamIstag;
+
+        public NoRedHatSupportFromSelector(GeneratorContext context, String prefix) {
+            super(context);
+            DefaultImageLookup lookup = new DefaultImageLookup(NoRedHatSupportFromSelector.class);
+
+            this.upstreamDocker = lookup.getImageName(prefix + ".upstream.docker");
+            this.upstreamS2i = lookup.getImageName(prefix + ".upstream.s2i");
+            this.upstreamIstag = lookup.getImageName(prefix + ".upstream.istag");
+        }
+
+        @Override
+        protected String getDockerBuildFrom() {
+            return upstreamDocker;
+        }
+
+        @Override
+        protected String getS2iBuildFrom() {
+            return upstreamS2i;
+        }
+
+        protected String getIstagFrom() {
+            return upstreamIstag;
         }
     }
 }

--- a/jkube-kit/generator/webapp/pom.xml
+++ b/jkube-kit/generator/webapp/pom.xml
@@ -38,7 +38,10 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.jmockit</groupId>
+      <artifactId>jmockit</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/AppServerHandler.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/AppServerHandler.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.generator.webapp;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Interface encapsulating a certain application handler
@@ -72,14 +73,38 @@ public interface AppServerHandler {
     List<String> exposedPorts();
 
     /**
+     * A Map containing environment variables to add to the Image.
+     *
+     * @return the Map containing environment variables.
+     */
+    default Map<String, String> getEnv() {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * The name for the assembly configuration (will also be the name of the directory where
+     * artifacts are placed for Dockerfile COPY).
+     *
+     * @return the assembly name.
+     */
+    default String getAssemblyName() {
+        return null;
+    }
+
+    /**
      * A list of commands to run during image build phase.
      *
-     * @return the list of commands to run
+     * @return the list of commands to run.
      */
     default List<String> runCmds() {
         return Collections.emptyList();
     }
 
+    /**
+     * If this handler support S2I source builds.
+     *
+     * @return true if the handler supports S2I builds, false otherwise.
+     */
     default boolean supportsS2iBuild() {
         return false;
     }

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
@@ -133,6 +133,7 @@ public class WebAppGenerator extends BaseGenerator {
     protected Map<String, String> getEnv(AppServerHandler handler) {
         Map<String, String> defaultEnv = new HashMap<>();
         defaultEnv.put("DEPLOY_DIR", getDeploymentDir(handler));
+        defaultEnv.putAll(handler.getEnv());
         return defaultEnv;
     }
 
@@ -144,7 +145,10 @@ public class WebAppGenerator extends BaseGenerator {
         getProject().getProperties().setProperty("jkube.generator.webapp.path",path);
         final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
 
-        builder.targetDir(getDeploymentDir(handler)).descriptorRef("webapp");
+        builder
+            .descriptorRef("webapp")
+            .name(handler.getAssemblyName())
+            .targetDir(getDeploymentDir(handler));
 
         String user = getUser(handler);
         if (user != null) {

--- a/jkube-kit/generator/webapp/src/main/resources-filtered/META-INF/jkube/default-images.properties
+++ b/jkube-kit/generator/webapp/src/main/resources-filtered/META-INF/jkube/default-images.properties
@@ -16,4 +16,6 @@
 # The images with their versions are set in the parent/pom.xml
 tomcat.upstream.docker=${image.tomcat.upstream}
 jetty.upstream.docker=${image.jetty.upstream}
-wildfly.upstream.docker=${image.wildfly.upstream}
+wildfly.upstream.docker=${image.wildfly.upstream.docker}
+wildfly.upstream.s2i=${image.wildfly.upstream.s2i}
+wildfly.upstream.istag=${image.wildfly.upstream.istag}

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/WildFlyAppSeverHandlerTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/WildFlyAppSeverHandlerTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.generator.webapp.handler;
+
+
+import java.util.Collections;
+
+import org.eclipse.jkube.generator.api.GeneratorContext;
+import org.eclipse.jkube.kit.config.image.build.OpenShiftBuildStrategy;
+import org.eclipse.jkube.kit.config.resource.RuntimeMode;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class WildFlyAppSeverHandlerTest {
+
+  @Mocked
+  private GeneratorContext generatorContext;
+
+  @Test
+  public void kubernetes() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      generatorContext.getRuntimeMode(); result = RuntimeMode.kubernetes;
+    }};
+    // @formatter:on
+    // When
+    final WildFlyAppSeverHandler handler = new WildFlyAppSeverHandler(generatorContext);
+    // Then
+    assertCommonValues(handler);
+    assertEquals("jboss/wildfly:19.0.0.Final", handler.getFrom());
+    assertTrue(handler.runCmds().isEmpty());
+  }
+
+  @Test
+  public void openShiftDockerStrategy() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      generatorContext.getRuntimeMode(); result = RuntimeMode.openshift;
+      generatorContext.getStrategy(); result = OpenShiftBuildStrategy.docker;
+    }};
+    // @formatter:on
+    // When
+    final WildFlyAppSeverHandler handler = new WildFlyAppSeverHandler(generatorContext);
+    // Then
+    assertCommonValues(handler);
+    assertEquals("jboss/wildfly:19.0.0.Final", handler.getFrom());
+    assertEquals(Collections.singletonList("chmod -R a+rw /opt/jboss/wildfly/standalone/"), handler.runCmds());
+  }
+
+  @Test
+  public void openShiftSourceStrategy() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      generatorContext.getRuntimeMode(); result = RuntimeMode.openshift;
+      generatorContext.getStrategy(); result = OpenShiftBuildStrategy.s2i;
+    }};
+    // @formatter:on
+    // When
+    final WildFlyAppSeverHandler handler = new WildFlyAppSeverHandler(generatorContext);
+    // Then
+    assertCommonValues(handler);
+    assertEquals("quay.io/wildfly/wildfly-centos7:19.0", handler.getFrom());
+    assertTrue(handler.runCmds().isEmpty());
+  }
+
+  private static void assertCommonValues(WildFlyAppSeverHandler handler) {
+    assertTrue(handler.supportsS2iBuild());
+    assertEquals("deployments", handler.getAssemblyName());
+    assertEquals("/opt/jboss/wildfly/standalone/deployments", handler.getDeploymentDir());
+    assertEquals("/opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0", handler.getCommand());
+    assertEquals("jboss:jboss:jboss", handler.getUser());
+    assertEquals(Collections.singletonMap("GALLEON_PROVISION_LAYERS", "cloud-server,web-clustering"), handler.getEnv());
+    assertEquals(Collections.singletonList("8080"), handler.exposedPorts());
+  }
+}

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -98,7 +98,8 @@
     <!-- Servlet container images -->
     <version.image.tomcat.upstream>1.2.1</version.image.tomcat.upstream>
     <version.image.jetty.upstream>1.5.1</version.image.jetty.upstream>
-    <version.image.wildfly.upstream>19.0.0.Final</version.image.wildfly.upstream>
+    <version.image.wildfly.upstream.docker>19.0.0.Final</version.image.wildfly.upstream.docker>
+    <version.image.wildfly.upstream.s2i>19.0</version.image.wildfly.upstream.s2i>
 
     <!-- ============================================= -->
     <!-- Default images used in the default generators. Please note that the generators make some assumption about
@@ -125,7 +126,10 @@
     <!-- webapp -->
     <image.tomcat.upstream>fabric8/tomcat-9:${version.image.tomcat.upstream}</image.tomcat.upstream>
     <image.jetty.upstream>fabric8/jetty-9:${version.image.jetty.upstream}</image.jetty.upstream>
-    <image.wildfly.upstream>jboss/wildfly:${version.image.wildfly.upstream}</image.wildfly.upstream>
+    <image.wildfly.upstream.docker>jboss/wildfly:${version.image.wildfly.upstream.docker}</image.wildfly.upstream.docker>
+    <image.wildfly.upstream.s2i>quay.io/wildfly/wildfly-centos7:${version.image.wildfly.upstream.s2i}</image.wildfly.upstream.s2i>
+    <image.wildfly.upstream.istag>wildfly:${version.image.wildfly.upstream.s2i}</image.wildfly.upstream.istag>
+
   </properties>
 
   <dependencyManagement>

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_webapp.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_webapp.adoc
@@ -16,7 +16,7 @@ The base images chosen are:
 | | Docker Build | S2I Build
 
 | *Tomcat*
-| `jkube.tomcat-8`
+| `jkube.tomcat-9`
 | ---
 
 | *Jetty*
@@ -25,7 +25,7 @@ The base images chosen are:
 
 | *Wildfly*
 | `jboss/wildfly`
-| ---
+| https://github.com/wildfly/wildfly-s2i[`quay.io/wildfly/wildfly-centos7`]
 |===
 
 [IMPORTANT]

--- a/quickstarts/maven/webapp-wildfly/pom.xml
+++ b/quickstarts/maven/webapp-wildfly/pom.xml
@@ -24,7 +24,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <jkube.build.strategy>docker</jkube.build.strategy>
     <jkube.version>${project.version}</jkube.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
3 build modes:
 - Docker (Kubernetes) `mvn k8s:build`
 - OpenShift-Docker (S2I Binary) `mvn oc:build -Djkube.build.strategy=docker`
 - OpenShift-S2I (S2I Source) `mvn oc:build`