### PR TITLE
fix: Maven Quarkus quickstart supports JIB builds for native image

### DIFF
--- a/quickstarts/maven/quarkus/README.md
+++ b/quickstarts/maven/quarkus/README.md
@@ -4,7 +4,7 @@ A simple REST application demonstrating usage of Eclipse JKube with Quarkus.
 
 ## Requirements:
 
-- JDK 8 or 11+
+- JDK 11+
 - Kubernetes Cluster (Minikube, OpenShift, CRC, etc.)
 
 ## Regular mode
@@ -99,6 +99,8 @@ On invoking this, you can see it in browser:
 
 ### Warning
 
+### Docker
+
 > There is a [known issue](https://github.com/quarkusio/quarkus/issues/1610)
 > when building a quarkus native image with a remote docker daemon.
 > 
@@ -110,8 +112,18 @@ On invoking this, you can see it in browser:
 To build the application, just reproduce the steps for the regular mode appending `-Pnative ` to
 all your maven commands:
 ```
-mvn clean package -Pnative
-eval $(minikube docker-env)
-mvn k8s:build k8s:resource k8s:apply -Pnative
-minikube service quarkus
+$ mvn clean package -Pnative-docker
+$ eval $(minikube docker-env)
+$ mvn k8s:build k8s:resource k8s:apply -Pnative-docker
+$ minikube service quarkus
+```
+
+### JIB
+
+```
+$ mvn clean package k8s:build -Pnative-jib
+$ eval $(minikube docker-env)
+$ docker load -i target/docker/maven/quarkus/latest/tmp/docker-build.tar
+$ mvn k8s:resource k8s:apply -Pnative-jib
+$ minikube service quarkus
 ```

--- a/quickstarts/maven/quarkus/pom.xml
+++ b/quickstarts/maven/quarkus/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.eclipse.jkube.quickstarts.maven</groupId>
   <artifactId>quarkus</artifactId>
-  <version>1.0.0-alpha-4</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Eclipse JKube :: Quickstarts :: Maven :: Quarkus</name>
   <description>
     Quarkus REST JSON project
@@ -29,7 +29,8 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <version.quarkus>1.5.2.Final</version.quarkus>
+    <version.quarkus>1.6.0.Final</version.quarkus>
+    <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
   </properties>
 
   <dependencies>
@@ -75,45 +76,25 @@
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>kubernetes-maven-plugin</artifactId>
         <version>${project.version}</version>
-        <configuration>
-          <enricher>
-            <config>
-              <jkube-service>
-                <type>NodePort</type>
-              </jkube-service>
-            </config>
-          </enricher>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>openshift-maven-plugin</artifactId>
         <version>${project.version}</version>
-        <configuration>
-            <enricher>
-              <config>
-                <jkube-service>
-                  <type>NodePort</type>
-                </jkube-service>
-              </config>
-            </enricher>
-        </configuration>
       </plugin>
     </plugins>
   </build>
   <profiles>
     <profile>
-      <id>native</id>
+      <id>native-docker</id>
       <activation>
         <property>
-          <name>native</name>
+          <name>native-docker</name>
         </property>
       </activation>
-
       <properties>
         <jkube.generator.quarkus.nativeImage>true</jkube.generator.quarkus.nativeImage>
       </properties>
-
       <build>
         <plugins>
           <plugin>
@@ -128,6 +109,38 @@
                 <configuration>
                   <enableHttpUrlHandler>true</enableHttpUrlHandler>
                   <dockerBuild>true</dockerBuild>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>native-jib</id>
+      <activation>
+        <property>
+          <name>native-jib</name>
+        </property>
+      </activation>
+      <properties>
+        <jkube.build.strategy>jib</jkube.build.strategy>
+        <jkube.generator.quarkus.nativeImage>true</jkube.generator.quarkus.nativeImage>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${version.quarkus}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>native-image</goal>
+                </goals>
+                <configuration>
+                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                  <dockerBuild>false</dockerBuild>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Signed-off-by: Marc Nuri <marc@marcnuri.com>

## Description
Maven Quarkus quickstart supports JIB builds for native image

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->