### PR TITLE
refactor: Replace Quarkus Native Base image with ubi-minimal (same as…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,12 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.0.0-SNAPSHOT
+* Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)
 * Fix #187: Provided Dockerfile is always skipped in simple Dockerfile mode
 * Fix #237: Remove deprecated fields and method calls
 * Fix #192: Removed `@Deprecated` fields from ClusterAccess
 * Fix #190: Removed `@Deprecated` fields from AssemblyConfiguration
 * Fix #189: Removed `@Deprecated` fields from BuildConfiguration
-
 
 ### 1.0.0-alpha-4 (2020-06-08)
 * Fix #173: Use OpenShift compliant git/vcs annotations 

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusGenerator.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusGenerator.java
@@ -84,7 +84,7 @@ public class QuarkusGenerator extends BaseGenerator {
 
         Optional<String> fromConfigured = Optional.ofNullable(getFromAsConfigured());
         if (isNative) {
-            buildBuilder.from(fromConfigured.orElse("registry.fedoraproject.org/fedora-minimal"))
+            buildBuilder.from(fromConfigured.orElse("registry.access.redhat.com/ubi8/ubi-minimal:8.1"))
                         .entryPoint(Arguments.builder()
                                         .execArgument("./" + findSingleFileThatEndsWith("-runner"))
                                         .execArgument("-Dquarkus.http.host=0.0.0.0")

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
@@ -42,9 +42,6 @@ import mockit.Mocked;
  */
 public class QuarkusGeneratorTest {
 
-    private static final String QUARKUS_GROUP = "io.quarkus";
-    private static final String QUARKUS_MAVEN_PLUGIN = "quarkus-maven-plugin";
-
     private static final String BASE_JAVA_IMAGE = "java:latest";
     private static final String BASE_NATIVE_IMAGE = "fedora:latest";
 
@@ -69,7 +66,6 @@ public class QuarkusGeneratorTest {
             project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
             // project.getPlugin(QUARKUS_GROUP + ":" + QUARKUS_MAVEN_PLUGIN); result = quarkusPlugin;
         }};
-
         // @formatter:on
         projectProps.put("jkube.generator.name", "quarkus");
         setupContextOpenShift(projectProps, null, null);
@@ -78,12 +74,11 @@ public class QuarkusGeneratorTest {
     @Test
     public void testCustomizeReturnsDefaultFrom () {
         QuarkusGenerator generator = new QuarkusGenerator(ctx);
-        List<ImageConfiguration> resultImages = null;
         List<ImageConfiguration> existingImages = new ArrayList<>();
 
-        resultImages = generator.customize(existingImages, true);
+        final List<ImageConfiguration> result = generator.customize(existingImages, true);
 
-        assertBuildFrom(resultImages, "openjdk:11");
+        assertBuildFrom(result, "openjdk:11");
     }
 
     @Test
@@ -96,7 +91,7 @@ public class QuarkusGeneratorTest {
 
         resultImages = generator.customize(existingImages, true);
 
-        assertBuildFrom(resultImages, "registry.fedoraproject.org/fedora-minimal");
+        assertBuildFrom(resultImages, "registry.access.redhat.com/ubi8/ubi-minimal:8.1");
     }
 
     @Test

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_quarkus.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_quarkus.adoc
@@ -11,7 +11,7 @@ The base images chosen are:
 | | Docker Build | S2I Build
 
 | *Native*
-| `registry.fedoraproject.org/fedora-minimal`
+| `registry.access.redhat.com/ubi8/ubi-minimal:8.1`
 | ---
 
 | *Normal Build*


### PR DESCRIPTION
## Description

Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

`registry.fedoraproject.org` is  down many times and `registry.fedoraproject.org/fedora-minimal:latest` is not even the same base image Quarkus uses in its `Dockerfile.native`. This changes the base image to the one used in the mentioned file.

TODO: Need to refactor QuarkusGenerator to behave like the other generators, and pick up base image configurations (not hardcoded).

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->