### PR TITLE
Fix #340: Exclude the main artifact from Docker build when Fat Jar is detected (JavaExecGenerator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Usage:
 * Fix #342: Maven Quickstart for Spring-Boot with complete Camel integration
 * Fix #336: Fix pull from insecure registries and pull registry authentication for JIB
 * Fix #332: OpenShift build resources are deleted (as long as build config manifest is available)
+* Fix #350: Prevents default docker configuration overwriting XML assembly configuration
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Usage:
 * Fix #336: Fix pull from insecure registries and pull registry authentication for JIB
 * Fix #332: OpenShift build resources are deleted (as long as build config manifest is available)
 * Fix #350: Prevents default docker configuration overwriting XML assembly configuration
+* Fix #340: Exclude the main artifact from Docker build when Fat Jar is detected (JavaExecGenerator)
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
+++ b/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
@@ -21,7 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtilsTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtilsTest.java
@@ -34,18 +34,17 @@ public class AssemblyFileUtilsTest {
 
   @Test
   public void getAssemblyFileOutputDirectoryRequired() throws IOException {
-      // Given
-      final AssemblyFile af = AssemblyFile.builder().build();
-      final File outputDirectoryForRelativePaths = temporaryFolder.newFolder("output");
-      final AssemblyConfiguration ac = AssemblyConfiguration.builder().build();
-
-      // When
-      try {
-          AssemblyFileUtils.getAssemblyFileOutputDirectory(af, outputDirectoryForRelativePaths, ac);
-          fail("Should fail as output directory should not be null");
-      } catch(NullPointerException ex) {
-          assertEquals("Assembly Configuration output dir is required", ex.getMessage());
-      }
+    // Given
+    final AssemblyFile af = AssemblyFile.builder().build();
+    final File outputDirectoryForRelativePaths = temporaryFolder.newFolder("output");
+    final AssemblyConfiguration ac = AssemblyConfiguration.builder().build();
+    // When
+    final NullPointerException result = assertThrows(NullPointerException.class, () -> {
+      AssemblyFileUtils.getAssemblyFileOutputDirectory(af, outputDirectoryForRelativePaths, ac);
+      fail("Should fail as output directory should not be null");
+    });
+    // Then
+    assertEquals("Assembly Configuration output dir is required", result.getMessage());
   }
 
   @Test

--- a/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
+++ b/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
@@ -179,6 +179,7 @@ public class JavaExecGenerator extends BaseGenerator {
     protected void addAssembly(AssemblyConfiguration.AssemblyConfigurationBuilder builder) {
         final List<AssemblyFileSet> fileSets = new ArrayList<>(addAdditionalFiles());
         if (isFatJar()) {
+            builder.excludeFinalOutputArtifact(true);
             FatJarDetector.Result fatJar = detectFatJar();
             if (fatJar != null) {
                 fileSets.add(getOutputDirectoryFileSet(fatJar, getProject()));

--- a/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorTest.java
+++ b/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.generator.javaexec;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.eclipse.jkube.generator.api.GeneratorContext;
+import org.eclipse.jkube.kit.common.AssemblyConfiguration;
+import org.eclipse.jkube.kit.common.Plugin;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+
+@SuppressWarnings({"ResultOfMethodCallIgnored", "unchecked", "unused"})
+public class JavaExecGeneratorTest {
+
+  @Mocked
+  private GeneratorContext generatorContext;
+  private List<Plugin> plugins;
+  private Properties properties;
+
+  @Before
+  public void setUp() {
+    properties = new Properties();
+    plugins = new ArrayList<>();
+    // @formatter:off
+    new Expectations() {{
+      generatorContext.getProject().getProperties(); result = properties; minTimes = 0;
+      generatorContext.getProject().getPlugins(); result = plugins; minTimes = 0;
+    }};
+    // @formatter:on
+  }
+
+  @Test
+  public void isApplicableWithDefaultsShouldReturnFalse() {
+    // When
+    final boolean result = new JavaExecGenerator(generatorContext).isApplicable(Collections.emptyList());
+    // Then
+    assertThat(result, equalTo(false));
+  }
+
+  @Test
+  public void isApplicableWithConfiguredMainClassShouldReturnTrue() {
+    // Given
+    properties.put("jkube.generator.java-exec.mainClass", "com.example.main");
+    // When
+    final boolean result = new JavaExecGenerator(generatorContext).isApplicable(Collections.emptyList());
+    // Then
+    assertThat(result, equalTo(true));
+  }
+
+  @Test
+  public void isApplicableWithExecPluginShouldReturnTrue() {
+    // Given
+    plugins.add(Plugin.builder().groupId("org.apache.maven.plugins").artifactId("maven-shade-plugin").build());
+    // When
+    final boolean result = new JavaExecGenerator(generatorContext).isApplicable(Collections.emptyList());
+    // Then
+    assertThat(result, equalTo(true));
+  }
+
+  @Test
+  public void addAssemblyWithNoFatJarShouldAddDefaultFileSets() {
+    // Given
+    final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
+    // When
+    new JavaExecGenerator(generatorContext).addAssembly(builder);
+    // Then
+    final AssemblyConfiguration ac = builder.build();
+    assertThat(ac.getInline().getFileSets(), hasSize(2));
+    assertThat(ac.isExcludeFinalOutputArtifact(), equalTo(false));
+  }
+
+  @Test
+  public void addAssemblyWithFatJarShouldAddDefaultFileSetsAndFatJar(
+      @Mocked FatJarDetector fatJarDetector, @Mocked FatJarDetector.Result fjResult) {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      generatorContext.getProject().getBuildDirectory(); result = new File("");
+      generatorContext.getProject().getBaseDirectory(); result = new File("");
+      fjResult.getArchiveFile(); result = new File("fat.jar");
+      fatJarDetector.scan(); result = fjResult;
+    }};
+    // @formatter:on
+    final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
+    // When
+    new JavaExecGenerator(generatorContext).addAssembly(builder);
+    // Then
+    final AssemblyConfiguration ac = builder.build();
+    assertThat(ac.getInline().getFileSets(), hasSize(3));
+    assertThat(ac.getInline().getFileSets(), containsInAnyOrder(
+        hasProperty("directory", equalTo(new File("src/main/jkube-includes"))),
+        hasProperty("directory", equalTo(new File("src/main/jkube-includes/bin"))),
+        hasProperty("includes", containsInAnyOrder("fat.jar"))
+    ));
+    assertThat(ac.isExcludeFinalOutputArtifact(), equalTo(true));
+  }
+}

--- a/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
+++ b/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
@@ -16,10 +16,12 @@ package org.eclipse.jkube.openliberty.generator;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.generator.javaexec.FatJarDetector;
-import org.eclipse.jkube.kit.common.AssemblyConfiguration;
+import org.eclipse.jkube.kit.common.AssemblyFileSet;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 
@@ -28,11 +30,17 @@ import mockit.Mocked;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.notNullValue;
 
+@SuppressWarnings({"ResultOfMethodCallIgnored", "unused", "unchecked"})
 public class OpenLibertyGeneratorTest {
 
     @Mocked
@@ -41,55 +49,76 @@ public class OpenLibertyGeneratorTest {
     private GeneratorContext context;
     @Mocked
     private JavaProject project;
-    private OpenLibertyGenerator generator;
 
   @Before
   public void setUp() throws Exception {
+    // @formatter:off
     new Expectations() {{
-      context.getProject();
-      result = project;
-      project.getBaseDirectory();
-      minTimes = 0;
-      result = "basedirectory";
+      context.getProject(); result = project;
+      project.getBaseDirectory(); result = "basedirectory"; minTimes = 0;
 
       String tempDir = Files.createTempDirectory("openliberty-test-project").toFile().getAbsolutePath();
-
-      project.getBuildDirectory();
-      result = tempDir;
-      project.getOutputDirectory();
-      result = tempDir;
-      minTimes = 0;
-      project.getVersion();
-      result = "1.0.0";
-      minTimes = 0;
+      project.getBuildDirectory(); result = tempDir;
+      project.getOutputDirectory(); result = tempDir; minTimes = 0;
+      project.getVersion(); result = "1.0.0"; minTimes = 0;
     }};
-    generator = new OpenLibertyGenerator(context);
+    // @formatter:on
   }
 
   @Test
-  public void testLibertyRunnable(@Mocked FatJarDetector fatJarDetector, @Mocked FatJarDetector.Result mockResult) {
+  public void getEnvWithFatJar(@Mocked FatJarDetector fatJarDetector, @Mocked FatJarDetector.Result mockResult) {
     // Given
+    // @formatter:off
     new Expectations() {{
-      fatJarDetector.scan();
-      result = mockResult;
-      mockResult.getArchiveFile();
-      result = new File("/the/archive/file");
-      mockResult.getMainClass();
-      result = OpenLibertyGenerator.LIBERTY_SELF_EXTRACTOR;
+      fatJarDetector.scan(); result = mockResult;
+      mockResult.getArchiveFile(); result = new File("/the/archive/file");
+      mockResult.getMainClass(); result = OpenLibertyGenerator.LIBERTY_SELF_EXTRACTOR;
     }};
+    // @formatter:on
     // When
-    generator.addAssembly(AssemblyConfiguration.builder());
+    final Map<String, String> result = new OpenLibertyGenerator(context).getEnv(false);
     // Then
-    assertThat(generator.getEnv(false), hasKey(OpenLibertyGenerator.LIBERTY_RUNNABLE_JAR));
-    assertThat(generator.getEnv(false), hasKey(OpenLibertyGenerator.JAVA_APP_JAR));
+    assertThat(result, hasKey(OpenLibertyGenerator.LIBERTY_RUNNABLE_JAR));
+    assertThat(result, hasKey(OpenLibertyGenerator.JAVA_APP_JAR));
+  }
+
+  @Test
+  public void getEnvWithoutFatJar() {
+    // Given
+    final Properties properties = new Properties();
+    properties.put("jkube.generator.openliberty.mainClass", "com.example.MainClass");
+    properties.put("jkube.generator.java-exec.mainClass", "com.example.main");
+    // @formatter:off
+    new Expectations() {{
+      context.getProject().getProperties(); result = properties;
+    }};
+    // @formatter:on
+    // When
+    final Map<String, String> result = new OpenLibertyGenerator(context).getEnv(false);
+    // Then
+    assertThat(result, not(hasKey(OpenLibertyGenerator.LIBERTY_RUNNABLE_JAR)));
+    assertThat(result, not(hasKey(OpenLibertyGenerator.JAVA_APP_JAR)));
+    assertThat(result, hasEntry("JAVA_MAIN_CLASS", "com.example.MainClass"));
   }
 
   @Test
   public void testExtractPorts() {
     // When
-    final List<String> ports = generator.extractPorts();
+    final List<String> ports = new OpenLibertyGenerator(context).extractPorts();
     // Then
     assertThat(ports, notNullValue());
     assertThat(ports, hasItem("9080"));
+  }
+
+  @Test
+  public void addAdditionalFiles() {
+    // When
+    final List<AssemblyFileSet> result = new OpenLibertyGenerator(context).addAdditionalFiles();
+    // Then
+    assertThat(result, containsInAnyOrder(
+        hasProperty("directory", equalTo(new File("src/main/jkube-includes"))),
+        hasProperty("directory", equalTo(new File("src/main/jkube-includes/bin"))),
+        hasProperty("directory", equalTo(new File("src/main/liberty/config")))
+    ));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
   <artifactId>jkube</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <description>JKube</description>
-  <name>JKube</name>
+  <description>Eclipse JKube</description>
+  <name>Eclipse JKube</name>
 
   <url>https://projects.eclipse.org/projects/ecd.jkube</url>
 
@@ -36,7 +36,7 @@
   <developers>
     <developer>
       <id>geeks</id>
-      <name>JKube Development Team</name>
+      <name>Eclipse JKube Development Team</name>
       <email>jkube-dev@eclipse.org</email>
       <organization>Eclipse Foundation</organization>
       <organizationUrl>https://projects.eclipse.org/projects/ecd.jkube</organizationUrl>


### PR DESCRIPTION
## Description
Fix #340: Exclude the main artifact from Docker build when Fat Jar is detected (JavaExecGenerator)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->