### PR TITLE
fix: WebAppGenerator path configuration is no longer ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Usage:
 * Fix #339: Https should be considered default while converting tcp urls
 * Fix #362: Quarkus supports S2I builds both for JVM and native mode
 * Fix #297: Added missing documentation for WatchMojo configuration parameters
+* Fix #371: WebAppGenerator path configuration is no longer ignored
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
@@ -37,6 +37,8 @@ import org.eclipse.jkube.generator.api.support.BaseGenerator;
 import org.eclipse.jkube.generator.webapp.handler.CustomAppServerHandler;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 /**
  * A generator for WAR apps
  *
@@ -154,10 +156,12 @@ public class WebAppGenerator extends BaseGenerator {
     final File sourceFile = Objects.requireNonNull(JKubeProjectUtil.getFinalOutputArtifact(getProject()),
         "Final output artifact file was not detected");
     final String targetFilename;
-    if (getConfig(Config.PATH).equals("/")) {
-      targetFilename = String.format("ROOT.%s",  FilenameUtils.getExtension(sourceFile.getName()));
+    final String extension = FilenameUtils.getExtension(sourceFile.getName());
+    final String path = getConfig(Config.PATH);
+    if (path.equals("/") || isBlank(path)) {
+      targetFilename = String.format("ROOT.%s", extension);
     } else {
-      targetFilename =  sourceFile.getName();
+      targetFilename = String.format("%s.%s", path.replaceAll("[\\\\/]", ""), extension);
     }
     final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
     builder

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
@@ -127,7 +127,7 @@ public class WebAppGeneratorTest {
     projectProperties.put("jkube.generator.webapp.targetDir", "/other-dir");
     projectProperties.put("jkube.generator.webapp.user", "root");
     projectProperties.put("jkube.generator.webapp.cmd", "sleep 3600");
-    projectProperties.put("jkube.generator.webapp.path", "/some-context/");
+    projectProperties.put("jkube.generator.webapp.path", "/some-context");
     projectProperties.put("jkube.generator.webapp.ports", "8082,80");
     projectProperties.put("jkube.generator.webapp.supportsS2iBuild", "true");
     projectProperties.put("jkube.generator.from", "image-to-trigger-custom-app-server-handler");
@@ -155,7 +155,7 @@ public class WebAppGeneratorTest {
         equalTo(true));
     assertThat(imageConfiguration.getBuildConfiguration().getAssembly().getUser(), equalTo("root"));
     assertThat(imageConfiguration.getBuildConfiguration().getAssembly().getInline().getFiles().iterator().next().getDestName(),
-        equalTo("artifact.war"));
+        equalTo("some-context.war"));
     assertThat(imageConfiguration.getBuildConfiguration().getPorts(), contains("8082", "80"));
     assertThat(imageConfiguration.getBuildConfiguration().getEnv(), hasEntry("DEPLOY_DIR", "/other-dir"));
     assertThat(imageConfiguration.getBuildConfiguration().getCmd().getShell(), equalTo("sleep 3600"));


### PR DESCRIPTION
## Description
fix #371: WebAppGenerator path configuration is no longer ignored

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->