### PR TITLE
Fix #339: Https should be considered default while converting tcp urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Usage:
 * Fix #341: JKube doesn't add ImageChange triggers in DC when merging from a deployment fragment
 * Fix #326: Add default `/metrics` path for `prometheus.io/path` annotation
   (Sort of [redundant](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config), this makes it explicit)
+* Fix #339: Https should be considered default while converting tcp urls
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/EnvUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/EnvUtil.java
@@ -52,18 +52,17 @@ public class EnvUtil {
 
     public static final String MAVEN_PROPERTY_REGEXP = "\\s*\\$\\{\\s*([^}]+)\\s*}\\s*$";
 
-    // Standard HTTPS port (IANA registered). The other 2375 with plain HTTP is used only in older
-    // docker installations.
-    public static final String DOCKER_HTTPS_PORT = "2376";
+    // Standard HTTP port (IANA registered). It is used only in older docker installations.
+    public static final String DOCKER_HTTP_PORT = "2375";
 
     public static final String PROPERTY_COMBINE_POLICY_SUFFIX = "_combine";
 
     private EnvUtil() {
     }
 
-    // Convert docker host URL to an http URL
+    // Convert docker host URL to an HTTP(s) URL
     public static String convertTcpToHttpUrl(String connect) {
-        String protocol = connect.contains(":" + DOCKER_HTTPS_PORT) ? "https:" : "http:";
+        String protocol = connect.contains(":" + DOCKER_HTTP_PORT) ? "http:" : "https:";
         return connect.replaceFirst("^tcp:", protocol);
     }
 

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/EnvUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/EnvUtilTest.java
@@ -73,6 +73,16 @@ public class EnvUtilTest {
     }
 
     @Test
+    public void testConvertTcpToHttpUrlShouldDefaultToHttps() {
+        // Given
+        String url = "tcp://127.0.0.1:32770";
+        // When
+        String result = EnvUtil.convertTcpToHttpUrl(url);
+        // Then
+        assertEquals("https://127.0.0.1:32770", result);
+    }
+
+    @Test
     public void testExtractLargerVersionWhenBothNull(){
         assertNull(EnvUtil.extractLargerVersion(null,null));
     }


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fix #339 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->