### PR TITLE
Fix License Check Github Workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,17 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 version: 2
 updates:
   - package-ecosystem: "maven"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           java-version: '11'
       - name: Check License Headers
-        run: mvn -N license:format
+        run: mvn -N license:check

--- a/jkube-kit/jkube-kit-wildfly-jar/pom.xml
+++ b/jkube-kit/jkube-kit-wildfly-jar/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at:

--- a/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at:

--- a/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGenerator.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at:

--- a/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricherTest.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricherTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at:

--- a/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGeneratorTest.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at:

--- a/quickstarts/maven/external-resources/src/main/jkube/configmap.yml
+++ b/quickstarts/maven/external-resources/src/main/jkube/configmap.yml
@@ -1,3 +1,17 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 metadata:
   name: ${project.artifactId}
 data:

--- a/quickstarts/maven/spring-boot-camel-complete/src/main/resources/application.properties
+++ b/quickstarts/maven/spring-boot-camel-complete/src/main/resources/application.properties
@@ -11,4 +11,5 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 #
+
 camel.greeting=Hello from Camel!

--- a/quickstarts/maven/wildfly-jar/pom.xml
+++ b/quickstarts/maven/wildfly-jar/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020 Red Hat, Inc.
+    Copyright (c) 2019 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at:

--- a/quickstarts/maven/wildfly-jar/src/main/java/org/eclipse/jkube/maven/sample/wildflyjar/HelloWorldEndpoint.java
+++ b/quickstarts/maven/wildfly-jar/src/main/java/org/eclipse/jkube/maven/sample/wildflyjar/HelloWorldEndpoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at:

--- a/quickstarts/maven/wildfly-jar/src/main/java/org/eclipse/jkube/maven/sample/wildflyjar/RestApplication.java
+++ b/quickstarts/maven/wildfly-jar/src/main/java/org/eclipse/jkube/maven/sample/wildflyjar/RestApplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2019 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at:


### PR DESCRIPTION
License check was doing `mvn license:format` instead of
`mvn license:check`

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->