### PR TITLE
feat: JavaExecGenerator uses jkube/jkube-java-binary-s2i for Docker and S2I builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Usage:
 * Fix #198: Wildfly works in OpenShift with S2I binary build (Docker)
 * Fix #199: BaseGenerator retrieves runtime mode from context (not from missing properties)
 * Fix #201: Webapp-Wildfly supports S2I source builds too (3 modes Docker, OpenShift-Docker, OpenShift-S2I)
+* Fix #205: JavaExecGenerator uses jkube/jkube-java-binary-s2i for Docker and S2I builds (#183)
 
 ### 1.0.0-alpha-3 (2020-05-06)
 * Fix #167: Add CMD for wildfly based applications

--- a/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
+++ b/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
@@ -38,7 +38,6 @@ import static org.eclipse.jkube.kit.common.util.FileUtil.getRelativePath;
 
 /**
  * @author roland
- * @since 21/09/16
  */
 
 public class JavaExecGenerator extends BaseGenerator {
@@ -170,6 +169,7 @@ public class JavaExecGenerator extends BaseGenerator {
         final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
         builder.targetDir(getConfig(Config.targetDir));
         addAssembly(builder);
+        builder.name("deployments");
         return builder.build();
     }
 

--- a/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGenerator.java
+++ b/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGenerator.java
@@ -60,19 +60,12 @@ public class OpenLibertyGenerator extends JavaExecGenerator {
 
     @Override
     protected Map<String, String> getEnv(boolean prePackagePhase) {
-    	Map<String,String> ret = super.getEnv(prePackagePhase);
-    	if ( runnableJarName != null) {
-    		ret.put(LIBERTY_RUNNABLE_JAR, runnableJarName);
-    		ret.put(JAVA_APP_JAR, runnableJarName);
-    	}
-    	return ret;
-    }
-    @Override
-    protected AssemblyConfiguration createAssembly() {
-        final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
-        builder.targetDir(getConfig(Config.targetDir));
-        addAssembly(builder);
-        return builder.build();
+        Map<String, String> ret = super.getEnv(prePackagePhase);
+        if (runnableJarName != null) {
+            ret.put(LIBERTY_RUNNABLE_JAR, runnableJarName);
+            ret.put(JAVA_APP_JAR, runnableJarName);
+        }
+        return ret;
     }
 
     @Override

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -77,8 +77,8 @@
     <!-- =======================================================  -->
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
     <!-- Upstream -->
-    <version.image.java.upstream.docker>1.5.6</version.image.java.upstream.docker>
-    <version.image.java.upstream.s2i>3.0-java8</version.image.java.upstream.s2i>
+    <version.image.java.upstream.docker>0.0.1</version.image.java.upstream.docker>
+    <version.image.java.upstream.s2i>0.0.1</version.image.java.upstream.s2i>
 
     <!-- RedHat -->
     <version.image.java.redhat.docker>2.0</version.image.java.redhat.docker>
@@ -106,9 +106,9 @@
          these images (e.g. where the deployment directory is), so don't change them arbitrarily -->
 
     <!-- java (java-exec, spring-boot, wildfly-swarm) -->
-    <image.java.upstream.s2i>fabric8/s2i-java:${version.image.java.upstream.s2i}</image.java.upstream.s2i>
-    <image.java.upstream.docker>fabric8/java-centos-openjdk8-jdk:${version.image.java.upstream.docker}</image.java.upstream.docker>
-    <image.java.upstream.istag>fabric8-java:${version.image.java.upstream.s2i}</image.java.upstream.istag>
+    <image.java.upstream.s2i>quay.io/jkube/jkube-java-binary-s2i:${version.image.java.upstream.s2i}</image.java.upstream.s2i>
+    <image.java.upstream.docker>quay.io/jkube/jkube-java-binary-s2i:${version.image.java.upstream.docker}</image.java.upstream.docker>
+    <image.java.upstream.istag>jkube-java:${version.image.java.upstream.s2i}</image.java.upstream.istag>
 
     <image.java.redhat.s2i>jboss-fuse-6/fis-java-openshift:${version.image.java.redhat.s2i}</image.java.redhat.s2i>
     <image.java.redhat.docker>jboss-fuse-6/fis-java-openshift:${version.image.java.redhat.docker}</image.java.redhat.docker>

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_java_exec.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_java_exec.adoc
@@ -22,9 +22,9 @@ It will use the following base image by default, but as explained <<generator-op
 | | Docker Build | S2I Build | ImageStream
 
 | *Community*
-| `fabric8/java-jboss-openjdk8-jdk`
-| `fabric8/s2i-java`
-| `fabric8-java`
+| `quay.io/jkube/jkube-java-binary-s2i`
+| `quay.io/jkube/jkube-java-binary-s2i`
+| `jkube-java`
 
 | *Red Hat*
 | `jboss-fuse-6/fis-java-openshift`

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/develop/_jkube-watch.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/develop/_jkube-watch.adoc
@@ -69,6 +69,9 @@ This watcher is enabled by default for all Spring Boot projects. It performs the
 * tails the log of the latest running pod for your application
 * watches the local development build of your Spring Boot based application and then triggers a reload of the application when there are changes
 
+WARNING: Spring devtools automatically ignores projects named `spring-boot`, `spring-boot-devtools`,
+         `spring-boot-autoconfigure`, `spring-boot-actuator`, `and spring-boot-starter`
+
 You can try it on any spring boot application via:
 
 [source, sh, subs="+attributes"]

--- a/quickstarts/maven/spring-boot-watch/README.md
+++ b/quickstarts/maven/spring-boot-watch/README.md
@@ -1,0 +1,32 @@
+# Spring Boot Sample
+
+This is a sample project to use Eclipse JKube plugins.
+
+### Steps to use
+
+Make sure that Kubernetes cluster or Minikube is running. 
+
+
+#### For Kubernetes
+
+Below command will create your OpenShift resource descriptors.
+```
+mvn clean k8s:resource
+```
+
+Now start docker build  by hitting the build goal.
+```
+mvn package k8s:build
+```
+
+Below command will deploy your application on OpenShift cluster.
+```
+mvn k8s:deploy
+```
+
+You can now start watch goal by running.
+```
+mvn k8s:watch
+```
+
+If your source code is changed and recompiled (`mvn package`), application in the cluster should live-reload.

--- a/quickstarts/maven/spring-boot-watch/pom.xml
+++ b/quickstarts/maven/spring-boot-watch/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.2.7.RELEASE</version>
+  </parent>
+
+  <groupId>org.eclipse.jkube.quickstarts.maven</groupId>
+  <artifactId>spring-boot-watch</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>Eclipse JKube :: Quickstarts :: Maven :: Spring Boot Watch</name>
+  <packaging>jar</packaging>
+
+  <description>Minimal Example with Spring Boot to test k8s:watch goal</description>
+
+  <dependencies>
+    <!-- Boot generator  -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-devtools</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-core</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <excludeDevtools>false</excludeDevtools>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <enricher>
+            <config>
+              <jkube-service>
+                <type>NodePort</type>
+              </jkube-service>
+            </config>
+          </enricher>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/quickstarts/maven/spring-boot-watch/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/Application.java
+++ b/quickstarts/maven/spring-boot-watch/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/Application.java
@@ -16,10 +16,6 @@ package org.eclipse.jkube.maven.sample.spring.boot;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-/**
- * @author roland
- */
-
 @SpringBootApplication
 public class Application {
 

--- a/quickstarts/maven/spring-boot-watch/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/HelloController.java
+++ b/quickstarts/maven/spring-boot-watch/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/HelloController.java
@@ -13,18 +13,15 @@
  */
 package org.eclipse.jkube.maven.sample.spring.boot;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-/**
- * @author roland
- */
+@RestController
+public class HelloController {
 
-@SpringBootApplication
-public class Application {
-
-    public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
+    @RequestMapping("/")
+    public String index() {
+        return "Greetings from Spring Boot";
     }
 
 }

--- a/quickstarts/maven/spring-boot-watch/src/main/resources/application.properties
+++ b/quickstarts/maven/spring-boot-watch/src/main/resources/application.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# Remote secret added by jkube-kit-plugin
+spring.devtools.remote.secret=8442e2f7-2f69-44ee-b4ae-3d0e5641f027

--- a/quickstarts/maven/spring-boot/README.md
+++ b/quickstarts/maven/spring-boot/README.md
@@ -2,6 +2,11 @@
 
 This is a sample project to use Eclipse JKube plugins.
 
+**Notice:**
+> k8s:watch / oc:watch goal won't work as Spring devtools automatically
+> ignores projects named `spring-boot`, `spring-boot-devtools`, `spring-boot-autoconfigure`, `spring-boot-actuator`, 
+> `and spring-boot-starter`.
+
 ### Steps to use
 
 Make sure that Kubernetes/OpenShift cluster or Minikube/minishift is running. In case, if anything of this is not running, you can

--- a/quickstarts/maven/spring-boot/pom.xml
+++ b/quickstarts/maven/spring-boot/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.4.1.RELEASE</version>
+    <version>2.2.7.RELEASE</version>
   </parent>
 
   <groupId>org.eclipse.jkube.quickstarts.maven</groupId>
   <artifactId>spring-boot</artifactId>
-  <version>1.0.0-alpha-3</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Eclipse JKube :: Quickstarts :: Maven :: Spring Boot Web</name>
   <packaging>jar</packaging>
 

--- a/quickstarts/maven/spring-boot/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/HelloController.java
+++ b/quickstarts/maven/spring-boot/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/HelloController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * @author roland
- * @since 16/05/16
  */
 
 @RestController


### PR DESCRIPTION
Closes spike PoC in #203 where standard base images are used.

Replace base images used in `JavaExecGenerator` (#183) for partially customized images based on [JBoss CEKit modules](https://github.com/jboss-openshift/cct_module).

Images are maintained by us in https://github.com/jkubeio/jkube-images and deployed to our public [Quay.io repositories](https://quay.io/organization/jkube), in this case https://quay.io/repository/jkube/jkube-java-binary-s2i.

These images shouldn't be used outside of Eclipse JKube as we don't want to provide extra-support or maintenance other than that related to the images working with JKube.