### PR TITLE
fix: Dekorate quick-start works in a deterministic way

### DIFF
--- a/quickstarts/maven/spring-boot-dekorate/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/dekorate/SpringDekorateApplication.java
+++ b/quickstarts/maven/spring-boot-dekorate/src/main/java/org/eclipse/jkube/maven/sample/spring/boot/dekorate/SpringDekorateApplication.java
@@ -22,6 +22,7 @@ import io.dekorate.s2i.annotation.S2iBuild;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+// Make Dekorate generated manifests compatible with JKube Naming conventions for image builds (group, name and version fields)
 @OpenshiftApplication(
         name ="spring-boot-dekorate",
         labels = @Label(key = "decorated-by", value = "dekorate"),
@@ -33,16 +34,19 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
         name ="spring-boot-dekorate",
         labels = @Label(key = "decorated-by", value = "dekorate"),
         group = "jkube",
+        version = "latest",
         serviceType = ServiceType.NodePort
 )
-// Make Dekorate generated manifests compatible with JKube Naming conventions for image builds
 @DockerBuild(
+        enabled = false,
         group = "maven",
         version = "latest",
         name = "spring-boot-dekorate"
 )
 @S2iBuild(
-        enabled = false
+        enabled = false,
+        group = "maven",
+        version = "latest"
 )
 @SpringBootApplication
 public class SpringDekorateApplication {


### PR DESCRIPTION
## Description
fix: Dekorate quick-start works in a deterministic way

If configuration for all annotation types is not provided, the resource manifests get generated
in a non-deterministic fashion since generators which provide common configurations (such as group or version)
will overwrite configuration in the Session for other generators.

I previously thought that setting some annotations (such as @DockerBuild) with an enabled = false field
would fix this, but it didn't, handlers/configurators/generators for those annotations are still being used.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] ~I Added [CHANGELOG](../CHANGELOG.md) entry~
 - [ ] ~I have implemented unit tests to cover my changes~
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->