### PR TITLE
Fix #381: Remove root as default user in AssemblyConfigurationUtils#getAssemblyConfigurationOrCreateDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.0.1-SNAPSHOT
+* Fix #381: Remove root as default user in AssemblyConfigurationUtils#getAssemblyConfigurationOrCreateDefault
 
 ### 1.0.0 (2020-09-09)
 * Fix #351: Fix AutoTLSEnricher - add annotation + volume config to resource

--- a/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyConfigurationUtils.java
+++ b/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyConfigurationUtils.java
@@ -30,7 +30,6 @@ class AssemblyConfigurationUtils {
 
   private static final String LINUX_FILE_SEPARATOR = "/";
   private static final String DEFAULT_NAME = "maven";
-  private static final String DEFAULT_USER = "root";
 
   private AssemblyConfigurationUtils() {}
 
@@ -38,7 +37,7 @@ class AssemblyConfigurationUtils {
   static AssemblyConfiguration getAssemblyConfigurationOrCreateDefault(@Nullable BuildConfiguration buildConfiguration) {
     final AssemblyConfiguration ac = Optional.ofNullable(buildConfiguration)
             .map(BuildConfiguration::getAssembly)
-            .orElse(AssemblyConfiguration.builder().user(DEFAULT_USER).build());
+            .orElse(AssemblyConfiguration.builder().build());
     final AssemblyConfiguration.AssemblyConfigurationBuilder builder = ac.toBuilder();
     final String name;
     if (StringUtils.isBlank(ac.getName())) {

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyConfigurationUtilsTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyConfigurationUtilsTest.java
@@ -33,6 +33,7 @@ import static org.eclipse.jkube.kit.build.api.assembly.AssemblyConfigurationUtil
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class AssemblyConfigurationUtilsTest {
@@ -51,7 +52,7 @@ public class AssemblyConfigurationUtilsTest {
     // Then
     assertEquals("maven", result.getName());
     assertEquals("/maven", result.getTargetDir());
-    assertEquals("root", result.getUser());
+    assertNull(result.getUser());
   }
 
   @Test


### PR DESCRIPTION
Fix #381 

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->