### PR TITLE
fix: Debug goals work on webapp (Tomcat & Jetty)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Usage:
 * Fix #195: Added MigrateMojo for migrating projects from FMP to JKube
 * Fix #261: DockerFileBuilder only supports *nix paths (Dockerfile Linux only), fixed invalid default configs
 * Fix #238: Watch uses same logic as build to monitor changed assembly files
+* Fix #245: Debug goals work on webapp (Tomcat & Jetty) > See https://github.com/jkubeio/jkube-images/releases/tag/v0.0.7
 
 ### 1.0.0-alpha-4 (2020-06-08)
 * Fix #173: Use OpenShift compliant git/vcs annotations 

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.wagon-ssh-external>2.3</version.wagon-ssh-external>
 
     <!-- =======================================================  -->
-    <version.image.jkube-images>0.0.5</version.image.jkube-images>
+    <version.image.jkube-images>0.0.7</version.image.jkube-images>
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
     <!-- Upstream -->
     <version.image.java.upstream.docker>${version.image.jkube-images}</version.image.java.upstream.docker>


### PR DESCRIPTION
## Description
fix #245: Debug goals work on webapp (Tomcat & Jetty)

Related commits:
 - https://github.com/jkubeio/jkube-images/commit/6d6674cadab70101d1ecf43065c967e513d18779
 - https://github.com/jkubeio/jkube-images/commit/541788d3e4de757d0b094e8d4b607bc74f68b213

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] ~I have implemented unit tests to cover my changes~
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->