### PR TITLE
Fix #273: Enabling custom naming of the app label in deployment descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 ### 1.0.0-SNAPSHOT
 * Fix #290: Bump Fabric8 Kubernetes Client to v4.10.3
+* Fix #273: Added new parameter to allow for custom _app_ name
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)
@@ -47,7 +48,7 @@ Usage:
 * Fix #306: Template resolution and helm work in OpenShift-Maven-Plugin
 
 ### 1.0.0-alpha-4 (2020-06-08)
-* Fix #173: Use OpenShift compliant git/vcs annotations 
+* Fix #173: Use OpenShift compliant git/vcs annotations
 * Fix #182: Assembly is never null
 * Fix #184: IngressEnricher seems to be broken, Port of fabric8io/fabric8-maven-plugin#1730
 * Fix #198: Wildfly works in OpenShift with S2I binary build (Docker)
@@ -92,7 +93,7 @@ Usage:
 * Fix #97: Port of fabric8io/fabric8-maven-plugin#1794 to fix ImageChange triggers not being set in DeploymentConfig when resource fragments are used
 * Ported PR fabric8io/fabric8-maven-plugin#1802, Labels are missing for some objects
 * Ported PR fabric8io/fabric8-maven-plugin#1805, NullPointerException in ConfigMapEnricher
-* Ported PR fabric8io/fabric8-maven-plugin#1772, Support for setting BuildConfig memory/cpu request and limits 
+* Ported PR fabric8io/fabric8-maven-plugin#1772, Support for setting BuildConfig memory/cpu request and limits
 * Fix #112: Fix windows specific path error while splitting file path
 * Fix #102: HelmMojo works again
 * Fix #120: Critical bugs reported by Sonar

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
@@ -54,7 +54,8 @@ public class ProjectLabelEnricher extends BaseEnricher {
 
     @AllArgsConstructor
     private enum Config implements Configs.Config {
-        USE_PROJECT_LABEL("useProjectLabel", "false");
+        USE_PROJECT_LABEL("useProjectLabel", "false"),
+    	CUSTOM_APP_NAME("customAppName", "");
 
         @Getter
         protected String key;
@@ -160,8 +161,13 @@ public class ProjectLabelEnricher extends BaseEnricher {
         if (enableProjectLabel) {
             ret.put("project", groupArtifactVersion.getArtifactId());
         } else {
-            // default label is app
-            ret.put("app", groupArtifactVersion.getArtifactId());
+        	String customAppName = Configs.asString(getConfig(Config.CUSTOM_APP_NAME));
+        	if (customAppName != null && !customAppName.isEmpty()) {
+        		ret.put("app", customAppName);
+        	} else {
+                // default label is app
+                ret.put("app", groupArtifactVersion.getArtifactId());
+        	}
         }
 
         ret.put("group", groupArtifactVersion.getGroupId());

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
@@ -55,7 +55,7 @@ public class ProjectLabelEnricher extends BaseEnricher {
     @AllArgsConstructor
     private enum Config implements Configs.Config {
         USE_PROJECT_LABEL("useProjectLabel", "false"),
-    	CUSTOM_APP_NAME("customAppName", "");
+    	APP("app", null);
 
         @Getter
         protected String key;
@@ -161,13 +161,7 @@ public class ProjectLabelEnricher extends BaseEnricher {
         if (enableProjectLabel) {
             ret.put("project", groupArtifactVersion.getArtifactId());
         } else {
-        	String customAppName = Configs.asString(getConfig(Config.CUSTOM_APP_NAME));
-        	if (customAppName != null && !customAppName.isEmpty()) {
-        		ret.put("app", customAppName);
-        	} else {
-                // default label is app
-                ret.put("app", groupArtifactVersion.getArtifactId());
-        	}
+        	ret.put("app", getConfig(Config.APP, groupArtifactVersion.getArtifactId()));
         }
 
         ret.put("group", groupArtifactVersion.getGroupId());

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/MavenProjectEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/MavenProjectEnricherTest.java
@@ -79,6 +79,45 @@ public class MavenProjectEnricherTest {
         assertNull(selectors.get("version"));
         assertNull(selectors.get("project"));
     }
+    
+    @Test
+    public void testCustomAppName() {
+
+    	// Setup
+    	final String CUSTOM_APP_NAME =  "my-custom-app-name";
+    	final Properties properties = new Properties();
+        properties.setProperty("jkube.enricher.jkube-project-label.customAppName", CUSTOM_APP_NAME);
+        // @formatter:off
+        new Expectations() {{
+            context.getProperties(); result = properties;
+        }};
+        // @formatter:on
+
+    	ProjectLabelEnricher projectEnricher = new ProjectLabelEnricher(context);
+
+        KubernetesListBuilder builder = createListWithDeploymentConfig();
+        projectEnricher.enrich(PlatformMode.kubernetes, builder);
+        KubernetesList list = builder.build();
+
+        Map<String, String> labels = list.getItems().get(0).getMetadata().getLabels();
+
+        assertNotNull(labels);
+        assertEquals("groupId", labels.get("group"));
+        assertEquals(CUSTOM_APP_NAME, labels.get("app"));
+        assertEquals("version", labels.get("version"));
+        assertNull(labels.get("project"));
+
+        builder = new KubernetesListBuilder().withItems(new DeploymentBuilder().build());
+        projectEnricher.create(PlatformMode.kubernetes, builder);
+
+        Deployment deployment = (Deployment)builder.buildFirstItem();
+        Map<String, String> selectors = deployment.getSpec().getSelector().getMatchLabels();
+        assertEquals("groupId", selectors.get("group"));
+        assertEquals(CUSTOM_APP_NAME, selectors.get("app"));
+        assertNull(selectors.get("version"));
+        assertNull(selectors.get("project"));
+
+    }
 
     @Test
     public void testOldStyleGeneratedResources() {

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricherTest.java
@@ -13,34 +13,33 @@
  */
 package org.eclipse.jkube.enricher.generic;
 
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
-import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
-import org.eclipse.jkube.kit.config.resource.PlatformMode;
-import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
-import org.eclipse.jkube.kit.enricher.api.model.Configuration;
-import mockit.Expectations;
-import mockit.Mocked;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.Map;
-import java.util.Properties;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.util.Map;
+import java.util.Properties;
+
+import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
+import org.eclipse.jkube.kit.config.resource.PlatformMode;
+import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import mockit.Expectations;
+import mockit.Mocked;
+
 /**
  * Test label generation.
  *
- * @author nicola
+ * @author Tue Dissing
  */
-public class MavenProjectEnricherTest {
+public class ProjectLabelEnricherTest {
 
     @Mocked
     private JKubeEnricherContext context;
@@ -52,10 +51,86 @@ public class MavenProjectEnricherTest {
             result = new GroupArtifactVersion("groupId", "artifactId", "version");
         }};
     }
-
+    
     @Test
-    public void testGeneratedResources() {
-        ProjectLabelEnricher projectEnricher = new ProjectLabelEnricher(context);
+    public void testCustomAppName() {
+
+    	// Setup
+    	final String APP =  "my-custom-app-name";
+    	final Properties properties = new Properties();
+        properties.setProperty("jkube.enricher.jkube-project-label.app", APP);
+        // @formatter:off
+        new Expectations() {{
+            context.getProperties(); result = properties;
+        }};
+        // @formatter:on
+
+    	ProjectLabelEnricher projectEnricher = new ProjectLabelEnricher(context);
+
+        KubernetesListBuilder builder = createListWithDeploymentConfig();
+        projectEnricher.enrich(PlatformMode.kubernetes, builder);
+        KubernetesList list = builder.build();
+
+        Map<String, String> labels = list.getItems().get(0).getMetadata().getLabels();
+
+        assertNotNull(labels);
+        assertEquals("groupId", labels.get("group"));
+        assertEquals(APP, labels.get("app"));
+        assertEquals("version", labels.get("version"));
+        assertNull(labels.get("project"));
+
+        builder = new KubernetesListBuilder().withItems(new DeploymentBuilder().build());
+        projectEnricher.create(PlatformMode.kubernetes, builder);
+
+        Deployment deployment = (Deployment)builder.buildFirstItem();
+        Map<String, String> selectors = deployment.getSpec().getSelector().getMatchLabels();
+        assertEquals("groupId", selectors.get("group"));
+        assertEquals(APP, selectors.get("app"));
+        assertNull(selectors.get("version"));
+        assertNull(selectors.get("project"));
+    }
+    
+    @Test
+    public void testEmptyCustomAppName() {
+
+    	// Setup
+    	final String APP =  "";
+    	final Properties properties = new Properties();
+        properties.setProperty("jkube.enricher.jkube-project-label.app", APP);
+        // @formatter:off
+        new Expectations() {{
+            context.getProperties(); result = properties;
+        }};
+        // @formatter:on
+
+    	ProjectLabelEnricher projectEnricher = new ProjectLabelEnricher(context);
+
+        KubernetesListBuilder builder = createListWithDeploymentConfig();
+        projectEnricher.enrich(PlatformMode.kubernetes, builder);
+        KubernetesList list = builder.build();
+
+        Map<String, String> labels = list.getItems().get(0).getMetadata().getLabels();
+
+        assertNotNull(labels);
+        assertEquals("groupId", labels.get("group"));
+        assertEquals(APP, labels.get("app"));
+        assertEquals("version", labels.get("version"));
+        assertNull(labels.get("project"));
+
+        builder = new KubernetesListBuilder().withItems(new DeploymentBuilder().build());
+        projectEnricher.create(PlatformMode.kubernetes, builder);
+
+        Deployment deployment = (Deployment)builder.buildFirstItem();
+        Map<String, String> selectors = deployment.getSpec().getSelector().getMatchLabels();
+        assertEquals("groupId", selectors.get("group"));
+        assertEquals(APP, selectors.get("app"));
+        assertNull(selectors.get("version"));
+        assertNull(selectors.get("project"));
+    }
+    
+    @Test
+    public void testDefaultAppName() {
+    	ProjectLabelEnricher projectEnricher = new ProjectLabelEnricher(context);
 
         KubernetesListBuilder builder = createListWithDeploymentConfig();
         projectEnricher.enrich(PlatformMode.kubernetes, builder);
@@ -78,42 +153,6 @@ public class MavenProjectEnricherTest {
         assertEquals("artifactId", selectors.get("app"));
         assertNull(selectors.get("version"));
         assertNull(selectors.get("project"));
-    }
-
-    @Test
-    public void testOldStyleGeneratedResources() {
-
-        final Properties properties = new Properties();
-        properties.setProperty("jkube.enricher.jkube-project-label.useProjectLabel", "true");
-        // @formatter:off
-        new Expectations() {{
-            context.getProperties(); result = properties;
-        }};
-        // @formatter:on
-
-        ProjectLabelEnricher projectEnricher = new ProjectLabelEnricher(context);
-
-        KubernetesListBuilder builder = createListWithDeploymentConfig();
-        projectEnricher.enrich(PlatformMode.kubernetes, builder);
-        KubernetesList list = builder.build();
-
-        Map<String, String> labels = list.getItems().get(0).getMetadata().getLabels();
-
-        assertNotNull(labels);
-        assertEquals("groupId", labels.get("group"));
-        assertEquals("artifactId", labels.get("project"));
-        assertEquals("version", labels.get("version"));
-        assertNull(labels.get("app"));
-
-        builder = new KubernetesListBuilder().withItems(new DeploymentConfigBuilder().build());
-        projectEnricher.create(PlatformMode.kubernetes, builder);
-
-        DeploymentConfig deploymentConfig = (DeploymentConfig)builder.buildFirstItem();
-        Map<String, String> selectors = deploymentConfig.getSpec().getSelector();
-        assertEquals("groupId", selectors.get("group"));
-        assertEquals("artifactId", selectors.get("project"));
-        assertNull(selectors.get("version"));
-        assertNull(selectors.get("app"));
     }
 
     private KubernetesListBuilder createListWithDeploymentConfig() {

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_project_label.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_project_label.adoc
@@ -16,7 +16,11 @@ been replaced by the `app` label in newer versions of the plugin.
 
   Defaults to `false`.
 | `jkube.enricher.jkube-project-label.useProjectLabel`
+| *customAppName*
+| Makes it possible to define a custom `app` label used in the generated resource files used for deployment. 
 
+Defaults to the Maven `project.artifactId` property.
+| `jkube.enricher.jkube-project-label.customAppName`
 |===
 
 The project labels which are already specified in the input fragments are not overridden by the enricher.

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_project_label.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_project_label.adoc
@@ -16,11 +16,11 @@ been replaced by the `app` label in newer versions of the plugin.
 
   Defaults to `false`.
 | `jkube.enricher.jkube-project-label.useProjectLabel`
-| *customAppName*
+| *app*
 | Makes it possible to define a custom `app` label used in the generated resource files used for deployment. 
 
 Defaults to the Maven `project.artifactId` property.
-| `jkube.enricher.jkube-project-label.customAppName`
+| `jkube.enricher.jkube-project-label.app`
 |===
 
 The project labels which are already specified in the input fragments are not overridden by the enricher.


### PR DESCRIPTION
## Description
Adding a new parameter for the `ProjectLabelEnricher`, called `customAppName` to make it possible to deploy the same application under the same namespace, but in different versions.
This PR closes #273 .

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report (waiting for report to run)
 - [ ] I tested my code in Kubernetes _(do not have a Kubernetes cluster available)_
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->