### PR TITLE
fix: Remove deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.0.0-SNAPSHOT
+* Fix : Remove deprecated fields and method calls
 
-### 1.0.0-alpha-4
+### 1.0.0-alpha-4 (2020-06-08)
 * Fix #173: Use OpenShift compliant git/vcs annotations 
 * Fix #182: Assembly is never null
 * Fix #184: IngressEnricher seems to be broken, Port of fabric8io/fabric8-maven-plugin#1730

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/DockerRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/DockerRegistryAuthHandlerTest.java
@@ -44,7 +44,6 @@ import static org.junit.Assert.assertNull;
 
 /**
  * @author roland
- * @since 23.10.18
  */
 public class DockerRegistryAuthHandlerTest {
 

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/helper/DockerFileUtilTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/helper/DockerFileUtilTest.java
@@ -19,8 +19,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.Properties;
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * @author roland
- * @since 21/01/16
  */
 public class DockerFileUtilTest {
 
@@ -93,7 +92,7 @@ public class DockerFileUtilTest {
         File actualDockerFile = createTmpFile(dockerFile.getName());
         FileUtils.write(actualDockerFile, DockerFileUtil.interpolate(dockerFile, projectProperties), "UTF-8");
         // Compare text lines without regard to EOL delimiters
-        assertEquals(FileUtils.readLines(expectedDockerFile), FileUtils.readLines(actualDockerFile));
+        assertEquals(FileUtils.readLines(expectedDockerFile, StandardCharsets.UTF_8), FileUtils.readLines(actualDockerFile, StandardCharsets.UTF_8));
     }
 
     private File getDockerfilePath(String dir) {

--- a/jkube-kit/common-maven/src/test/java/org/eclipse/jkube/kit/common/util/MavenUtilTest.java
+++ b/jkube-kit/common-maven/src/test/java/org/eclipse/jkube/kit/common/util/MavenUtilTest.java
@@ -49,10 +49,10 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class MavenUtilTest {
   @Rule

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/ResourceUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/ResourceUtil.java
@@ -31,7 +31,6 @@ import org.apache.commons.lang3.StringUtils;
  * Utility for resource file handling
  *
  * @author roland
- * @since 07/02/17
  */
 public class ResourceUtil {
 

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/EnvUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/EnvUtilTest.java
@@ -27,8 +27,8 @@ import java.util.Date;
 
 import static org.eclipse.jkube.kit.common.util.EnvUtil.loadTimestamp;
 import static org.eclipse.jkube.kit.common.util.EnvUtil.storeTimestamp;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class EnvUtilTest {
 

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/TemplateUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/TemplateUtilTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 
 import static org.eclipse.jkube.kit.common.util.TemplateUtil.escapeYamlTemplate;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TemplateUtilTest {
 

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/YamlUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/YamlUtilTest.java
@@ -26,9 +26,9 @@ import static org.eclipse.jkube.kit.common.util.YamlUtil.splitYamlResource;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class YamlUtilTest {

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageConfigurationTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageConfigurationTest.java
@@ -19,7 +19,7 @@ import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ImageConfigurationTest {
 

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/BuildConfigurationTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/BuildConfigurationTest.java
@@ -25,15 +25,14 @@ import static org.eclipse.jkube.kit.common.archive.ArchiveCompression.bzip2;
 import static org.eclipse.jkube.kit.common.archive.ArchiveCompression.gzip;
 import static org.eclipse.jkube.kit.common.archive.ArchiveCompression.none;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
  * @author roland
- * @since 04/04/16
  */
 
 public class BuildConfigurationTest {

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/DockerFileBuilderTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/DockerFileBuilderTest.java
@@ -20,15 +20,17 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.Matchers.hasEntry;
 
@@ -72,7 +74,7 @@ public class DockerFileBuilderTest {
     }
 
     @Test
-    public void testBuildLabelWithSpace() throws Exception {
+    public void testBuildLabelWithSpace() {
         String dockerfileContent = new DockerFileBuilder()
                 .labels(Collections.singletonMap("key", "label with space"))
                 .content();
@@ -114,7 +116,7 @@ public class DockerFileBuilderTest {
     }
 
     @Test(expected= IllegalArgumentException.class)
-    public void testBuildDockerFileBadPort() throws Exception {
+    public void testBuildDockerFileBadPort() {
         Arguments a = Arguments.builder().execArgument("c1").execArgument("c2").build();
         new DockerFileBuilder().add("/src", "/dest")
                 .baseImage("image")
@@ -131,7 +133,7 @@ public class DockerFileBuilderTest {
     }
 
     @Test(expected= IllegalArgumentException.class)
-    public void testBuildDockerFileBadProtocol() throws Exception {
+    public void testBuildDockerFileBadProtocol() {
         Arguments a = Arguments.builder().execArgument("c1").execArgument("c2").build();
         new DockerFileBuilder().add("/src", "/dest")
                 .baseImage("image")
@@ -181,7 +183,8 @@ public class DockerFileBuilderTest {
 
     @Test
     public void testOptimiseOnEmptyRunCommandListDoesNotThrowException() {
-        new DockerFileBuilder().optimise().content();
+        final String result = new DockerFileBuilder().optimise().content();
+        assertThat(result, notNullValue());
     }
 
     @Test
@@ -262,7 +265,7 @@ public class DockerFileBuilderTest {
         assertEquals("RUN apt-get update\n", b.toString());
 
         b = new StringBuilder();
-        DockerFileKeyword.EXPOSE.addTo(b, new String[]{"1010", "2020"});
+        DockerFileKeyword.EXPOSE.addTo(b, "1010", "2020");
         assertEquals("EXPOSE 1010 2020\n",b.toString());
 
         b = new StringBuilder();
@@ -275,7 +278,7 @@ public class DockerFileBuilderTest {
     }
 
     private String loadFile(String fileName) throws IOException {
-        return stripCR(IOUtils.toString(getClass().getClassLoader().getResource(fileName), Charset.defaultCharset()));
+        return stripCR(IOUtils.toString(Objects.requireNonNull(getClass().getClassLoader().getResource(fileName)), Charset.defaultCharset()));
     }
 
     private static Map<String, String> dockerfileToMap(String dockerFile) {

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
@@ -376,7 +376,7 @@ public class KubernetesResourceUtil {
         TypeReference<HashMap<String,Object>> typeRef = new TypeReference<HashMap<String,Object>>() {};
         try {
             Map<String, Object> ret = mapper.readValue(file, typeRef);
-            return ret != null ? ret : new HashMap<String, Object>();
+            return ret != null ? ret : new HashMap<>();
         } catch (JsonProcessingException e) {
             throw new JsonMappingException(String.format("[%s] %s", file, e.getMessage()), e.getLocation(), e);
         }
@@ -416,7 +416,7 @@ public class KubernetesResourceUtil {
 
     public static boolean checkForKind(KubernetesListBuilder builder, String... kinds) {
         Set<String> kindSet = new HashSet<>(Arrays.asList(kinds));
-        for (HasMetadata item : builder.getItems()) {
+        for (HasMetadata item : builder.buildItems()) {
             if (kindSet.contains(item.getKind())) {
                 return true;
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DebugEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DebugEnricher.java
@@ -58,7 +58,7 @@ public class DebugEnricher extends BaseEnricher {
     public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
         if (debugEnabled()) {
             int count = 0;
-            List<HasMetadata> items = builder.getItems();
+            List<HasMetadata> items = builder.buildItems();
             if (items != null) {
                 for (HasMetadata item : items) {
                     if (enableDebug(item)) {
@@ -127,7 +127,7 @@ public class DebugEnricher extends BaseEnricher {
             PodSpec podSpec = template.getSpec();
             if (podSpec != null) {
                 List<Container> containers = podSpec.getContainers();
-                if (containers.size() > 0) {
+                if (!containers.isEmpty()) {
                     Container container = containers.get(0);
                     List<EnvVar> env = container.getEnv();
                     if (env == null) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DependencyEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DependencyEnricher.java
@@ -180,8 +180,8 @@ public class DependencyEnricher extends BaseEnricher {
         int nItems = 0;
 
         // Populate map with existing items in the builder
-        for(int index = 0; index < builder.getItems().size(); index++, nItems++) {
-            HasMetadata aItem = builder.getItems().get(index);
+        for(int index = 0; index < builder.buildItems().size(); index++, nItems++) {
+            HasMetadata aItem = builder.buildItems().get(index);
             KindAndName aKey = new KindAndName(aItem);
             aIndexMap.put(aKey, index);
         }
@@ -190,7 +190,7 @@ public class DependencyEnricher extends BaseEnricher {
             KindAndName aKey = new KindAndName(item);
 
             if(aIndexMap.containsKey(aKey)) { // Merge the override fragments, and remove duplicate
-                HasMetadata duplicateItem = builder.getItems().get(aIndexMap.get(aKey));
+                HasMetadata duplicateItem = builder.buildItems().get(aIndexMap.get(aKey));
                 item = KubernetesResourceUtil.mergeResources(item, duplicateItem, log, false);
                 builder.setToItems(aIndexMap.get(aKey), item);
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
@@ -114,10 +114,10 @@ public class ImageEnricher extends BaseEnricher {
             @Override
             public void visit(ReplicationControllerBuilder item) {
                 ReplicationControllerFluent.SpecNested<ReplicationControllerBuilder> spec =
-                    item.getSpec() == null ? item.withNewSpec() : item.editSpec();
+                    item.buildSpec() == null ? item.withNewSpec() : item.editSpec();
                 ReplicationControllerSpecFluent.TemplateNested<ReplicationControllerFluent.SpecNested<ReplicationControllerBuilder>>
                     template =
-                    spec.getTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
+                    spec.buildTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
                 template.endTemplate().endSpec();
             }
         });
@@ -128,9 +128,9 @@ public class ImageEnricher extends BaseEnricher {
             @Override
             public void visit(ReplicaSetBuilder item) {
                 ReplicaSetFluent.SpecNested<ReplicaSetBuilder> spec =
-                    item.getSpec() == null ? item.withNewSpec() : item.editSpec();
+                    item.buildSpec() == null ? item.withNewSpec() : item.editSpec();
                 ReplicaSetSpecFluent.TemplateNested<ReplicaSetFluent.SpecNested<ReplicaSetBuilder>> template =
-                    spec.getTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
+                    spec.buildTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
                 template.endTemplate().endSpec();
             }
         });
@@ -141,9 +141,9 @@ public class ImageEnricher extends BaseEnricher {
             @Override
             public void visit(DeploymentBuilder item) {
                 DeploymentFluent.SpecNested<DeploymentBuilder> spec =
-                    item.getSpec() == null ? item.withNewSpec() : item.editSpec();
+                    item.buildSpec() == null ? item.withNewSpec() : item.editSpec();
                 DeploymentSpecFluent.TemplateNested<DeploymentFluent.SpecNested<DeploymentBuilder>> template =
-                    spec.getTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
+                    spec.buildTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
                 template.endTemplate().endSpec();
             }
         });
@@ -154,9 +154,9 @@ public class ImageEnricher extends BaseEnricher {
             @Override
             public void visit(DaemonSetBuilder item) {
                 DaemonSetFluent.SpecNested<DaemonSetBuilder> spec =
-                        item.getSpec() == null ? item.withNewSpec() : item.editSpec();
+                        item.buildSpec() == null ? item.withNewSpec() : item.editSpec();
                 DaemonSetSpecFluent.TemplateNested<DaemonSetFluent.SpecNested<DaemonSetBuilder>> template =
-                        spec.getTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
+                        spec.buildTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
                 template.endTemplate().endSpec();
             }
         });
@@ -167,9 +167,9 @@ public class ImageEnricher extends BaseEnricher {
             @Override
             public void visit(StatefulSetBuilder item) {
                 StatefulSetFluent.SpecNested<StatefulSetBuilder> spec =
-                        item.getSpec() == null ? item.withNewSpec() : item.editSpec();
+                        item.buildSpec() == null ? item.withNewSpec() : item.editSpec();
                 StatefulSetSpecFluent.TemplateNested<StatefulSetFluent.SpecNested<StatefulSetBuilder>> template =
-                        spec.getTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
+                        spec.buildTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
                 template.endTemplate().endSpec();
             }
         });
@@ -180,9 +180,9 @@ public class ImageEnricher extends BaseEnricher {
             @Override
             public void visit(DeploymentConfigBuilder item) {
                 DeploymentConfigFluent.SpecNested<DeploymentConfigBuilder> spec =
-                        item.getSpec() == null ? item.withNewSpec() : item.editSpec();
+                        item.buildSpec() == null ? item.withNewSpec() : item.editSpec();
                 DeploymentConfigSpecFluent.TemplateNested<DeploymentConfigFluent.SpecNested<DeploymentConfigBuilder>> template =
-                        spec.getTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
+                        spec.buildTemplate() == null ? spec.withNewTemplate() : spec.editTemplate();
                 template.endTemplate().endSpec();
             }
         });
@@ -196,11 +196,11 @@ public class ImageEnricher extends BaseEnricher {
             @Override
             public void visit(PodTemplateSpecBuilder templateBuilder) {
                 PodTemplateSpecFluent.SpecNested<PodTemplateSpecBuilder> podSpec =
-                    templateBuilder.getSpec() == null ? templateBuilder.withNewSpec() : templateBuilder.editSpec();
+                    templateBuilder.buildSpec() == null ? templateBuilder.withNewSpec() : templateBuilder.editSpec();
 
-                List<Container> containers = podSpec.getContainers();
+                List<Container> containers = podSpec.buildContainers();
                 if (containers == null) {
-                    containers = new ArrayList<Container>();
+                    containers = new ArrayList<>();
                 }
                 mergeImageConfigurationWithContainerSpec(containers);
                 podSpec.withContainers(containers).endSpec();

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PodAnnotationEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PodAnnotationEnricher.java
@@ -41,7 +41,7 @@ public class PodAnnotationEnricher extends BaseEnricher {
     public void enrich(PlatformMode platformMode, KubernetesListBuilder builder) {
         super.enrich(platformMode, builder);
 
-        List<HasMetadata> items = builder.getItems();
+        List<HasMetadata> items = builder.buildItems();
         for (HasMetadata item : items) {
             if (platformMode == PlatformMode.kubernetes && item instanceof Deployment) {
                 Deployment deployment = (Deployment) item;

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricherTest.java
@@ -33,8 +33,8 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.TreeMap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author kamesh

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherTest.java
@@ -35,10 +35,10 @@ import java.util.TreeMap;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author roland

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ImageEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ImageEnricherTest.java
@@ -36,8 +36,8 @@ import org.junit.Test;
 
 import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author nicola

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/IngressEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/IngressEnricherTest.java
@@ -75,7 +75,7 @@ public class IngressEnricherTest {
         assertNotNull(ingress);
         assertEquals(testSvcBuilder.buildMetadata().getName(), ingress.getMetadata().getName());
         assertEquals(1, ingress.getSpec().getRules().size());
-        assertEquals(testSvcBuilder.getMetadata().getName() + "." + "org.eclipse.jkube", ingress.getSpec().getRules().get(0).getHost());
+        assertEquals(testSvcBuilder.buildMetadata().getName() + "." + "org.eclipse.jkube", ingress.getSpec().getRules().get(0).getHost());
     }
 
     private ServiceBuilder getTestService() {

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/PortNameEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/PortNameEnricherTest.java
@@ -34,13 +34,12 @@ import java.util.TreeMap;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author dgaur
- * @since 03/06/16
  */
 public class PortNameEnricherTest {
 

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/RevisionHistoryEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/RevisionHistoryEnricherTest.java
@@ -32,8 +32,8 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.TreeMap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class RevisionHistoryEnricherTest {
 

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/AutoTLSEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/AutoTLSEnricherTest.java
@@ -135,7 +135,7 @@ public class AutoTLSEnricherTest {
             KubernetesListBuilder klb = new KubernetesListBuilder().addNewPodTemplateItem().withNewMetadata().and()
                     .withNewTemplate().withNewMetadata().and().withNewSpec().and().and().and();
             enricher.enrich(PlatformMode.kubernetes, klb);
-            PodTemplate pt = (PodTemplate) klb.getItems().get(0);
+            PodTemplate pt = (PodTemplate) klb.buildItems().get(0);
 
             List<Container> initContainers = pt.getTemplate().getSpec().getInitContainers();
             assertEquals(tc.mode == PlatformMode.openshift, !initContainers.isEmpty());

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/DeploymentConfigEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/DeploymentConfigEnricherTest.java
@@ -63,7 +63,7 @@ public class DeploymentConfigEnricherTest {
         deploymentConfigEnricher.create(PlatformMode.openshift, kubernetesListBuilder);
 
         // Then
-        assertEquals(1, kubernetesListBuilder.getItems().size());
+        assertEquals(1, kubernetesListBuilder.buildItems().size());
         HasMetadata result = kubernetesListBuilder.buildFirstItem();
         assertTrue(result instanceof DeploymentConfig);
         assertDeploymentConfig((DeploymentConfig) result, "Rolling");
@@ -102,7 +102,7 @@ public class DeploymentConfigEnricherTest {
         deploymentConfigEnricher.create(PlatformMode.openshift, kubernetesListBuilder);
 
         // Then
-        assertEquals(1, kubernetesListBuilder.getItems().size());
+        assertEquals(1, kubernetesListBuilder.buildItems().size());
         HasMetadata result = kubernetesListBuilder.buildFirstItem();
         assertTrue(result instanceof DeploymentConfig);
         assertDeploymentConfig((DeploymentConfig) result, "Recreate");
@@ -142,7 +142,7 @@ public class DeploymentConfigEnricherTest {
         deploymentConfigEnricher.create(PlatformMode.openshift, kubernetesListBuilder);
 
         // Then
-        assertEquals(1, kubernetesListBuilder.getItems().size());
+        assertEquals(1, kubernetesListBuilder.buildItems().size());
         HasMetadata result = kubernetesListBuilder.buildFirstItem();
         assertTrue(result instanceof DeploymentConfig);
         assertDeploymentConfig((DeploymentConfig) result, "Rolling");

--- a/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/DockerHealthCheckEnricherTest.java
+++ b/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/DockerHealthCheckEnricherTest.java
@@ -37,8 +37,8 @@ import mockit.Mocked;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author nicola

--- a/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/support/AbstractPortsExtractorTest.java
+++ b/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/support/AbstractPortsExtractorTest.java
@@ -23,10 +23,10 @@ import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 public class AbstractPortsExtractorTest {
 

--- a/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/FatJarDetectorTest.java
+++ b/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/FatJarDetectorTest.java
@@ -23,8 +23,8 @@ import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 public class FatJarDetectorTest {
 

--- a/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
+++ b/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
@@ -28,10 +28,10 @@ import mockit.Mocked;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 public class OpenLibertyGeneratorTest {
 

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/ChartTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/ChartTest.java
@@ -18,9 +18,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 public class ChartTest {
 

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmConfigTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmConfigTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class HelmConfigTest {

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceIT.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceIT.java
@@ -32,9 +32,9 @@ import io.fabric8.openshift.api.model.Template;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 public class HelmServiceIT {
 

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceTest.java
@@ -27,8 +27,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 public class HelmServiceTest {
 

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/MaintainerTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/MaintainerTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MaintainerTest {
 

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmMojoTest.java
@@ -42,10 +42,10 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class HelmMojoTest {

--- a/quickstarts/maven/openliberty/pom.xml
+++ b/quickstarts/maven/openliberty/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.eclipse.jkube.quickstarts.maven</groupId>
     <artifactId>openliberty</artifactId>
-    <version>1.0.0-alpha-4</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>Eclipse JKube :: Quickstarts :: Maven :: Open Liberty</name>
     <packaging>war</packaging>
 


### PR DESCRIPTION
Signed-off-by: Marc Nuri <marc@marcnuri.com>

## Description
Removed several of the deprecation warnings that appear when compiling the project (and probably on SonarCloud reports too).

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] ~I have implemented unit tests to cover my changes~
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] ~I tested my code in Kubernetes~
 - [ ] ~I tested my code in OpenShift~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->