### PR TITLE
fix: added required configurations for WildFlySwarmGenerator to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,11 @@ Usage:
 * Fix #201: Webapp-Wildfly supports S2I source builds too (3 modes Docker, OpenShift-Docker, OpenShift-S2I)
 * Fix #205: JavaExecGenerator uses jkube/jkube-java-binary-s2i for Docker and S2I builds (#183)
 * Fix #206: WebAppGenerator with "/" path renames artifacts to ROOT.war
-* Fix #206: WebAppGenerator>TomcatAppSeverHandler uses quay.io/jkube/jkube-tomcat9-binary-s2i as base image
-* Fix #210: WebAppGenerator>JettyAppSeverHandler uses quay.io/jkube/jkube-jetty9-binary-s2i as base image
+* Fix #206: WebAppGenerator\>TomcatAppSeverHandler uses quay.io/jkube/jkube-tomcat9-binary-s2i as base image
+* Fix #210: WebAppGenerator\>JettyAppSeverHandler uses quay.io/jkube/jkube-jetty9-binary-s2i as base image
 * Fix #211: pom.xml configured runtime mode `<mode>` is considered instead of `<configuredRuntimeMode>`
+* Fix #209: WildFlySwarmGenerator includes required env variables + java options
+
 
 ### 1.0.0-alpha-3 (2020-05-06)
 * Fix #167: Add CMD for wildfly based applications

--- a/jkube-kit/generator/wildfly-swarm/src/main/java/org/eclipse/jkube/generator/wildflyswarm/WildFlySwarmGenerator.java
+++ b/jkube-kit/generator/wildfly-swarm/src/main/java/org/eclipse/jkube/generator/wildflyswarm/WildFlySwarmGenerator.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.generator.wildflyswarm;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +45,12 @@ public class WildFlySwarmGenerator extends JavaExecGenerator {
         // - https://github.com/fabric8io/fabric8-maven-plugin/issues/1173
         // - https://issues.jboss.org/browse/SWARM-1859
         ret.put("AB_PROMETHEUS_OFF", "true");
+        ret.put("AB_OFF", "true");
         return ret;
+    }
+
+    @Override
+    protected List<String> getExtraJavaOptions() {
+        return Collections.singletonList("-Djava.net.preferIPv4Stack=true");
     }
 }


### PR DESCRIPTION
Integration tests work due to a workaround introduced in the config while implementing them:
https://github.com/jkubeio/jkube-integration-tests/blob/17b80a4d5ec2b5c7343b512f92edefec6dba8317/projects-to-be-tested/wildflyswarm/rest/pom.xml#L85