### PR TITLE
Fix #267: openshift-maven-plugin does not update Routes

### DIFF
--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
@@ -928,7 +928,7 @@ public class ApplyService {
 
     private <T extends HasMetadata> void doPatchEntity(T oldEntity, T newEntity, String namespace, String sourceName) {
         String kind = newEntity.getKind();
-        log.info("Updating {} from {}", kind, sourceName);
+        log.info("Updating %s from %s", kind, sourceName);
         try {
             Object answer = patchService.compareAndPatchEntity(namespace, newEntity, oldEntity);
             logGeneratedEntity("Updated " + kind + ": ", namespace, newEntity, answer);

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
@@ -79,7 +79,6 @@ import static org.eclipse.jkube.kit.common.util.KubernetesHelper.getName;
 import static org.eclipse.jkube.kit.common.util.KubernetesHelper.getOrCreateLabels;
 import static org.eclipse.jkube.kit.common.util.KubernetesHelper.getOrCreateMetadata;
 
-
 /**
  * Applies DTOs to the current Kubernetes master
  */
@@ -244,9 +243,8 @@ public class ApplyService {
     protected void doCreateOAuthClient(OAuthClient entity, String sourceName) {
         OpenShiftClient openShiftClient = getOpenShiftClient();
         if (openShiftClient != null) {
-            Object result = null;
             try {
-                result = openShiftClient.oAuthClients().create(entity);
+                openShiftClient.oAuthClients().create(entity);
             } catch (Exception e) {
                 onApplyError("Failed to create OAuthClient from " + sourceName + ". " + e + ". " + entity, e);
             }
@@ -402,13 +400,7 @@ public class ApplyService {
                         doCreatePersistentVolumeClaim(entity, namespace, sourceName);
                     }
                 } else {
-                    log.info("Updating a PersistentVolumeClaim from " + sourceName);
-                    try {
-                        HasMetadata answer = patchService.compareAndPatchEntity(namespace, entity, old);
-                        logGeneratedEntity("Updated PersistentVolumeClaim: ", namespace, entity, answer);
-                    } catch (Exception e) {
-                        onApplyError("Failed to update PersistentVolumeClaim from " + sourceName + ". " + e + ". " + entity, e);
-                    }
+                    doPatchEntity(old, entity, namespace, sourceName);
                 }
             }
         } else {
@@ -438,13 +430,7 @@ public class ApplyService {
                     kubernetesClient.customResourceDefinitions().withName(id).delete();
                     doCreateCustomResourceDefinition(entity, sourceName);
                 } else {
-                    log.info("Updating a Custom Resource Definition from " + sourceName + " name " + getName(entity));
-                    try {
-                        HasMetadata answer = patchService.compareAndPatchEntity(namespace, entity, old);
-                        log.info("Updated Custom Resource Definition result: " + getName(answer));
-                    } catch (Exception e) {
-                        onApplyError("Failed to update Custom Resource Definition from " + sourceName + ". " + e + ". " + entity, e);
-                    }
+                    doPatchEntity(old, entity, namespace, sourceName);
                 }
             }
         } else {
@@ -459,8 +445,8 @@ public class ApplyService {
     private void doCreateCustomResourceDefinition(CustomResourceDefinition entity, String sourceName) {
         log.info("Creating a Custom Resource Definition from " + sourceName + " name " + getName(entity));
         try {
-            Object answer = kubernetesClient.customResourceDefinitions().create(entity);
-            log.info("Created Custom Resource Definition result: " + ((CustomResourceDefinition) answer).getMetadata().getName());
+            CustomResourceDefinition answer = kubernetesClient.customResourceDefinitions().create(entity);
+            log.info("Created Custom Resource Definition result: " + answer.getMetadata().getName());
         } catch (Exception e) {
             onApplyError("Failed to create Custom Resource Definition from " + sourceName + ". " + e + ". " + entity, e);
         }
@@ -535,19 +521,12 @@ public class ApplyService {
             // if the secret already exists and is the same, then do nothing
             if (UserConfigurationCompare.configEqual(secret, old)) {
                 log.info("Secret has not changed so not doing anything");
-                return;
             } else {
                 if (isRecreateMode()) {
                     kubernetesClient.secrets().inNamespace(namespace).withName(id).delete();
                     doCreateSecret(secret, namespace, sourceName);
                 } else {
-                    log.info("Updating a Secret from " + sourceName);
-                    try {
-                        Object answer = patchService.compareAndPatchEntity(namespace, secret, old);
-                        logGeneratedEntity("Updated Secret:", namespace, secret, answer);
-                    } catch (Exception e) {
-                        onApplyError("Failed to update secret from " + sourceName + ". " + e + ". " + secret, e);
-                    }
+                    doPatchEntity(old, secret, namespace, sourceName);
                 }
             }
         } else {
@@ -558,7 +537,6 @@ public class ApplyService {
             }
         }
     }
-
 
     protected void doCreateSecret(Secret secret, String namespace, String sourceName) {
         log.info("Creating a Secret from " + sourceName + " namespace " + namespace + " name " + getName(secret));
@@ -642,7 +620,6 @@ public class ApplyService {
             }
     }
 
-
     public void applyRoute(Route entity, String sourceName) {
         OpenShiftClient openShiftClient = getOpenShiftClient();
         if (openShiftClient != null) {
@@ -652,18 +629,44 @@ public class ApplyService {
             if (StringUtils.isBlank(namespace)) {
                 namespace = getNamespace();
             }
+            if (isServicesOnlyMode()) {
+                log.debug("Ignoring Route: " + namespace + ":" + id);
+                return;
+            }
             Route route = openShiftClient.routes().inNamespace(namespace).withName(id).get();
-            if (route == null) {
-                try {
-                    log.info("Creating Route " + namespace + ":" + id + " " +
-                             (entity.getSpec() != null ?
-                                 "host: " + entity.getSpec().getHost() :
-                                 "No Spec !"));
-                    openShiftClient.routes().inNamespace(namespace).create(entity);
-                } catch (Exception e) {
-                    onApplyError("Failed to create Route from " + sourceName + ". " + e + ". " + entity, e);
+            if (isRunning(route)) {
+                if (UserConfigurationCompare.configEqual(entity, route)) {
+                    log.info("Route has not changed so not doing anything");
+                } else {
+                    if (isRecreateMode()) {
+                        log.info("Deleting Route: " + id);
+                        openShiftClient.routes().inNamespace(namespace).withName(id).delete();
+                        doCreateRoute(entity, namespace, sourceName);
+                    } else {
+                        doPatchEntity(route, entity, namespace, sourceName);
+                    }
+                }
+            } else {
+                if (!isAllowCreate()) {
+                    log.warn("Creation disabled so not creating a Route from " + sourceName + " namespace " + namespace + " name " + id);
+                } else {
+                    doCreateRoute(entity, namespace, sourceName);
                 }
             }
+        }
+    }
+
+    private void doCreateRoute(Route entity, String namespace, String sourceName) {
+        OpenShiftClient openShiftClient = getOpenShiftClient();
+        String id = getName(entity);
+        try {
+            log.info("Creating Route " + namespace + ":" + id + " " +
+                    (entity.getSpec() != null ?
+                            "host: " + entity.getSpec().getHost() :
+                            "No Spec !"));
+            openShiftClient.routes().inNamespace(namespace).create(entity);
+        } catch (Exception e) {
+            onApplyError("Failed to create Route from " + sourceName + ". " + e + ". " + entity, e);
         }
     }
 
@@ -688,17 +691,7 @@ public class ApplyService {
                         openShiftClient.buildConfigs().inNamespace(namespace).withName(id).delete();
                         doCreateBuildConfig(entity, namespace, sourceName);
                     } else {
-                        log.info("Updating BuildConfig from " + sourceName);
-                        try {
-                            String resourceVersion = KubernetesHelper.getResourceVersion(old);
-                            ObjectMeta metadata = getOrCreateMetadata(entity);
-                            metadata.setNamespace(namespace);
-                            metadata.setResourceVersion(resourceVersion);
-                            Object answer = patchService.compareAndPatchEntity(namespace, entity, old);
-                            logGeneratedEntity("Updated BuildConfig: ", namespace, entity, answer);
-                        } catch (Exception e) {
-                            onApplyError("Failed to update BuildConfig from " + sourceName + ". " + e + ". " + entity, e);
-                        }
+                        doPatchEntity(old, entity, namespace, sourceName);
                     }
                 }
             } else {
@@ -868,13 +861,7 @@ public class ApplyService {
                     kubernetesClient.services().inNamespace(namespace).withName(id).delete();
                     doCreateService(service, namespace, sourceName);
                 } else {
-                    log.info("Updating a Service from " + sourceName);
-                    try {
-                        Object answer = patchService.compareAndPatchEntity(namespace, service, old);
-                        logGeneratedEntity("Updated Service: ", namespace, service, answer);
-                    } catch (Exception e) {
-                        onApplyError("Failed to update Service from " + sourceName + ". " + e + ". " + service, e);
-                    }
+                    doPatchEntity(old, service, namespace, sourceName);
                 }
             }
         } else {
@@ -936,6 +923,17 @@ public class ApplyService {
             logGeneratedEntity("Created " + kind + ": ", namespace, resource, answer);
         } catch (Exception e) {
             onApplyError("Failed to create " + kind + " from " + sourceName + ". " + e + ". " + resource, e);
+        }
+    }
+
+    private <T extends HasMetadata> void doPatchEntity(T oldEntity, T newEntity, String namespace, String sourceName) {
+        String kind = newEntity.getKind();
+        log.info("Updating {} from {}", kind, sourceName);
+        try {
+            Object answer = patchService.compareAndPatchEntity(namespace, newEntity, oldEntity);
+            logGeneratedEntity("Updated " + kind + ": ", namespace, newEntity, answer);
+        } catch (Exception e) {
+            onApplyError("Failed to update " + kind + " from " + sourceName + ". " + e + ". " + newEntity, e);
         }
     }
 
@@ -1185,13 +1183,7 @@ public class ApplyService {
                     kubernetesClient.pods().inNamespace(namespace).withName(id).delete();
                     doCreatePod(pod, namespace, sourceName);
                 } else {
-                    log.info("Updating a Pod from " + sourceName + " namespace " + namespace + " name " + getName(pod));
-                    try {
-                        Object answer = patchService.compareAndPatchEntity(namespace, pod, old);
-                        log.info("Updated Pod result: " + answer);
-                    } catch (Exception e) {
-                        onApplyError("Failed to update Pod from " + sourceName + ". " + e + ". " + pod, e);
-                    }
+                    doPatchEntity(old, pod, namespace, sourceName);
                 }
             }
         } else {

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
@@ -1,0 +1,96 @@
+package org.eclipse.jkube.kit.config.service;
+
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
+import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
+import mockit.Mocked;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.service.openshift.WebServerEventCollector;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ApplyServiceTest {
+
+    @Mocked
+    private KitLogger log;
+
+    private OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
+
+    private ApplyService applyService;
+
+    @Before
+    public void setUp() {
+        applyService = new ApplyService(mockServer.createOpenShiftClient(), log);
+    }
+
+    @Test
+    public void testCreateRoute() throws Exception {
+        Route route = buildRoute();
+
+        WebServerEventCollector<OpenShiftMockServer> collector = new WebServerEventCollector<>(mockServer);
+        mockServer.expect().get()
+                .withPath("/apis/route.openshift.io/v1/namespaces/default/routes/route")
+                .andReply(collector.record("get-route").andReturn(404, ""))
+                .always();
+        mockServer.expect().post()
+                .withPath("/apis/route.openshift.io/v1/namespaces/default/routes")
+                .andReply(collector.record("new-route").andReturn(201, route))
+                .once();
+
+        applyService.apply(route, "route.yml");
+
+        collector.assertEventsRecordedInOrder("get-route", "new-route");
+    }
+
+    @Test
+    public void testCreateRouteInServiceOnlyMode() throws Exception {
+        Route route = buildRoute();
+
+        WebServerEventCollector<OpenShiftMockServer> collector = new WebServerEventCollector<>(mockServer);
+        mockServer.expect().get()
+                .withPath("/apis/route.openshift.io/v1/namespaces/default/routes/route")
+                .andReply(collector.record("get-route").andReturn(404, ""))
+                .always();
+
+        applyService.setServicesOnlyMode(true);
+        applyService.apply(route, "route.yml");
+
+        collector.assertEventsNotRecorded("get-route");
+        assertEquals(1, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testCreateRouteNotAllowed() throws Exception {
+        Route route = buildRoute();
+
+        WebServerEventCollector<OpenShiftMockServer> collector = new WebServerEventCollector<>(mockServer);
+        mockServer.expect().get()
+                .withPath("/apis/route.openshift.io/v1/namespaces/default/routes/route")
+                .andReply(collector.record("get-route").andReturn(404, ""))
+                .always();
+
+        applyService.setAllowCreate(false);
+        applyService.apply(route, "route.yml");
+
+        collector.assertEventsRecordedInOrder("get-route");
+        assertEquals(2, mockServer.getRequestCount());
+    }
+
+    private Route buildRoute() {
+        return new RouteBuilder()
+                .withNewMetadata()
+                    .withName("route")
+                .endMetadata()
+                .withNewSpec()
+                    .withHost("www.example.com")
+                    .withNewTo()
+                        .withKind("Service")
+                        .withName("frontend")
+                    .endTo()
+                .endSpec()
+                .build();
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Marcos Trejo <marcos.trejo@gmail.com>

## Description
Generating a patch for Route, in a similar fashion as the plugin already did for Service and other resources. This fixes https://github.com/eclipse/jkube/issues/267

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] ~I tested my code in Kubernetes~
 - [x] I tested my code in OpenShift