### PR TITLE
fix: Build strategy picked up from XML configuration and properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Usage:
 * Fix #290: Bump Fabric8 Kubernetes Client to v4.10.3
 * Fix #273: Added new parameter to allow for custom _app_ name
 * Fix #329: Vert.x generator and enricher applicable when `io.vertx` dependencies present
+* Fix #334: Build strategy picked up from XML configuration and properties
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/JKubeServiceHub.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/JKubeServiceHub.java
@@ -87,8 +87,7 @@ public class JKubeServiceHub implements Closeable {
         applyService = new LazyBuilder<>(() -> new ApplyService(client, log));
         buildService = new LazyBuilder<>(() -> {
             BuildService ret;
-            String jkubeBuildStrategy = (String)configuration.getProperties().get("jkube.build.strategy");
-            if (jkubeBuildStrategy != null && jkubeBuildStrategy.equalsIgnoreCase(JKubeBuildStrategy.jib.getLabel())) {
+            if (JKubeBuildStrategy.jib == buildServiceConfig.getJKubeBuildStrategy()) {
                 return new JibBuildService(JKubeServiceHub.this, log);
             }
             // Creating platform-dependent services

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -665,6 +665,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo
     protected BuildServiceConfig.BuildServiceConfigBuilder buildServiceConfigBuilder() {
         return BuildServiceConfig.builder()
                 .buildRecreateMode(BuildRecreateMode.fromParameter(buildRecreate))
+                .jKubeBuildStrategy(getJKubeBuildStrategy())
                 .forcePull(forcePull)
                 .imagePullManager(getImagePullManager(imagePullPolicy, autoPull))
                 .buildDirectory(project.getBuild().getDirectory())

--- a/openshift-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenshiftBuildMojo.java
+++ b/openshift-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenshiftBuildMojo.java
@@ -78,7 +78,6 @@ public class OpenshiftBuildMojo extends BuildMojo {
     @Override
     protected BuildServiceConfig.BuildServiceConfigBuilder buildServiceConfigBuilder() {
         return super.buildServiceConfigBuilder()
-            .jKubeBuildStrategy(getJKubeBuildStrategy())
             .openshiftPullSecret(openshiftPullSecret)
             .s2iBuildNameSuffix(s2iBuildNameSuffix)
             .s2iImageStreamLookupPolicyLocal(s2iImageStreamLookupPolicyLocal);


### PR DESCRIPTION
## Description
fix #334: Build strategy picked up from XML configuration and properties

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->