### PR TITLE
Fix #350: Stops docker configuration overwriting assembly configuration

### DIFF
--- a/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
+++ b/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -447,15 +448,15 @@ public class AssemblyManager {
 
         AssemblyConfiguration assemblyConfig = getAssemblyConfigurationOrCreateDefault(buildConfiguration);
         final AssemblyConfiguration.AssemblyConfigurationBuilder builder = assemblyConfig.toBuilder();
+        final Assembly.AssemblyBuilder inlineBuilder = assemblyConfig.getInline() == null ? Assembly.builder() : assemblyConfig.getInline().toBuilder();
 
         File contextDir = buildConfiguration.getAbsoluteContextDirPath(params.getSourceDirectory(), params.getBasedir().getAbsolutePath());
-        builder.inline(Assembly.builder()
-                .fileSet(AssemblyFileSet.builder()
-                        .directory(contextDir)
-                        .outputDirectory(new File("."))
-                        .directoryMode("0775")
-                        .build()).build());
-
+        builder.inline(inlineBuilder
+                       .fileSet(AssemblyFileSet.builder()
+                           .directory(contextDir)
+                           .outputDirectory(new File("."))
+                           .directoryMode("0775")
+                           .build()).build());
         return builder.build();
     }
 

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/Assembly.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/Assembly.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
 import java.util.List;
 
 @SuppressWarnings("JavaDoc")
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtils.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtils.java
@@ -26,6 +26,9 @@ public class AssemblyFileUtils {
   public static File getAssemblyFileOutputDirectory(
       AssemblyFile assemblyFile, File outputDirectoryForRelativePaths, AssemblyConfiguration assemblyConfiguration) {
     final File outputDirectory;
+
+    Objects.requireNonNull(assemblyFile.getOutputDirectory(), "Assembly Configuration output dir is required");
+
     if (assemblyFile.getOutputDirectory().isAbsolute()) {
       outputDirectory = assemblyFile.getOutputDirectory();
     } else {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtilsTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtilsTest.java
@@ -33,6 +33,22 @@ public class AssemblyFileUtilsTest {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
+  public void getAssemblyFileOutputDirectoryRequired() throws IOException {
+      // Given
+      final AssemblyFile af = AssemblyFile.builder().build();
+      final File outputDirectoryForRelativePaths = temporaryFolder.newFolder("output");
+      final AssemblyConfiguration ac = AssemblyConfiguration.builder().build();
+
+      // When
+      try {
+          AssemblyFileUtils.getAssemblyFileOutputDirectory(af, outputDirectoryForRelativePaths, ac);
+          fail("Should fail as output directory should not be null");
+      } catch(NullPointerException ex) {
+          assertEquals("Assembly Configuration output dir is required", ex.getMessage());
+      }
+  }
+
+  @Test
   public void getAssemblyFileOutputDirectoryWithAbsoluteDirectoryShouldReturnSame() throws IOException {
     // Given
     assumeFalse(isWindows());


### PR DESCRIPTION
Fix #350 
* AssemblyManager
 * Makes use of existing assembly configuration and adds to it if it exists

* AssemblyManagerTest
 * Tests for creating tar archive with docker file AND additional assembly

* AssemblyFileUtils
 * Checks for and handles no output directory specified in inline assemblies

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->