### PR TITLE
spike: JavaExecGenerator uses ubi8/openjdk-11 always

### DIFF
--- a/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
+++ b/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
@@ -38,7 +38,6 @@ import static org.eclipse.jkube.kit.common.util.FileUtil.getRelativePath;
 
 /**
  * @author roland
- * @since 21/09/16
  */
 
 public class JavaExecGenerator extends BaseGenerator {
@@ -170,6 +169,7 @@ public class JavaExecGenerator extends BaseGenerator {
         final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
         builder.targetDir(getConfig(Config.targetDir));
         addAssembly(builder);
+        builder.name("deployments");
         return builder.build();
     }
 

--- a/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGenerator.java
+++ b/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGenerator.java
@@ -60,19 +60,12 @@ public class OpenLibertyGenerator extends JavaExecGenerator {
 
     @Override
     protected Map<String, String> getEnv(boolean prePackagePhase) {
-    	Map<String,String> ret = super.getEnv(prePackagePhase);
-    	if ( runnableJarName != null) {
-    		ret.put(LIBERTY_RUNNABLE_JAR, runnableJarName);
-    		ret.put(JAVA_APP_JAR, runnableJarName);
-    	}
-    	return ret;
-    }
-    @Override
-    protected AssemblyConfiguration createAssembly() {
-        final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
-        builder.targetDir(getConfig(Config.targetDir));
-        addAssembly(builder);
-        return builder.build();
+        Map<String, String> ret = super.getEnv(prePackagePhase);
+        if (runnableJarName != null) {
+            ret.put(LIBERTY_RUNNABLE_JAR, runnableJarName);
+            ret.put(JAVA_APP_JAR, runnableJarName);
+        }
+        return ret;
     }
 
     @Override

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -77,8 +77,8 @@
     <!-- =======================================================  -->
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
     <!-- Upstream -->
-    <version.image.java.upstream.docker>1.5.6</version.image.java.upstream.docker>
-    <version.image.java.upstream.s2i>3.0-java8</version.image.java.upstream.s2i>
+    <version.image.java.upstream.docker>1.3-3</version.image.java.upstream.docker>
+    <version.image.java.upstream.s2i>1.3-3</version.image.java.upstream.s2i>
 
     <!-- RedHat -->
     <version.image.java.redhat.docker>2.0</version.image.java.redhat.docker>
@@ -106,8 +106,8 @@
          these images (e.g. where the deployment directory is), so don't change them arbitrarily -->
 
     <!-- java (java-exec, spring-boot, wildfly-swarm) -->
-    <image.java.upstream.s2i>fabric8/s2i-java:${version.image.java.upstream.s2i}</image.java.upstream.s2i>
-    <image.java.upstream.docker>fabric8/java-centos-openjdk8-jdk:${version.image.java.upstream.docker}</image.java.upstream.docker>
+    <image.java.upstream.s2i>registry.access.redhat.com/ubi8/openjdk-11:${version.image.java.upstream.s2i}</image.java.upstream.s2i>
+    <image.java.upstream.docker>registry.access.redhat.com/ubi8/openjdk-11:${version.image.java.upstream.docker}</image.java.upstream.docker>
     <image.java.upstream.istag>fabric8-java:${version.image.java.upstream.s2i}</image.java.upstream.istag>
 
     <image.java.redhat.s2i>jboss-fuse-6/fis-java-openshift:${version.image.java.redhat.s2i}</image.java.redhat.s2i>

--- a/quickstarts/maven/spring-boot/pom.xml
+++ b/quickstarts/maven/spring-boot/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.4.1.RELEASE</version>
+    <version>2.2.7.RELEASE</version>
   </parent>
 
   <groupId>org.eclipse.jkube.quickstarts.maven</groupId>
   <artifactId>spring-boot</artifactId>
-  <version>1.0.0-alpha-3</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Eclipse JKube :: Quickstarts :: Maven :: Spring Boot Web</name>
   <packaging>jar</packaging>
 

--- a/quickstarts/maven/spring-boot/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/Application.java
+++ b/quickstarts/maven/spring-boot/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/Application.java
@@ -18,7 +18,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
  * @author roland
- * @since 16/05/16
  */
 
 @SpringBootApplication

--- a/quickstarts/maven/spring-boot/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/HelloController.java
+++ b/quickstarts/maven/spring-boot/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/HelloController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * @author roland
- * @since 16/05/16
  */
 
 @RestController


### PR DESCRIPTION
This is PoC PR intended for review of options regarding base image replacements (#183)

What this PR accomplishes is the use of `registry.access.redhat.com/ubi8/openjdk-11` image for all build strategies.
The main advantage for this is the reduced complexity in maintenance, as configuration should only deal with one image type.

We're also replacing 2 different fabric8 maintained images for a single community-driven image.

In order to be able to use the s2i builder image both as a builder image and as a runtime image is by providing the packaged artifacts in the specific directory for s2i assembly (`/tmp/src/deployments`). And by adding the COPY statement from deployments to `/deployments` in the generated Dockerfile.