### PR TITLE
fix: Removed @Deprecated fields from ClusterAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.0.0-SNAPSHOT
-* Fix : Remove deprecated fields and method calls
+* Fix #237: Remove deprecated fields and method calls
+* Fix #192: Removed `@Deprecated` fields from ClusterAccess
 
 ### 1.0.0-alpha-4 (2020-06-08)
 * Fix #173: Use OpenShift compliant git/vcs annotations 
@@ -44,7 +45,7 @@ Usage:
 * Fix #224: RoleBinding Resources Not Supported by Kubernetes Cluster Configurations
 * Fix #191: Removed `@Deprecated` fields from RunImageConfiguration
 * Fix #233: Provided Slf4j delegate KitLogger implementation
-* Fix #234:Watch works with complex assemblies using AssemblyFile
+* Fix #234: Watch works with complex assemblies using AssemblyFile
 
 ### 1.0.0-alpha-3 (2020-05-06)
 * Fix #167: Add CMD for wildfly based applications

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/OpenshiftHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/OpenshiftHelper.java
@@ -33,12 +33,13 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author roland
- * @since 23.05.17
  */
 public class OpenshiftHelper {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     public static final String DEFAULT_API_VERSION = "v1";
+
+    private OpenshiftHelper() {}
 
     public static OpenShiftClient asOpenShiftClient(KubernetesClient client) {
         if (client instanceof OpenShiftClient) {

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/JKubeServiceHub.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/JKubeServiceHub.java
@@ -75,13 +75,13 @@ public class JKubeServiceHub implements Closeable {
             platformMode = RuntimeMode.DEFAULT;
         }
         if (clusterAccess == null) {
-            clusterAccess = new ClusterAccess(ClusterConfiguration.from(System.getProperties()).build());
+            clusterAccess = new ClusterAccess(log, ClusterConfiguration.from(System.getProperties()).build());
         }
-        this.resolvedMode = clusterAccess.resolveRuntimeMode(platformMode, log);
+        this.resolvedMode = clusterAccess.resolveRuntimeMode(platformMode);
         if (resolvedMode != RuntimeMode.kubernetes && resolvedMode != RuntimeMode.openshift) {
             throw new IllegalArgumentException("Unknown platform mode " + platformMode + " resolved as "+ resolvedMode);
         }
-        this.client = clusterAccess.createDefaultClient(log);
+        this.client = clusterAccess.createDefaultClient();
 
         // Lazily building services
 

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/JKubeServiceHubTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/JKubeServiceHubTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 public class JKubeServiceHubTest {
 
@@ -54,23 +54,21 @@ public class JKubeServiceHubTest {
 
     @Before
     public void init() {
+      // @formatter:off
         new Expectations() {{
-            clusterAccess.resolveRuntimeMode(RuntimeMode.kubernetes, withInstanceOf(KitLogger.class));
+            clusterAccess.resolveRuntimeMode(RuntimeMode.kubernetes);
             result = RuntimeMode.kubernetes;
             minTimes = 0;
 
-            clusterAccess.resolveRuntimeMode(RuntimeMode.openshift, withInstanceOf(KitLogger.class));
+            clusterAccess.resolveRuntimeMode(RuntimeMode.openshift);
             result = RuntimeMode.openshift;
             minTimes = 0;
 
-            clusterAccess.resolveRuntimeMode(RuntimeMode.auto, withInstanceOf(KitLogger.class));
+            clusterAccess.resolveRuntimeMode(RuntimeMode.auto);
             result = RuntimeMode.kubernetes;
             minTimes = 0;
-
-            clusterAccess.createKubernetesClient();
-            result = openShiftClient;
-            minTimes = 0;
         }};
+      // @formatter:on
     }
 
     @Test(expected = NullPointerException.class)

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
@@ -101,8 +101,8 @@ public class DockerImageWatcher extends BaseWatcher {
     protected void restartContainer(WatchService.ImageWatcher watcher, Set<HasMetadata> resources) {
         ImageConfiguration imageConfig = watcher.getImageConfiguration();
         String imageName = imageConfig.getName();
-        ClusterAccess clusterAccess = new ClusterAccess(getContext().getClusterConfiguration());
-        try (KubernetesClient client = clusterAccess.createDefaultClient(log)) {
+        ClusterAccess clusterAccess = new ClusterAccess(log, getContext().getClusterConfiguration());
+        try (KubernetesClient client = clusterAccess.createDefaultClient()) {
 
             String namespace = clusterAccess.getNamespace();
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -396,8 +396,8 @@ public abstract class AbstractDockerMojo extends AbstractMojo
         log = new AnsiLogger(getLog(), useColorForLogging(), verbose, !settings.getInteractiveMode(), getLogPrefix());
         authConfigFactory = new AuthConfigFactory(log);
         imageConfigResolver.setLog(log);
-        clusterAccess = new ClusterAccess(initClusterConfiguration());
-        runtimeMode = clusterAccess.resolveRuntimeMode(getConfiguredRuntimeMode(), log);
+        clusterAccess = new ClusterAccess(log, initClusterConfiguration());
+        runtimeMode = clusterAccess.resolveRuntimeMode(getConfiguredRuntimeMode());
     }
 
     protected boolean canExecute() {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractJKubeMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractJKubeMojo.java
@@ -66,7 +66,7 @@ public abstract class AbstractJKubeMojo extends AbstractMojo implements KitLogge
 
     protected void init() {
         log = createLogger(null);
-        clusterAccess = new ClusterAccess(initClusterConfiguration());
+        clusterAccess = new ClusterAccess(log, initClusterConfiguration());
     }
 
     protected boolean canExecute() {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
@@ -177,7 +177,7 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
     @Override
     public void executeInternal() throws MojoExecutionException {
         try {
-            KubernetesClient kubernetes = clusterAccess.createDefaultClient(log);
+            KubernetesClient kubernetes = clusterAccess.createDefaultClient();
             applyService = new ApplyService(kubernetes, log);
             initServices(kubernetes);
 
@@ -248,8 +248,7 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
             applyService.setNamespace(namespace);
 
             applyEntities(kubernetes, namespace, manifest.getName(), entities);
-            log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up", clusterAccess.isOpenShiftImageStream(log) ? "oc" : "kubectl");
-
+            log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up", clusterAccess.isOpenShift() ? "oc" : "kubectl");
         } catch (KubernetesClientException e) {
             KubernetesResourceUtil.handleKubernetesClientException(e, this.log);
         } catch (MojoExecutionException e) {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
@@ -428,7 +428,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
     }
 
     private void lateInit() {
-        runtimeMode = clusterAccess.resolveRuntimeMode(runtimeMode, log);
+        runtimeMode = clusterAccess.resolveRuntimeMode(runtimeMode);
         if (runtimeMode.equals(RuntimeMode.openshift)) {
             Properties properties = project.getProperties();
             if (!properties.contains(DOCKER_IMAGE_USER)) {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
@@ -83,7 +83,7 @@ public class WatchMojo extends AbstractDockerMojo implements ManifestProvider {
     @Override
     protected void init() {
         super.init();
-        kubernetesClient = clusterAccess.createDefaultClient(log);
+        kubernetesClient = clusterAccess.createDefaultClient();
     }
 
     @Override


### PR DESCRIPTION
## Description
Removed @Deprecated fields from ClusterAccess

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->