### PR TITLE
fix: Vert.x generator and enricher applicable when `io.vertx` dependencies present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ### 1.0.0-SNAPSHOT
 * Fix #290: Bump Fabric8 Kubernetes Client to v4.10.3
 * Fix #273: Added new parameter to allow for custom _app_ name
+* Fix #329: Vert.x generator and enricher applicable when `io.vertx` dependencies present
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtil.java
@@ -71,6 +71,12 @@ public class JKubeProjectUtil {
         return getDependency(jkubeProject, groupId, artifactId) != null;
     }
 
+    public static boolean hasDependencyWithGroupId(JavaProject project, String groupId) {
+      return Optional.ofNullable(project).map(JavaProject::getDependencies)
+          .map(deps -> deps.stream().anyMatch(dep -> Objects.equals(dep.getGroupId(), groupId)))
+          .orElse(false);
+    }
+
     public static Dependency getDependency(JavaProject jkubeProject, String groupId, String artifactId) {
         List<Dependency> dependencyList = jkubeProject.getDependencies();
         if (dependencyList != null) {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtilTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util;
+
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.eclipse.jkube.kit.common.Dependency;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("ResultOfMethodCallIgnored")
+public class JKubeProjectUtilTest {
+
+  @Test
+  public void hasDependencyWithGroupIdWithNulls() {
+    // When
+    final boolean result = JKubeProjectUtil.hasDependencyWithGroupId(null, null);
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void hasDependencyWithGroupIdWithDependency(@Mocked JavaProject project) {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      project.getDependencies(); result = Arrays.asList(
+          Dependency.builder().groupId("io.dep").build(),
+          Dependency.builder().groupId("io.dep").artifactId("artifact").version("1.3.37").build(),
+          Dependency.builder().groupId("io.other").artifactId("artifact").version("1.3.37").build()
+        );
+    }};
+    // @formatter:on
+    // When
+    final boolean result = JKubeProjectUtil.hasDependencyWithGroupId(project, "io.dep");
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void hasDependencyWithGroupIdWithNoDependency(@Mocked JavaProject project) {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      project.getDependencies(); result = Arrays.asList(
+          Dependency.builder().groupId("io.dep").build(),
+          Dependency.builder().groupId("io.dep").artifactId("artifact").version("1.3.37").build(),
+          Dependency.builder().groupId("io.other").artifactId("artifact").version("1.3.37").build()
+      );
+    }};
+    // @formatter:on
+    // When
+    final boolean result = JKubeProjectUtil.hasDependencyWithGroupId(project, "io.nothere");
+    // Then
+    assertThat(result).isFalse();
+  }
+}

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/EnricherContext.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/EnricherContext.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import org.eclipse.jkube.kit.common.Dependency;
+import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
 import org.eclipse.jkube.kit.enricher.api.model.Configuration;
@@ -125,4 +126,6 @@ public interface EnricherContext {
      * @return value of property if set.
      */
     String getProperty(String key);
+
+    JavaProject getProject();
 }

--- a/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricher.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static org.eclipse.jkube.kit.common.util.JKubeProjectUtil.hasDependencyWithGroupId;
+
 
 /**
  * Configures the health checks for a Vert.x project. Unlike other enricher this enricher extract the configuration from
@@ -101,7 +103,7 @@ public class VertxHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
     private boolean isApplicable() {
         return getContext().hasPlugin(VERTX_MAVEN_PLUGIN_GROUP, VERTX_MAVEN_PLUGIN_ARTIFACT)
-               || getContext().hasDependency(VERTX_GROUPID, null);
+               || hasDependencyWithGroupId(getContext().getProject(), VERTX_GROUPID);
     }
 
     private String getSpecificPropertyName(boolean readiness, Config config) {

--- a/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/generator/VertxGenerator.java
+++ b/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/generator/VertxGenerator.java
@@ -51,7 +51,7 @@ public class VertxGenerator extends JavaExecGenerator {
   public boolean isApplicable(List<ImageConfiguration> configs) {
     return shouldAddGeneratedImageConfiguration(configs)
         && (JKubeProjectUtil.hasPlugin(getProject(), Constants.VERTX_MAVEN_PLUGIN_GROUP, Constants.VERTX_MAVEN_PLUGIN_ARTIFACT)
-        || JKubeProjectUtil.hasDependency(getProject(), Constants.VERTX_GROUPID, null));
+        || JKubeProjectUtil.hasDependencyWithGroupId(getProject(), Constants.VERTX_GROUPID));
   }
 
   @Override

--- a/jkube-kit/jkube-kit-vertx/src/test/java/org/eclipse/jkube/vertx/generator/VertxGeneratorTest.java
+++ b/jkube-kit/jkube-kit-vertx/src/test/java/org/eclipse/jkube/vertx/generator/VertxGeneratorTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.vertx.generator;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -26,6 +27,7 @@ import org.eclipse.jkube.generator.api.GeneratorContext;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
+import org.eclipse.jkube.kit.common.Plugin;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +39,7 @@ import static org.assertj.core.api.Assertions.entry;
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
+@SuppressWarnings("ResultOfMethodCallIgnored")
 public class VertxGeneratorTest {
 
   @Injectable
@@ -45,6 +48,10 @@ public class VertxGeneratorTest {
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
 
+  @Mocked
+  private JavaProject project;
+
+  private GeneratorContext context;
   private Dependency dropwizard;
   private Dependency core;
   private Dependency infinispan;
@@ -57,67 +64,102 @@ public class VertxGeneratorTest {
         .scope("compile").file(folder.newFile("vertx-core.jar")).build();
     infinispan = Dependency.builder().groupId("io.vertx").artifactId("vertx-infinispan").version("3.4.2")
         .type("jar").scope("compile").file(folder.newFile("vertx-infinispan.jar")).build();
+    context = GeneratorContext.builder()
+        .logger(logger)
+        .project(project)
+        .build();
+  }
+
+  @Test
+  public void isApplicableEmptyProject() {
+    // When
+    final boolean result = new VertxGenerator(context).isApplicable(Collections.emptyList());
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void isApplicableWithPlugin() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      project.getPlugins(); result = Collections.singletonList(
+          Plugin.builder().groupId("io.reactiverse").artifactId("vertx-maven-plugin").build());
+    }};
+    // @formatter:on
+    // When
+    final boolean result = new VertxGenerator(context).isApplicable(Collections.emptyList());
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isApplicableWithDependency() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      project.getDependencies(); result = Collections.singletonList(
+          Dependency.builder().groupId("io.vertx").build());
+    }};
+    // @formatter:on
+    // When
+    final boolean result = new VertxGenerator(context).isApplicable(Collections.emptyList());
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void testDefaultOptions() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
+      project.getOutputDirectory(); result = new File("target/tmp/target").getAbsolutePath();
+    }};
+    // @formatter:on
+    // When
+    List<String> list = new VertxGenerator(context).getExtraJavaOptions();
+    // Then
+    assertThat(list).containsOnly("-Dvertx.cacheDirBase=/tmp", "-Dvertx.disableDnsResolver=true");
+  }
+
+  @Test
+  public void testWithMetrics() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
+      project.getOutputDirectory(); result = new File("target/tmp/target").getAbsolutePath();
+      project.getDependencies(); result = Arrays.asList(dropwizard, core);
+    }};
+    // @formatter:on
+    // When
+    List<String> list = new VertxGenerator(context).getExtraJavaOptions();
+    // Then
+    assertThat(list).containsOnly(
+            // Default entries
+            "-Dvertx.cacheDirBase=/tmp", "-Dvertx.disableDnsResolver=true",
+            // Metrics entries
+            "-Dvertx.metrics.options.enabled=true", "-Dvertx.metrics.options.jmxEnabled=true", "-Dvertx.metrics.options.jmxDomain=vertx");
   }
 
     @Test
-    public void testDefaultOptions(@Mocked final JavaProject project) {
-        new Expectations() {{
-            project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
-            project.getOutputDirectory(); result = new File("target/tmp/target").getAbsolutePath();
-        }};
-
-        GeneratorContext context = GeneratorContext.builder()
-                .logger(logger)
-                .project(project)
-                .build();
-        VertxGenerator generator = new VertxGenerator(context);
-        List<String> list = generator.getExtraJavaOptions();
-
-        assertThat(list).containsOnly("-Dvertx.cacheDirBase=/tmp", "-Dvertx.disableDnsResolver=true");
-    }
-
-    @Test
-    public void testWithMetrics(@Mocked final JavaProject project) {
-
-        new Expectations() {{
-            project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
-            project.getOutputDirectory(); result = new File("target/tmp/target").getAbsolutePath();
-            project.getDependencies(); result = Arrays.asList(dropwizard, core);
-        }};
-
-        GeneratorContext context = GeneratorContext.builder()
-                .logger(logger)
-                .project(project)
-                .build();
-        VertxGenerator generator = new VertxGenerator(context);
-        List<String> list = generator.getExtraJavaOptions();
-
-        assertThat(list).containsOnly(
-                // Default entries
-                "-Dvertx.cacheDirBase=/tmp", "-Dvertx.disableDnsResolver=true",
-                // Metrics entries
-                "-Dvertx.metrics.options.enabled=true", "-Dvertx.metrics.options.jmxEnabled=true", "-Dvertx.metrics.options.jmxDomain=vertx");
-    }
-
-    @Test
-    public void testWithInfinispanClusterManager(@Mocked final JavaProject project) {
-        new Expectations() {{
-            project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
-            project.getOutputDirectory(); result = new File("target/tmp/target").getAbsolutePath();
-            project.getDependencies(); result = Arrays.asList(infinispan, core);
-        }};
-
-        GeneratorContext context = GeneratorContext.builder()
-                .logger(logger)
-                .project(project)
-                .build();
-        VertxGenerator generator = new VertxGenerator(context);
-        Map<String, String> env = generator.getEnv(true);
-
-        assertThat(env).contains(entry("JAVA_OPTIONS", "-Dvertx.cacheDirBase=/tmp -Dvertx.disableDnsResolver=true " +
-                // Force IPv4
-                "-Djava.net.preferIPv4Stack=true"));
-        assertThat(env).contains(entry("JAVA_ARGS", "-cluster"));
+    public void testWithInfinispanClusterManager() {
+      // Given
+      // @formatter:off
+      new Expectations() {{
+        project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
+        project.getOutputDirectory(); result = new File("target/tmp/target").getAbsolutePath();
+        project.getDependencies(); result = Arrays.asList(infinispan, core);
+      }};
+      // @formatter:on
+      // When
+      Map<String, String> env = new VertxGenerator(context).getEnv(true);
+      // Then
+      assertThat(env).contains(entry("JAVA_OPTIONS", "-Dvertx.cacheDirBase=/tmp -Dvertx.disableDnsResolver=true " +
+              // Force IPv4
+              "-Djava.net.preferIPv4Stack=true"));
+      assertThat(env).contains(entry("JAVA_ARGS", "-cluster"));
     }
 
 


### PR DESCRIPTION
# Description
fix: Vert.x generator and enricher to be applicable when `io.vertx` dependencies present

Previously projects containing a `<dependency><groupId>io.vertx</groupId><!-- .... --></dependency>` were not being picked up by Vert.x generator and enricher since the behavior of `JKubeProjectUtil.hasDependency(getProject(), Constants.VERTX_GROUPID, null)` was not the one expected before Maven decoupling happened.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->