### PR TITLE
fix: xml-config quickstart provides configmap configuration in pom.xml

### DIFF
--- a/quickstarts/maven/spring-boot-helm/README.md
+++ b/quickstarts/maven/spring-boot-helm/README.md
@@ -74,6 +74,6 @@ With a valid OpenShift cluster, perform the following commands:
 ```shell script
 $ mvn -Popenshift clean package
 $ helm install spring-boot-helm target/jkube/helm/spring-boot-helm/openshift/
-$ oc3 expose svc/spring-boot-helm
+$ oc expose svc/spring-boot-helm
 $ curl ${route-url}
 ```

--- a/quickstarts/maven/xml-config/pom.xml
+++ b/quickstarts/maven/xml-config/pom.xml
@@ -29,6 +29,7 @@
     <!-- User part of the docker image to create. If you want to push the image
          to a registry use a registry user here for which you have karma -->
     <image.user>jkube</image.user>
+    <image.name>${project.artifactId}</image.name>
 
     <!-- Versions -->
     <camel.version>2.16.2</camel.version>
@@ -164,7 +165,7 @@
         <configuration>
           <images>
             <image>
-              <name>${image.user}/${project.artifactId}:%l</name>
+              <name>${image.user}/${image.name}:%l</name>
               <!-- "alias" is used to correlate to the containers in the pod spec -->
               <alias>camel-service</alias>
               <build>
@@ -257,6 +258,15 @@
                 </ports>
               </service>
             </services>
+            <configMap>
+              <name>log-config</name>
+              <entries>
+                <entry>
+                  <name>log_level</name>
+                  <value>INFO</value>
+                </entry>
+              </entries>
+            </configMap>
           </resources>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description
fix: xml-config quickstart provides configmap configuration in pom.xml

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] ~I Added [CHANGELOG](../CHANGELOG.md) entry~
 - [ ] ~I have implemented unit tests to cover my changes~
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->