### PR TITLE
fix: Watch works with complex assemblies using AssemblyFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Usage:
 * Fix #224: RoleBinding Resources Not Supported by Kubernetes Cluster Configurations
 * Fix #191: Removed `@Deprecated` fields from RunImageConfiguration
 * Fix #233: Provided Slf4j delegate KitLogger implementation
+* Fix :Watch works with complex assemblies using AssemblyFile
 
 ### 1.0.0-alpha-3 (2020-05-06)
 * Fix #167: Add CMD for wildfly based applications

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/AssemblyFiles.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/AssemblyFiles.java
@@ -22,7 +22,6 @@ import java.util.List;
  * to rebuild an image.
  *
  * @author roland
- * @since 15/06/15
  */
 public class AssemblyFiles {
 

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/ArchiveService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/ArchiveService.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 /**
  * @author roland
- * @since 30/11/15
  */
 public class ArchiveService {
 
@@ -78,16 +77,16 @@ public class ArchiveService {
      *
      * @param imageConfig image config for which to get files. The build- and assembly configuration in this image
      *                    config must not be null.
-     * @param mojoParameters needed for tracking the assembly
+     * @param jKubeConfiguration needed for tracking the assembly
      * @return mapping of assembly files
      * @throws IOException IO Exception
      */
-    public AssemblyFiles getAssemblyFiles(ImageConfiguration imageConfig, JKubeConfiguration mojoParameters)
+    public AssemblyFiles getAssemblyFiles(ImageConfiguration imageConfig, JKubeConfiguration jKubeConfiguration)
         throws IOException {
 
         String name = imageConfig.getName();
         try {
-            return dockerAssemblyManager.getAssemblyFiles(name, imageConfig.getBuildConfiguration(), mojoParameters);
+            return dockerAssemblyManager.getAssemblyFiles(name, imageConfig.getBuildConfiguration(), jKubeConfiguration);
         } catch (Exception e) {
             throw new IOException("Cannot extract assembly files for image " + name + ": " + e, e);
         }

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/AssemblyFileSetUtils.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/AssemblyFileSetUtils.java
@@ -103,7 +103,6 @@ public class AssemblyFileSetUtils {
     return fileToPermissionsMap;
   }
 
-
   static File resolveSourceDirectory(File baseDirectory, AssemblyFileSet assemblyFileSet) {
     if (Objects.requireNonNull(assemblyFileSet.getDirectory(), "Assembly FileSet directory is required").isAbsolute()) {
       return assemblyFileSet.getDirectory();

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtils.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtils.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.archive;
+
+import org.eclipse.jkube.kit.common.AssemblyConfiguration;
+import org.eclipse.jkube.kit.common.AssemblyFile;
+
+import java.io.File;
+import java.util.Objects;
+
+public class AssemblyFileUtils {
+
+  private AssemblyFileUtils() {}
+
+  public static File getAssemblyFileOutputDirectory(
+      AssemblyFile assemblyFile, File outputDirectoryForRelativePaths, AssemblyConfiguration assemblyConfiguration) {
+    final File outputDirectory;
+    if (assemblyFile.getOutputDirectory().isAbsolute()) {
+      outputDirectory = assemblyFile.getOutputDirectory();
+    } else {
+      outputDirectory = outputDirectoryForRelativePaths.toPath()
+          .resolve(Objects.requireNonNull(assemblyConfiguration.getName(), "Assembly Configuration name is required"))
+          .resolve(assemblyFile.getOutputDirectory().toPath())
+          .toFile();
+    }
+    return outputDirectory;
+  }
+
+  public static File resolveSourceFile(File baseDirectory, AssemblyFile assemblyFile) {
+    return baseDirectory.toPath()
+        .resolve(Objects.requireNonNull(assemblyFile.getSource(), "Assembly File source is required").toPath())
+        .toFile();
+  }
+}

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtilsTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtilsTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.archive;
+
+import org.eclipse.jkube.kit.common.AssemblyConfiguration;
+import org.eclipse.jkube.kit.common.AssemblyFile;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class AssemblyFileUtilsTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void getAssemblyFileOutputDirectoryWithAbsoluteDirectoryShouldReturnSame() throws IOException {
+    // Given
+    final AssemblyFile af = AssemblyFile.builder().outputDirectory(new File("/")).build();
+    final File outputDirectoryForRelativePaths = temporaryFolder.newFolder("output");
+    final AssemblyConfiguration ac = AssemblyConfiguration.builder().build();
+    // When
+    final File result = AssemblyFileUtils.getAssemblyFileOutputDirectory(af, outputDirectoryForRelativePaths, ac);
+    // Then
+    assertEquals("/", result.getAbsolutePath());
+  }
+
+  @Test
+  public void getAssemblyFileOutputDirectoryWithRelativeDirectoryShouldReturnComputedPath() throws IOException {
+    // Given
+    final AssemblyFile af = AssemblyFile.builder().outputDirectory(new File("target")).build();
+    final File outputDirectoryForRelativePaths = temporaryFolder.newFolder("output");
+    final AssemblyConfiguration ac = AssemblyConfiguration.builder().name("project").build();
+    // When
+    final File result = AssemblyFileUtils.getAssemblyFileOutputDirectory(af, outputDirectoryForRelativePaths, ac);
+    // Then
+    final String expectedPath = outputDirectoryForRelativePaths.toPath().resolve("project").resolve("target")
+        .toAbsolutePath().toString();
+    assertEquals(expectedPath, result.getAbsolutePath());
+  }
+
+  @Test
+  public void resolveSourceFileAbsoluteFileShouldReturnSame() throws IOException {
+    // Given
+    final File baseDirectory = temporaryFolder.newFolder("base");
+    final AssemblyFile af = AssemblyFile.builder().source(new File("/")).build();
+    // When
+    final File result = AssemblyFileUtils.resolveSourceFile(baseDirectory, af);
+    // Then
+    assertEquals("/", result.getAbsolutePath());
+  }
+
+  @Test
+  public void resolveSourceFileRelativeSourceShouldReturnComputedPath() throws IOException {
+    // Given
+    final File baseDirectory = temporaryFolder.newFolder("base");
+    final AssemblyFile af = AssemblyFile.builder().source(new File("some-file.txt")).build();
+    // When
+    final File result = AssemblyFileUtils.resolveSourceFile(baseDirectory, af);
+    // Then
+    final String expectedPath = baseDirectory.toPath().resolve("some-file.txt")
+        .toAbsolutePath().toString();
+    assertEquals(expectedPath, result.getAbsolutePath());
+  }
+}

--- a/quickstarts/maven/webapp/pom.xml
+++ b/quickstarts/maven/webapp/pom.xml
@@ -49,6 +49,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
   </properties>
   <profiles>
     <profile>


### PR DESCRIPTION
## Description
Watch goal was not working with projects with more complex Assemblies that involved renaming files, etc.

This fix allows watch to work again.

You can test it on:
- https://github.com/eclipse/jkube/tree/master/quickstarts/maven/webapp
- https://github.com/eclipse/jkube/tree/master/quickstarts/maven/thorntail
- ...

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [ ] ~I tested my code in OpenShift~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->