### PR TITLE
Fix #356: Add further support for router config (tls termination and …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Usage:
 * Fix #362: Quarkus supports S2I builds both for JVM and native mode
 * Fix #297: Added missing documentation for WatchMojo configuration parameters
 * Fix #371: WebAppGenerator path configuration is no longer ignored
+* Fix #356: Add further support for tls termination and insecureEdgeTerminationPolicy in pom.xml
 
 ### 1.0.0-rc-1 (2020-07-23)
 * Fix #252: Replace Quarkus Native Base image with ubi-minimal (same as in `Dockerfile.native`)

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
@@ -13,20 +13,6 @@
  */
 package org.eclipse.jkube.enricher.generic.openshift;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.FileUtil;
-import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
-import org.eclipse.jkube.kit.config.resource.PlatformMode;
-import org.eclipse.jkube.kit.config.resource.ResourceConfig;
-import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
-import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
-
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
@@ -40,6 +26,19 @@ import io.fabric8.openshift.api.model.RoutePort;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.FileUtil;
+import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
+import org.eclipse.jkube.kit.config.resource.PlatformMode;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
+import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
+import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.containsLabelInMetadata;
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.removeLabel;
@@ -54,7 +53,9 @@ public class RouteEnricher extends BaseEnricher {
 
     @AllArgsConstructor
     private enum Config implements Configs.Config {
-        GENERATE_ROUTE("generateRoute", "true");
+        GENERATE_ROUTE("generateRoute", "true"),
+        TLS_TERMINATION("termination",null),
+        INSECURE_EDGE_TERMINATION_POLICY("insecureEdgeTerminationPolicy",null);
 
         @Getter
         protected String key;
@@ -70,6 +71,10 @@ public class RouteEnricher extends BaseEnricher {
 
     private boolean isGenerateRoute() {
         return Configs.asBoolean(getConfigWithFallback(Config.GENERATE_ROUTE, GENERATE_ROUTE_PROPERTY, null));
+    }
+
+    private boolean isRouteWithTLS(){
+        return StringUtils.isNotBlank(getConfig(Config.TLS_TERMINATION, null));
     }
 
     @Override
@@ -180,6 +185,8 @@ public class RouteEnricher extends BaseEnricher {
                             withHost(routeDomainPostfix.isEmpty() ? null : routeDomainPostfix).
                             endSpec();
 
+                    handleTlsTermination(routeBuilder);
+
                     // removing `expose : true` label from metadata.
                     removeLabel(routeBuilder.buildMetadata(), EXPOSE_LABEL, "true");
                     removeLabel(routeBuilder.buildMetadata(), JKubeAnnotations.SERVICE_EXPOSE_URL.value(), "true");
@@ -187,6 +194,17 @@ public class RouteEnricher extends BaseEnricher {
                     routes.add(routeBuilder.build());
                 }
             }
+        }
+    }
+
+    private void handleTlsTermination(RouteBuilder routeBuilder) {
+        if(isRouteWithTLS()){
+            routeBuilder.editSpec()
+                    .editOrNewTls()
+                    .withInsecureEdgeTerminationPolicy(getConfig(Config.INSECURE_EDGE_TERMINATION_POLICY, "Allow"))
+                    .withTermination(getConfig(Config.TLS_TERMINATION, "edge"))
+                    .endTls()
+                    .endSpec();
         }
     }
 

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherTest.java
@@ -13,20 +13,19 @@
  */
 package org.eclipse.jkube.enricher.generic.openshift;
 
-import java.util.Properties;
-
-import io.fabric8.openshift.api.model.RouteBuilder;
-import org.eclipse.jkube.kit.config.resource.PlatformMode;
-import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
-import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
-
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.openshift.api.model.RouteBuilder;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.eclipse.jkube.kit.config.resource.PlatformMode;
+import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
+import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,20 +47,20 @@ public class RouteEnricherTest {
         // @formatter:off
         klb.addToItems(new ServiceBuilder()
                 .editOrNewMetadata()
-                    .withName("test-svc")
-                    .addToLabels("expose", "true")
+                .withName("test-svc")
+                .addToLabels("expose", "true")
                 .endMetadata()
                 .editOrNewSpec()
-                    .addNewPort()
-                        .withName("http")
-                        .withPort(8080)
-                        .withProtocol("TCP")
-                        .withTargetPort(new IntOrString(8080))
-                    .endPort()
-                    .addToSelector("group", "test")
-                    .withType("LoadBalancer")
+                .addNewPort()
+                .withName("http")
+                .withPort(8080)
+                .withProtocol("TCP")
+                .withTargetPort(new IntOrString(8080))
+                .endPort()
+                .addToSelector("group", "test")
+                .withType("LoadBalancer")
                 .endSpec()
-            .build());
+                .build());
         new Expectations() {{
             context.getProperties(); result = properties;
             context.getConfiguration().getProcessorConfig(); result = processorConfig;
@@ -75,12 +74,12 @@ public class RouteEnricherTest {
         new RouteEnricher(context).create(PlatformMode.openshift, klb);
         // Then
         assertThat(klb.build().getItems())
-            .hasSize(2)
-            .extracting("kind")
-            .containsExactly("Service", "Route");
+                .hasSize(2)
+                .extracting("kind")
+                .containsExactly("Service", "Route");
         assertThat(klb.build().getItems().get(1))
-            .extracting("metadata.name", "spec.host", "spec.to.kind", "spec.to.name", "spec.port.targetPort.intVal")
-            .contains("test-svc", "test-svc", "Service", "test-svc", 8080);
+                .extracting("metadata.name", "spec.host", "spec.to.kind", "spec.to.name", "spec.port.targetPort.intVal")
+                .contains("test-svc", "test-svc", "Service", "test-svc", 8080);
     }
 
     @Test
@@ -96,9 +95,9 @@ public class RouteEnricherTest {
         new RouteEnricher(context).create(PlatformMode.kubernetes, klb);
         // Then
         assertThat(klb.build().getItems())
-            .hasSize(1)
-            .extracting("kind")
-            .containsExactly("Service");
+                .hasSize(1)
+                .extracting("kind")
+                .containsExactly("Service");
     }
 
     @Test
@@ -109,9 +108,9 @@ public class RouteEnricherTest {
         new RouteEnricher(context).create(PlatformMode.openshift, klb);
         // Then
         assertThat(klb.build().getItems())
-            .hasSize(1)
-            .extracting("kind")
-            .containsExactly("Service");
+                .hasSize(1)
+                .extracting("kind")
+                .containsExactly("Service");
     }
 
     @Test
@@ -122,9 +121,9 @@ public class RouteEnricherTest {
         new RouteEnricher(context).create(PlatformMode.openshift, klb);
         // Then
         assertThat(klb.build().getItems())
-            .hasSize(1)
-            .extracting("kind")
-            .containsExactly("Service");
+                .hasSize(1)
+                .extracting("kind")
+                .containsExactly("Service");
     }
 
     @Test
@@ -140,37 +139,73 @@ public class RouteEnricherTest {
         new RouteEnricher(context).create(PlatformMode.openshift, klb);
         // Then
         assertThat(klb.build().getItems())
-            .hasSize(2)
-            .extracting("kind")
-            .containsExactly("Service", "Route");
+                .hasSize(2)
+                .extracting("kind")
+                .containsExactly("Service", "Route");
         assertThat(klb.build().getItems().get(1))
-            .extracting("metadata.name", "spec.host", "spec.to.kind", "spec.to.name", "spec.port.targetPort.intVal")
-            .contains("test-svc", "test-svc.jkube.eclipse.org", "Service", "test-svc", 8080);
+                .extracting("metadata.name", "spec.host", "spec.to.kind", "spec.to.name", "spec.port.targetPort.intVal")
+                .contains("test-svc", "test-svc.jkube.eclipse.org", "Service", "test-svc", 8080);
     }
 
     @Test
     public void testCreateWithDefaultsAndExistingRouteWithMatchingNameInBuilderInOpenShiftShouldReuseExistingRoute() {
         // Given
         klb.addToItems(new RouteBuilder()
-            .editOrNewMetadata()
+                .editOrNewMetadata()
                 .withName("test-svc")
-            .endMetadata()
-            .editOrNewSpec()
+                .endMetadata()
+                .editOrNewSpec()
                 .withHost("example.com")
                 .editOrNewPort()
-                    .withNewTargetPort(1337)
+                .withNewTargetPort(1337)
                 .endPort()
-            .endSpec()
-            .build());
+                .endSpec()
+                .build());
         // When
         new RouteEnricher(context).create(PlatformMode.openshift, klb);
         // Then
         assertThat(klb.build().getItems())
-            .hasSize(2)
-            .extracting("kind")
-            .containsExactly("Service", "Route");
+                .hasSize(2)
+                .extracting("kind")
+                .containsExactly("Service", "Route");
         assertThat(klb.build().getItems().get(1))
-            .extracting("metadata.name", "spec.host", "spec.to.kind", "spec.to.name", "spec.port.targetPort.intVal")
-            .contains("test-svc", "example.com", null, null, 1337);
+                .extracting("metadata.name", "spec.host", "spec.to.kind", "spec.to.name", "spec.port.targetPort.intVal")
+                .contains("test-svc", "example.com", null, null, 1337);
+    }
+
+    @Test
+    public void testEnrichNoTls(){
+        // Given
+        properties.put("jkube.openshift.generateRoute", "true");
+        // When
+        new RouteEnricher(context).create(PlatformMode.openshift, klb);
+        // Then
+        assertThat(klb.build().getItems())
+                .hasSize(2)
+                .extracting("kind")
+                .containsExactly("Service", "Route");
+
+        assertThat(klb.build().getItems().stream().filter(h -> h.getKind().equals("Route")).findFirst().orElse(null))
+                .extracting("spec.tls")
+                .containsNull();
+
+    }
+
+    @Test
+    public void testEnrichWithTls(){
+        // Given
+        properties.put("jkube.enricher.jkube-openshift-route.termination", "edge");
+        properties.put("jkube.enricher.jkube-openshift-route.insecureEdgeTerminationPolicy", "Allow");
+        // When
+        new RouteEnricher(context).create(PlatformMode.openshift, klb);
+        // Then
+        assertThat(klb.build().getItems())
+                .hasSize(2)
+                .extracting("kind")
+                .containsExactly("Service", "Route");
+
+        assertThat(klb.build().getItems().stream().filter(h -> h.getKind().equals("Route")).findFirst().orElse(null))
+                .extracting("spec.tls.insecureEdgeTerminationPolicy", "spec.tls.termination")
+                .contains("Allow","edge");
     }
 }

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -192,14 +192,14 @@ Resource goal also validates the generated resource descriptors using API specif
 
 | *skipResourceValidation*
 | If value is set to `true` then resource validation is skipped. This may be useful if resource validation is failing
-  for some reason but you still want to continue the deployment.
+for some reason but you still want to continue the deployment.
 
   Default is `false`.
 | `jkube.skipResourceValidation`
 
 | *failOnValidationError*
 | If value is set to `true` then any validation error will block the plugin execution. A warning will be printed
-  otherwise.
+otherwise.
 
   Default is `false`.
 | `jkube.failOnValidationError`
@@ -222,11 +222,56 @@ If you do not want to generate a Route descriptor, you can set the `jkube.opensh
 
 | *generateRoute*
 | If value is set to `false` then no Route descriptor will be generated.
-  By default it is set to `true`, which will create a `route.yml` descriptor and also add Route resource to `openshift.yml`.
+By default it is set to `true`, which will create a `route.yml` descriptor and also add Route resource to `openshift.yml`.
 | `jkube.openshift.generateRoute`
 
   `jkube.enricher.jkube-openshift-route.generateRoute`
+| *termination*
+a| termination indicates termination type. The following values are supported:
+
+* edge (default)
+* passthrough
+* reencrypt
+
+See https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#secured-routes or https://docs.openshift.com/container-platform/latest/networking/routes/secured-routes.html
+| `jkube.enricher.jkube-openshift-route.termination`
+| *insecureEdgeTerminationPolicy*
+a| insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route.
+While each router may make its own decisions on which ports to expose, this is normally port 80.
+
+* Allow - traffic is sent to the server on the insecure port (default)
+* Disable - no traffic is allowed on the insecure port.
+* Redirect - clients are redirected to the secure port.
+
+See https://docs.openshift.com/container-platform/latest/rest_api/network_apis/route-route-openshift-io-v1.html
+| `jkube.enricher.jkube-openshift-route.insecureEdgeTerminationPolicy`
+
 |===
+
+Below is an example of generating a Route with "edge" termination and "Allow" insecureEdgeTerminationPolicy:
+.Example for generating route resource by configuring it in `pom.xml`
+
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+----
+<plugin>
+  <groupId>org.eclipse.jkube</groupId>
+  <artifactId>{plugin}</artifactId>
+  <version>{version}</version>
+  <configuration>
+    <enricher>
+      <config>
+        <jkube-openshift-route>
+          <generateRoute>true</generateRoute>
+          <insecureEdgeTerminationPolicy>Allow</insecureEdgeTerminationPolicy>
+          <termination>edge</termination>
+        </jkube-openshift-route>
+      </config>
+    </enricher>
+  </configuration>
+</plugin>
+----
+
+Adding certificates for routes is not directly supported in the pom, but can be added via a yaml fragment.
 
 If you do not want to generate a Route descriptor, you can also specify so in the plugin configuration in your POM as seen below.
 
@@ -297,7 +342,7 @@ ifeval::["{goal-prefix}" == "oc"]
 
 | *trimImageInContainerSpec*
 | If set to true it would set the container image reference to "", this is done to handle weird behavior of OpenShift
-  3.7 in which subsequent rollouts lead to ImagePullErr.
+3.7 in which subsequent rollouts lead to ImagePullErr.
 
   Defaults to `false`.
 | `jkube.openshift.trimImageInContainerSpec`
@@ -311,7 +356,7 @@ endif::[]
 
 | *profile*
 | Profile to use. A profile contains the enrichers and generators to use as well as their configuration. Profiles are
-  looked up in the classpath and can be provided as yaml files.
+looked up in the classpath and can be provided as yaml files.
 
   Defaults to `default`.
 | `jkube.profile`
@@ -334,7 +379,7 @@ endif::[]
 
 | *environment*
 | Environment name where resources are placed. For example, if you set this property to dev and resourceDir is the
-  default one, plugin will look at `src/main/jkube/dev`.
+default one, plugin will look at `src/main/jkube/dev`.
 
   Defaults to `null`.
 | `jkube.environment`


### PR DESCRIPTION
## Description
Added annotations so Router can be configured w/ TLS termination from the pom. Updated docs accordingly.
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] ~~I tested my code in Kubernetes~~
 - [x] I tested my code in OpenShift

