### PR TITLE
fix: JIB container image preserves file permissions configured by the…

### DIFF
--- a/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceUtilTest.java
+++ b/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceUtilTest.java
@@ -91,7 +91,7 @@ public class JibServiceUtilTest {
         boolean wasNewFileCreated = temporaryFile.createNewFile();
 
         // When
-        JibServiceUtil.copyToContainer(containerBuilder, temporaryDirectory, "/tmp");
+        JibServiceUtil.copyToContainer(containerBuilder, temporaryDirectory, "/tmp", Collections.emptyMap());
 
         // Then
         assertTrue(wasNewFileCreated);

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
@@ -102,7 +102,7 @@ public class JibBuildServiceTest {
         setupServiceHubExpectations(projectBaseDir);
 
         // When
-        File tarArchive = JibBuildService.getAssemblyTarArchive(imageConfiguration, serviceHub, logger);
+        File tarArchive = JibBuildService.getAssemblyTarArchive(imageConfiguration, serviceHub.getConfiguration(), logger);
 
         // Then
         assertNotNull(tarArchive);


### PR DESCRIPTION
## Description
fix: JIB container image preserves file permissions configured by the AssemblyManager in the initial docker-build.tar
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] ~I Added [CHANGELOG](../CHANGELOG.md) entry~ n/a
 - [ ] I have implemented unit tests to cover my changes
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
   - Reported TODO smell refres to issue #300
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->