### PR TITLE
Fix #341 : ImageChangeTrigger now gets applied when resource fragments used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Usage:
 * Fix #332: OpenShift build resources are deleted (as long as build config manifest is available)
 * Fix #350: Prevents default docker configuration overwriting XML assembly configuration
 * Fix #340: Exclude the main artifact from Docker build when Fat Jar is detected (JavaExecGenerator)
+* Fix #341: JKube doesn't add ImageChange triggers in DC when merging from a deployment fragment 
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
@@ -637,10 +637,16 @@ public class KubernetesResourceUtil {
                             container = new Container();
                             containers.add(container);
                         }
-                        // If default container name is not set, add first found
-                        // container as default application container.
-                        if (defaultApplicationContainerName == null) {
+                    }
+                    // If default container name is not set, add first found
+                    // container as default application container from resource
+                    // fragment, if not present set default application container
+                    // name from JKube generated PodSpec
+                    if (defaultApplicationContainerName == null) {
+                        if (container.getName() != null) { // Pick from fragment
                             defaultApplicationContainerName = container.getName();
+                        } else if (defaultContainer.getName() != null) { // Pick from default opinionated PodSpec
+                            defaultApplicationContainerName = defaultContainer.getName();
                         }
                     }
 
@@ -1002,4 +1008,3 @@ public class KubernetesResourceUtil {
         return true;
     }
 }
-


### PR DESCRIPTION
Fix #341 

Earlier due to sidecar refactor, JKube wasn't able to find out
default application container's name for which we need to add
ImageChange triggers during openshift S2I build when we were
providing resource fragments in which container name was absent.

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->