### PR TITLE
fix: Add default `/metrics` path for `prometheus.io/path` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ Usage:
 * Fix #332: OpenShift build resources are deleted (as long as build config manifest is available)
 * Fix #350: Prevents default docker configuration overwriting XML assembly configuration
 * Fix #340: Exclude the main artifact from Docker build when Fat Jar is detected (JavaExecGenerator)
-* Fix #341: JKube doesn't add ImageChange triggers in DC when merging from a deployment fragment 
+* Fix #341: JKube doesn't add ImageChange triggers in DC when merging from a deployment fragment
+* Fix #326: Add default `/metrics` path for `prometheus.io/path` annotation
+  (Sort of [redundant](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config), this makes it explicit)
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_prometheus.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_prometheus.adoc
@@ -15,6 +15,7 @@ items:
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: 9779
+      prometheus.io/path: "/metrics"
 ----
 
 By default the enricher inspects the images' BuildConfiguration and add the annotations if the port 9779 is listed.


### PR DESCRIPTION
## Description
fix #326: Add default `/metrics` path for `prometheus.io/path` annotation

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->