### PR TITLE
fix: Added missing documentation for WatchMojo configuration parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ Usage:
 * Fix #326: Add default `/metrics` path for `prometheus.io/path` annotation
   (Sort of [redundant](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config), this makes it explicit)
 * Fix #339: Https should be considered default while converting tcp urls
-* Fix: Quarkus supports S2I builds both for JVM and native mode
+* Fix #362: Quarkus supports S2I builds both for JVM and native mode
+* Fix #297: Added missing documentation for WatchMojo configuration parameters
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RunService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RunService.java
@@ -159,7 +159,7 @@ public class RunService {
      * Stop a container immediately by id.
      * @param containerId the container to stop
      * @param imageConfig image configuration for this container
-     * @param keepContainer whether to keep container or to remove them after stoppings
+     * @param keepContainer whether to keep container or to remove them after stopping
      * @param removeVolumes whether to remove volumes after stopping
      * @throws DockerAccessException docker access exception
      * @throws ExecException exec exception

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/develop/_jkube-watch.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/develop/_jkube-watch.adoc
@@ -140,8 +140,56 @@ Defaults to `both`.
 | `jkube.watch.mode`
 
 | *watchInterval*
-| Watch interval in milliseconds.
+| Interval in milliseconds (how often to check for changes).
 
   Defaults to `5000`.
 | `jkube.watch.interval`
+
+| *keepRunning*
+| If set to true all containers will be kept running after {goal-prefix}:watch has been stopped.
+
+  Defaults to `false`.
+| `jkube.watch.keepRunning`
+
+| *watchPostGoal*
+| A maven goal which should be called if a rebuild or a restart has been performed.
+
+  This goal must have the format `<pluginGroupId>:<pluginArtifactId>:<goal>` and the plugin must be
+  configured in the pom.xml.
+
+  For example a post-goal `com.example:group:delete-pods` will trigger the `delete-pods`
+  goal of this hypothetic example.
+| `jkube.watch.postGoal`
+
+| *watchPostExec*
+| A command which is executed within the container after files are copied into this container
+  when watchMode is copy. Note that this container must be running.
+
+| `jkube.watch.postExec`
+
+| *keepContainer*
+| If this is set to `false` (and `keepRunning` is disabled) then all containers will be removed after
+  they have been stopped.
+
+  Defaults to `false`.
+| `jkube.watch.keepContainer`
+
+| *removeVolumes*
+| If set to `true` remove any volumes associated with the container as well.
+
+  This option will be ignored if either `keepContainer` or `keepRunning` is `true`.
+
+  Defaults to `false`.
+| `jkube.watch.removeVolumes`
+
+| *watchShowLogs*
+| If set to `true`, logs will be shown for watched container.
+| `jkube.watch.showLogs`
+
+| *watchFollow*
+| If `watchShowLogs` is set to `false`, and there is a run image configuration, logs are followed
+  if set to `true`.
+
+  Defaults to `false`.
+| `jkube.watch.follow`
 |===


### PR DESCRIPTION
## Description
fix #297: Added missing documentation for WatchMojo configuration parameters

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] ~I have implemented unit tests to cover my changes~
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [ ] ~No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report~
 - [ ] ~I tested my code in Kubernetes~
 - [ ] ~I tested my code in OpenShift~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->