### PR TITLE
fix: DockerFileBuilder only supports *nix paths (Dockerfile Linux only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Usage:
 * Fix #190: Removed `@Deprecated` fields from AssemblyConfiguration
 * Fix #189: Removed `@Deprecated` fields from BuildConfiguration
 * Fix #195: Added MigrateMojo for migrating projects from FMP to JKube
+* Fix #261: DockerFileBuilder only supports *nix paths (Dockerfile Linux only), fixed invalid default configs
 
 ### 1.0.0-alpha-4 (2020-06-08)
 * Fix #173: Use OpenShift compliant git/vcs annotations 

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/AssemblyConfigurationUtils.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/AssemblyConfigurationUtils.java
@@ -20,7 +20,6 @@ import org.eclipse.jkube.kit.common.AssemblyFile;
 import org.eclipse.jkube.kit.common.AssemblyFileSet;
 import org.eclipse.jkube.kit.common.Assembly;
 
-import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -28,8 +27,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class AssemblyConfigurationUtils {
+class AssemblyConfigurationUtils {
 
+  private static final String LINUX_FILE_SEPARATOR = "/";
   private static final String DEFAULT_NAME = "maven";
   private static final String DEFAULT_USER = "root";
 
@@ -48,7 +48,7 @@ public class AssemblyConfigurationUtils {
       name = ac.getName();
     }
     if (StringUtils.isBlank(ac.getTargetDir())) {
-      builder.targetDir(File.separator.concat(name));
+      builder.targetDir(LINUX_FILE_SEPARATOR.concat(name));
     }
     return builder.build();
   }

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/core/assembly/AssemblyConfigurationUtilsTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/core/assembly/AssemblyConfigurationUtilsTest.java
@@ -71,7 +71,7 @@ public class AssemblyConfigurationUtilsTest {
     // Then
     assertNotNull(result);
     assertEquals("ImageName", result.getName());
-    assertEquals(File.separator + "ImageName", result.getTargetDir());
+    assertEquals("/ImageName", result.getTargetDir());
     assertEquals("OtherUser", result.getUser());
   }
 

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/DockerFileBuilder.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/DockerFileBuilder.java
@@ -374,7 +374,7 @@ public class DockerFileBuilder {
     public DockerFileBuilder basedir(String dir) {
         if (dir != null) {
             if (!dir.startsWith("/")) {
-                throw new IllegalArgumentException("'basedir' must be an absolute path starting with / (and not " +
+                throw new IllegalArgumentException("'basedir' must be an *nix absolute path starting with / (and not " +
                                                    "'" + basedir + "')");
             }
             basedir = dir;


### PR DESCRIPTION
## Description
DockerFileBuilder only supports *nix paths (Dockerfile Linux only)
- Fixed provided invalid default configs (Dockerfile mode, etc.)

Fixes: #261

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->