### PR TITLE
fix: Watch uses same logic as build to monitor changed assembly files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Usage:
 * Fix #189: Removed `@Deprecated` fields from BuildConfiguration
 * Fix #195: Added MigrateMojo for migrating projects from FMP to JKube
 * Fix #261: DockerFileBuilder only supports *nix paths (Dockerfile Linux only), fixed invalid default configs
+* Fix #238: Watch uses same logic as build to monitor changed assembly files
 
 ### 1.0.0-alpha-4 (2020-06-08)
 * Fix #173: Use OpenShift compliant git/vcs annotations 

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/AssemblyConfigurationUtils.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/AssemblyConfigurationUtils.java
@@ -20,6 +20,8 @@ import org.eclipse.jkube.kit.common.AssemblyFile;
 import org.eclipse.jkube.kit.common.AssemblyFileSet;
 import org.eclipse.jkube.kit.common.Assembly;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +37,8 @@ class AssemblyConfigurationUtils {
 
   private AssemblyConfigurationUtils() {}
 
-  static AssemblyConfiguration getAssemblyConfigurationOrCreateDefault(BuildConfiguration buildConfiguration) {
+  @Nonnull
+  static AssemblyConfiguration getAssemblyConfigurationOrCreateDefault(@Nullable BuildConfiguration buildConfiguration) {
     final AssemblyConfiguration ac = Optional.ofNullable(buildConfiguration)
             .map(BuildConfiguration::getAssembly)
             .orElse(AssemblyConfiguration.builder().user(DEFAULT_USER).build());
@@ -53,14 +56,16 @@ class AssemblyConfigurationUtils {
     return builder.build();
   }
 
-  static List<AssemblyFileSet> getJKubeAssemblyFileSets(AssemblyConfiguration configuration) {
+  @Nonnull
+  static List<AssemblyFileSet> getJKubeAssemblyFileSets(@Nullable AssemblyConfiguration configuration) {
     return Optional.ofNullable(configuration)
             .map(AssemblyConfiguration::getInline)
             .map(Assembly::getFileSets)
             .orElse(Collections.emptyList());
   }
 
-  static List<String> getJKubeAssemblyFileSetsExcludes(AssemblyConfiguration assemblyConfiguration) {
+  @Nonnull
+  static List<String> getJKubeAssemblyFileSetsExcludes(@Nullable AssemblyConfiguration assemblyConfiguration) {
     return getJKubeAssemblyFileSets(assemblyConfiguration).stream()
             .filter(Objects::nonNull)
             .map(AssemblyFileSet::getExcludes)
@@ -70,6 +75,7 @@ class AssemblyConfigurationUtils {
             .collect(Collectors.toList());
   }
 
+  @Nonnull
   static List<AssemblyFile> getJKubeAssemblyFiles(AssemblyConfiguration configuration) {
     return Optional.ofNullable(configuration)
             .map(AssemblyConfiguration::getInline)

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/JKubeBuildTarArchiver.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/core/assembly/JKubeBuildTarArchiver.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.jkube.kit.common.AssemblyFileEntry;
 import org.eclipse.jkube.kit.common.archive.ArchiveCompression;
 import org.eclipse.jkube.kit.common.archive.JKubeTarArchiver;
 import org.eclipse.jkube.kit.common.util.FileUtil;
@@ -27,6 +28,7 @@ import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.apache.commons.io.FileUtils;
 
 public class JKubeBuildTarArchiver {
+
     private Map<File, String> filesToIncludeNameMap = new HashMap<>();
     private Map<File, String> fileToPermissionsMap = new HashMap<>();
     private List<String> filesNamesToExclude = new ArrayList<>();
@@ -35,20 +37,12 @@ public class JKubeBuildTarArchiver {
         filesToIncludeNameMap.put(inputFile, destinationFileName);
     }
 
-    public void setFilePermissions(File file, String permissions) {
-        fileToPermissionsMap.put(file, permissions);
+    public void setFilePermissions(AssemblyFileEntry assemblyFileEntry) {
+        fileToPermissionsMap.put(assemblyFileEntry.getDest(), assemblyFileEntry.getPermission());
     }
 
     public void excludeFile(String inputFilePath) {
         filesNamesToExclude.add(inputFilePath);
-    }
-
-    public Map<File, String> getFilesToIncludeNameMap() {
-        return filesToIncludeNameMap;
-    }
-
-    public List<String> getFilesNamesToExcludeName() {
-        return filesNamesToExclude;
     }
 
     public File createArchive(File inputDirectory, BuildDirs buildDirs, ArchiveCompression compression) throws IOException {

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/ArchiveService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/ArchiveService.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.kit.build.service.docker;
 
+import org.eclipse.jkube.kit.common.AssemblyFileEntry;
 import org.eclipse.jkube.kit.config.JKubeConfiguration;
 import org.eclipse.jkube.kit.build.core.assembly.ArchiverCustomizer;
 import org.eclipse.jkube.kit.build.core.assembly.AssemblyFiles;
@@ -29,10 +30,8 @@ import java.util.List;
  */
 public class ArchiveService {
 
-
     private final KitLogger log;
     private DockerAssemblyManager dockerAssemblyManager;
-
 
     public ArchiveService(DockerAssemblyManager dockerAssemblyManager, KitLogger log) {
         this.log = log;
@@ -84,11 +83,10 @@ public class ArchiveService {
     public AssemblyFiles getAssemblyFiles(ImageConfiguration imageConfig, JKubeConfiguration jKubeConfiguration)
         throws IOException {
 
-        String name = imageConfig.getName();
         try {
-            return dockerAssemblyManager.getAssemblyFiles(name, imageConfig.getBuildConfiguration(), jKubeConfiguration);
-        } catch (Exception e) {
-            throw new IOException("Cannot extract assembly files for image " + name + ": " + e, e);
+            return dockerAssemblyManager.getAssemblyFiles(imageConfig, jKubeConfiguration);
+        } catch (IOException e) {
+            throw new IOException("Cannot extract assembly files for image " + imageConfig.getName() + ": " + e.getMessage(), e);
         }
     }
 
@@ -98,16 +96,16 @@ public class ArchiveService {
      * @param entries changed files. List must not be empty or null
      * @param assemblyDir assembly directory
      * @param imageName image's name
-     * @param mojoParameters maven build context
+     * @param jKubeConfiguration maven build context
      * @return created archive
      * @throws IOException in case of any I/O exception
      */
-    public File createChangedFilesArchive(List<AssemblyFiles.Entry> entries, File assemblyDir,
-                                          String imageName, JKubeConfiguration mojoParameters) throws IOException {
-        return dockerAssemblyManager.createChangedFilesArchive(entries, assemblyDir, imageName, mojoParameters);
-    }
+    public File createChangedFilesArchive(
+        List<AssemblyFileEntry> entries, File assemblyDir,String imageName,
+        JKubeConfiguration jKubeConfiguration) throws IOException {
 
-    // =============================================
+        return dockerAssemblyManager.createChangedFilesArchive(entries, assemblyDir, imageName, jKubeConfiguration);
+    }
 
     File createArchive(String imageName, BuildConfiguration buildConfig, JKubeConfiguration params, KitLogger log)
             throws IOException {

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/WatchMode.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/WatchMode.java
@@ -21,7 +21,7 @@ package org.eclipse.jkube.kit.build.service.docker.config;
 public enum WatchMode {
 
     /**
-     * Copy watched artefacts into contaienr
+     * Copy watched artifacts into container
      */
     copy(false, false, true, "build"),
 

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/AssemblyFileEntry.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/AssemblyFileEntry.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.File;
+
+
+@Getter
+@Setter
+@EqualsAndHashCode
+public class AssemblyFileEntry {
+
+  private long lastModified;
+  private File source;
+  private File dest;
+  private String permission;
+
+  @Builder
+  public AssemblyFileEntry(File source, File dest, String permission) {
+    this.lastModified = source.lastModified();
+    this.source = source;
+    this.dest = dest;
+    this.permission = permission;
+  }
+
+  public boolean isUpdated() {
+    if (source.lastModified() > lastModified) {
+      // Update last modified as a side effect
+      lastModified = source.lastModified();
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileSetUtilsProcessAssemblyFileSetTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileSetUtilsProcessAssemblyFileSetTest.java
@@ -17,12 +17,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jkube.kit.common.AssemblyConfiguration;
+import org.eclipse.jkube.kit.common.AssemblyFileEntry;
 import org.eclipse.jkube.kit.common.AssemblyFileSet;
 
 import org.apache.commons.io.FileUtils;
@@ -151,9 +151,9 @@ public class AssemblyFileSetUtilsProcessAssemblyFileSetTest {
         .targetDir("deployments")
         .build();
     // When
-    final Map<File, String> permissions = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
+    final List<AssemblyFileEntry> result = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
     // Then
-    assertThat(permissions.entrySet(), hasSize(4));
+    assertThat(result, hasSize(4));
     final File deployments = new File(outputDirectory, "deployments");
     assertThat(deployments.exists(), equalTo(true));
     assertThat(deployments.listFiles(), arrayWithSize(1));
@@ -181,9 +181,9 @@ public class AssemblyFileSetUtilsProcessAssemblyFileSetTest {
         .targetDir("deployments")
         .build();
     // When
-    final Map<File, String> permissions = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
+    final List<AssemblyFileEntry> result = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
     // Then
-    assertThat(permissions.entrySet(), empty());
+    assertThat(result, empty());
     final File deployments = new File(outputDirectory, "deployments");
     assertThat(deployments.exists(), equalTo(false));
   }
@@ -207,9 +207,9 @@ public class AssemblyFileSetUtilsProcessAssemblyFileSetTest {
         .targetDir("deployments")
         .build();
     // When
-    final Map<File, String> permissions = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
+    final List<AssemblyFileEntry> result = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
     // Then
-    assertThat(permissions.entrySet(), hasSize(4));
+    assertThat(result, hasSize(4));
     final File deployments = new File(outputDirectory, "deployments");
     assertThat(deployments.exists(), equalTo(true));
     assertThat(deployments.listFiles(), arrayWithSize(6));
@@ -236,9 +236,9 @@ public class AssemblyFileSetUtilsProcessAssemblyFileSetTest {
         .targetDir("/deployments")
         .build();
     // When
-    final Map<File, String> permissions = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
+    final List<AssemblyFileEntry> result = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
     // Then
-    assertThat(permissions.entrySet(), hasSize(4));
+    assertThat(result, hasSize(4));
     assertThat(new File(outputDirectory, "deployments").exists(), equalTo(false));
     assertThat(absoluteOutputDirectory.listFiles(), arrayWithSize(6));
     assertThat(absoluteOutputDirectory.list(), arrayContainingInAnyOrder("one", "two", "three", "1.txt", "3.other", "37"));
@@ -263,9 +263,9 @@ public class AssemblyFileSetUtilsProcessAssemblyFileSetTest {
         .targetDir("/deployments/")
         .build();
     // When
-    final Map<File, String> permissions = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
+    final List<AssemblyFileEntry> result = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
     // Then
-    assertThat(permissions.entrySet(), hasSize(4));
+    assertThat(result, hasSize(4));
     final File deployments = new File(outputDirectory, "deployments");
     assertThat(deployments.exists(), equalTo(true));
     assertThat(deployments.listFiles(), arrayWithSize(1));
@@ -296,9 +296,9 @@ public class AssemblyFileSetUtilsProcessAssemblyFileSetTest {
         .targetDir("/deployments")
         .build();
     // When
-    final Map<File, String> permissions = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
+    final List<AssemblyFileEntry> result = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
     // Then
-    assertThat(permissions.entrySet(), hasSize(1));
+    assertThat(result, hasSize(1));
     final File deployments = new File(outputDirectory, "deployments");
     assertThat(deployments.exists(), equalTo(true));
     assertThat(deployments.listFiles(), arrayWithSize(1));
@@ -331,9 +331,9 @@ public class AssemblyFileSetUtilsProcessAssemblyFileSetTest {
         .targetDir("maven")
         .build();
     // When
-    final Map<File, String> permissions = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
+    final List<AssemblyFileEntry> result = AssemblyFileSetUtils.processAssemblyFileSet(baseDirectory, outputDirectory, afs, ac);
     // Then
-    assertThat(permissions.entrySet(), hasSize(1));
+    assertThat(result, hasSize(1));
     final File maven = new File(outputDirectory, "maven");
     assertThat(maven.exists(), equalTo(true));
     assertThat(maven.listFiles(), arrayWithSize(1));

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
@@ -157,16 +157,8 @@ public class OpenshiftBuildService implements BuildService {
         final ArchiverCustomizer customizer = getS2ICustomizer(imageConfig);
 
         try {
-            // Create tar file with Docker archive
-            File dockerTar;
-            if (customizer != null) {
-                dockerTar = jKubeServiceHub.getDockerServiceHub().getArchiveService()
-                    .createDockerBuildArchive(imageConfig, jKubeServiceHub.getConfiguration(), customizer);
-            } else {
-                dockerTar = jKubeServiceHub.getDockerServiceHub()
-                    .getArchiveService().createDockerBuildArchive(imageConfig, jKubeServiceHub.getConfiguration());
-            }
-            return dockerTar;
+            return jKubeServiceHub.getDockerServiceHub().getArchiveService()
+                .createDockerBuildArchive(imageConfig, jKubeServiceHub.getConfiguration(), customizer);
         } catch (IOException e) {
             throw new JKubeServiceException("Unable to create the build archive", e);
         }

--- a/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/BaseWatcher.java
+++ b/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/BaseWatcher.java
@@ -32,7 +32,7 @@ public abstract class BaseWatcher implements Watcher {
 
     public BaseWatcher(WatcherContext context, String name) {
         this.context = context;
-        this.config = new WatcherConfig(context.getProject().getProperties(), name, context.getConfig());
+        this.config = new WatcherConfig(context.getBuildContext().getProject().getProperties(), name, context.getConfig());
         this.name = name;
         this.log = new PrefixedLogger(name, context.getLogger());
     }

--- a/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherContext.java
+++ b/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherContext.java
@@ -13,22 +13,18 @@
  */
 package org.eclipse.jkube.watcher.api;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
+import org.eclipse.jkube.kit.build.service.docker.WatchService;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.JKubeConfiguration;
+import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.eclipse.jkube.kit.config.JKubeConfiguration;
-import org.eclipse.jkube.kit.common.JavaProject;
-import org.eclipse.jkube.kit.build.service.docker.ServiceHub;
-import org.eclipse.jkube.kit.build.service.docker.WatchService;
-import org.eclipse.jkube.kit.common.KitLogger;
-import org.eclipse.jkube.kit.config.access.ClusterConfiguration;
-import org.eclipse.jkube.kit.config.resource.RuntimeMode;
-import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
-import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 
 /**
  * @author nicola
@@ -40,18 +36,13 @@ import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 @EqualsAndHashCode
 public class WatcherContext {
 
-    private JavaProject project;
-    private ProcessorConfig config;
-    private KitLogger logger;
-    private KitLogger newPodLogger;
-    private KitLogger oldPodLogger;
-    private RuntimeMode mode;
-    private boolean useProjectClasspath;
-    private ServiceHub serviceHub;
-    private WatchService.WatchContext watchContext;
-    private JKubeConfiguration buildContext;
-    private ClusterConfiguration clusterConfiguration;
-    private KubernetesClient kubernetesClient;
-    private JKubeServiceHub jKubeServiceHub;
+  private ProcessorConfig config;
+  private KitLogger logger;
+  private KitLogger newPodLogger;
+  private KitLogger oldPodLogger;
+  private boolean useProjectClasspath;
+  private WatchService.WatchContext watchContext;
+  private JKubeConfiguration buildContext;
+  private JKubeServiceHub jKubeServiceHub;
 
 }

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
@@ -64,7 +64,7 @@ public class DockerImageWatcher extends BaseWatcher {
                 .imageCustomizer(this::buildImage).containerRestarter(imageWatcher -> restartContainer(imageWatcher, resources))
                 .build();
 
-        ServiceHub hub = getContext().getServiceHub();
+        ServiceHub hub = getContext().getJKubeServiceHub().getDockerServiceHub();
         try {
             hub.getWatchService().watch(watchContext, getContext().getBuildContext(), configs);
         } catch (Exception ex) {
@@ -78,7 +78,7 @@ public class DockerImageWatcher extends BaseWatcher {
         try {
             String imagePrefix = getImagePrefix(imageName);
             imageName = imagePrefix + "%t";
-            ImageNameFormatter formatter = new ImageNameFormatter(getContext().getProject(), new Date());
+            ImageNameFormatter formatter = new ImageNameFormatter(getContext().getBuildContext().getProject(), new Date());
             imageName = formatter.format(imageName);
             imageConfig.setName(imageName);
             log.info("New image name: " + imageConfig.getName());
@@ -101,7 +101,7 @@ public class DockerImageWatcher extends BaseWatcher {
     protected void restartContainer(WatchService.ImageWatcher watcher, Set<HasMetadata> resources) {
         ImageConfiguration imageConfig = watcher.getImageConfiguration();
         String imageName = imageConfig.getName();
-        ClusterAccess clusterAccess = new ClusterAccess(log, getContext().getClusterConfiguration());
+        ClusterAccess clusterAccess = getContext().getJKubeServiceHub().getClusterAccess();
         try (KubernetesClient client = clusterAccess.createDefaultClient()) {
 
             String namespace = clusterAccess.getNamespace();

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -102,9 +102,6 @@ public abstract class AbstractDockerMojo extends AbstractMojo
     public static final String DMP_PLUGIN_DESCRIPTOR = "META-INF/maven/org.eclipse.jkube/k8s-plugin";
     public static final String DOCKER_EXTRA_DIR = "docker-extra";
 
-    // Key for indicating that a "start" goal has run
-    public static final String CONTEXT_KEY_START_CALLED = "CONTEXT_KEY_DOCKER_START_CALLED";
-
     // Key holding the log dispatcher
     public static final String CONTEXT_KEY_LOG_DISPATCHER = "CONTEXT_KEY_DOCKER_LOG_DISPATCHER";
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
@@ -110,18 +110,13 @@ public class WatchMojo extends AbstractDockerMojo implements ManifestProvider {
             WatchService.WatchContext watchContext = jkubeServiceHub.getDockerServiceHub() != null ? getWatchContext() : null;
 
             return WatcherContext.builder()
-                    .serviceHub(jkubeServiceHub.getDockerServiceHub())
                     .buildContext(buildContext)
                     .watchContext(watchContext)
                     .config(extractWatcherConfig())
                     .logger(log)
                     .newPodLogger(createLogger("[[C]][NEW][[C]] "))
                     .oldPodLogger(createLogger("[[R]][OLD][[R]] "))
-                    .mode(getConfiguredRuntimeMode())
-                    .project(MavenUtil.convertMavenProjectToJKubeProject(project, session))
                     .useProjectClasspath(useProjectClasspath)
-                    .clusterConfiguration(initClusterConfiguration())
-                    .kubernetesClient(kubernetesClient)
                     .jKubeServiceHub(jkubeServiceHub)
                     .build();
         } catch (IOException exception) {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/watcher/WatcherManager.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/watcher/WatcherManager.java
@@ -13,25 +13,24 @@
  */
 package org.eclipse.jkube.maven.plugin.watcher;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
+import java.util.List;
+import java.util.Set;
+
 import org.eclipse.jkube.kit.build.service.docker.ImageConfiguration;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.ClassUtil;
-import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
 import org.eclipse.jkube.kit.common.util.PluginServiceFactory;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.eclipse.jkube.watcher.api.Watcher;
 import org.eclipse.jkube.watcher.api.WatcherContext;
 
-import java.util.List;
-import java.util.Set;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 
 /**
  * Manager responsible for finding and calling watchers
  *
  * @author nicola
- * @since 06/02/17
  */
 public class WatcherManager {
 
@@ -39,10 +38,10 @@ public class WatcherManager {
 
         PluginServiceFactory<WatcherContext> pluginFactory =
                 watcherCtx.isUseProjectClasspath() ?
-            new PluginServiceFactory<>(watcherCtx, ClassUtil.createProjectClassLoader(watcherCtx.getProject().getCompileClassPathElements(), watcherCtx.getLogger())) :
+            new PluginServiceFactory<>(watcherCtx, ClassUtil.createProjectClassLoader(watcherCtx.getBuildContext().getProject().getCompileClassPathElements(), watcherCtx.getLogger())) :
             new PluginServiceFactory<>(watcherCtx);
 
-        boolean isOpenshift = OpenshiftHelper.isOpenShift(watcherCtx.getKubernetesClient());
+        boolean isOpenshift = watcherCtx.getJKubeServiceHub().getClusterAccess().isOpenShift();
         PlatformMode mode = isOpenshift ? PlatformMode.openshift : PlatformMode.kubernetes;
 
         List<Watcher> watchers =

--- a/quickstarts/maven/quarkus/pom.xml
+++ b/quickstarts/maven/quarkus/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <version.quarkus>1.2.1.Final</version.quarkus>
+    <version.quarkus>1.5.2.Final</version.quarkus>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Description
Watch uses same logic as build to monitor changed assembly files (fixes #238 )

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
   - One new code smell reported for TODO related to #94 for AssemblyFile permission/fileMode
 - [x] I tested my code in Kubernetes
 - [ ] ~I tested my code in OpenShift~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->