### PR TITLE
Fix Logging in ApplyMojo during OpenShift detection

### DIFF
--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
@@ -206,7 +206,7 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
 
             boolean openShift = OpenshiftHelper.isOpenShift(kubernetes);
             if (openShift) {
-                getLog().info("OpenShift platform detected");
+                log.info("[[B]]OpenShift[[B]] platform detected");
             } else {
                 disableOpenShiftFeatures(applyService);
             }

--- a/quickstarts/maven/webapp-jetty/pom.xml
+++ b/quickstarts/maven/webapp-jetty/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.eclipse.jkube.quickstarts.maven</groupId>
   <artifactId>webapp-jetty</artifactId>
-  <version>1.0.0-alpha-4</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Eclipse JKube :: Quickstarts :: Maven :: Webapp Jetty</name>
   <packaging>war</packaging>
 

--- a/quickstarts/maven/yaml-only/pom.xml
+++ b/quickstarts/maven/yaml-only/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.eclipse.jkube.quickstarts.maven</groupId>
   <artifactId>yaml</artifactId>
-  <version>1.0.0-alpha-4</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Eclipse JKube :: Quickstarts :: Maven :: Yaml</name>
   <packaging>jar</packaging>
 


### PR DESCRIPTION
Somehow Openshift detected statement was showing without
any color

`getLog()` seems to be using logger from `AbstractMojo` class.

Also, updated some quickstarts with SNAPSHOT version
Before:
![Screenshot from 2020-07-22 22-08-04](https://user-images.githubusercontent.com/13834498/88204190-92378a80-cc68-11ea-8c7b-743137f3ea64.png)

With this Patch:
![Screenshot from 2020-07-22 22-00-12](https://user-images.githubusercontent.com/13834498/88204237-9e234c80-cc68-11ea-91d1-2ea557e865dd.png)


## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->