### PR TITLE
Fix warning in PodLogService when no running pod is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Usage:
 * Fix #259: Cleanup unused properties inside Mojos
 * Fix #94: Properly define + document JKubeProjectAssembly behavior
 * Fix #248: Properly name and document (Maven/System) configuration properties
+* Fix warning message in log goal when no pod is found
 * Fix #267: openshift-maven-plugin does not update Routes
 
 ### 1.0.0-alpha-4 (2020-06-08)

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/PodLogService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/PodLogService.java
@@ -155,8 +155,8 @@ public class PodLogService {
             onPod(Watcher.Action.ADDED, latestPod, kubernetes, namespace, ctrlCMessage, followLog);
         }
         if (!watchAddedPodsOnly && !runningPod) {
-            log.warn("No pod is running yet. Are you sure you deployed your app via `jkube:deploy`?");
-            log.warn("Or did you stop it via `jkube:stop`? If so try running the `jkube:start` goal");
+            log.warn("No pod is running yet. Are you sure you deployed your app using Eclipse JKube apply/deploy mechanism?");
+            log.warn("Or did you undeploy it? If so try running the Eclipse JKube apply/deploy tasks again.");
         }
         podWatcher = pods.watch(new Watcher<Pod>() {
             @Override


### PR DESCRIPTION
We no longer have start and stop goals. Replacing those with deploy
and undeploy

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->