### PR TITLE
fix: Enricher defined Container env vars get merged with vars defined in Image Build Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ### 1.0.1-SNAPSHOT
 * Fix #381: Remove root as default user in AssemblyConfigurationUtils#getAssemblyConfigurationOrCreateDefault
 * Fix #358: Prometheus is enabled by default, opt-out via AB_PROMETHEUS_OFF required to disable (like in FMP)
+* Fix #384: Enricher defined Container environment variables get merged with vars defined in Image Build Configuration
 
 ### 1.0.0 (2020-09-09)
 * Fix #351: Fix AutoTLSEnricher - add annotation + volume config to resource

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeEnricher.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.enricher.generic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.eclipse.jkube.kit.config.resource.PlatformMode;
+import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
+import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
+
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+
+import static org.eclipse.jkube.kit.common.Configs.asBoolean;
+
+/**
+ * Enricher to merge <code>JAVA_OPTIONS</code> environment variables defined in {@link BuildConfiguration#getEnv()}
+ * with those added to {@link io.fabric8.kubernetes.api.model.Container} by other enrichers.
+ *
+ * <p> This prevents Container environment variables from overriding and hiding the initial JAVA_OPTIONS value
+ * possibly added by some <code>Generator</code>.
+ */
+public class ContainerEnvJavaOptionsMergeEnricher extends BaseEnricher {
+
+  @AllArgsConstructor
+  private enum Config implements Configs.Config {
+    // What pull policy to use when fetching images
+    DISABLE("disable", "false");
+
+    @Getter
+    protected String key;
+    @Getter
+    protected String defaultValue;
+  }
+
+  public ContainerEnvJavaOptionsMergeEnricher(JKubeEnricherContext enricherContext) {
+    super(enricherContext, "jkube-container-env-java-options");
+  }
+
+  @Override
+  public void enrich(PlatformMode platformMode, KubernetesListBuilder builder) {
+    if (!asBoolean(getConfig(Config.DISABLE)) && hasImageConfiguration()) {
+      builder.accept(new ContainerEnvJavaOptionsMergeVisitor(getImages()));
+    }
+  }
+
+  static final class ContainerEnvJavaOptionsMergeVisitor extends TypedVisitor<ContainerBuilder> {
+
+    private static final String ENV_KEY = "JAVA_OPTIONS";
+
+    private final List<ImageConfiguration> imageConfigurations;
+
+    public ContainerEnvJavaOptionsMergeVisitor(List<ImageConfiguration> imageConfigurations) {
+      this.imageConfigurations = imageConfigurations;
+    }
+
+    @Override
+    public void visit(ContainerBuilder containerBuilder) {
+      imageConfigurations.stream()
+          .filter(ic -> ImageEnricher.containerImageName(ic).equals(containerBuilder.getImage()))
+          .filter(ic -> !ic.getBuild().getEnv().isEmpty())
+          .filter(ic -> ic.getBuild().getEnv().containsKey(ENV_KEY))
+          .findFirst()
+          .ifPresent(ic -> containerBuilder.withEnv(mergeEnv(containerBuilder.buildEnv(), ic)));
+    }
+
+    private List<EnvVar> mergeEnv(List<EnvVar> envVars, ImageConfiguration imageConfiguration) {
+      final List<EnvVar> ret = new ArrayList<>();
+      for (EnvVar env : envVars) {
+        if (env.getName().equalsIgnoreCase(ENV_KEY)) {
+          final EnvVar merged = new EnvVar();
+          merged.setName(env.getName());
+          merged.setValueFrom(env.getValueFrom());
+          merged.setValue(String.format("%s %s",
+              imageConfiguration.getBuild().getEnv().getOrDefault(ENV_KEY, ""),
+              env.getValue()
+          ));
+          ret.add(merged);
+        } else {
+          ret.add(env);
+        }
+      }
+      return ret;
+    }
+  }
+}

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
@@ -56,7 +56,6 @@ import java.util.Optional;
 
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.extractContainerName;
 
-
 /**
  * Merge in image configuration like the image name into ReplicaSet and ReplicationController's
  * Pod specification.
@@ -94,7 +93,7 @@ public class ImageEnricher extends BaseEnricher {
             return;
         }
 
-        // Ensure that all contoller have template specs
+        // Ensure that all controller have template specs
         ensureTemplateSpecs(builder);
 
         // Update containers in template specs
@@ -247,12 +246,10 @@ public class ImageEnricher extends BaseEnricher {
 
     private void mergeImage(ImageConfiguration imageConfiguration, Container container) {
         if (StringUtils.isBlank(container.getImage())) {
-            String prefix = "";
             if (StringUtils.isNotBlank(imageConfiguration.getRegistry())) {
                 log.verbose("Using registry %s for the image", imageConfiguration.getRegistry());
-                prefix = imageConfiguration.getRegistry() + "/";
             }
-            String imageFullName = prefix + imageConfiguration.getName();
+            final String imageFullName = containerImageName(imageConfiguration);
             log.verbose("Setting image %s", imageFullName);
             container.setImage(imageFullName);
         }
@@ -310,4 +307,11 @@ public class ImageEnricher extends BaseEnricher {
         return envVars.stream().anyMatch(e -> e.getName().equals(name));
     }
 
+    static String containerImageName(ImageConfiguration imageConfiguration) {
+        String prefix = "";
+        if (StringUtils.isNotBlank(imageConfiguration.getRegistry())) {
+            prefix = imageConfiguration.getRegistry() + "/";
+        }
+        return prefix + imageConfiguration.getName();
+    }
 }

--- a/jkube-kit/enricher/generic/src/main/resources/META-INF/jkube/enricher-default
+++ b/jkube-kit/enricher/generic/src/main/resources/META-INF/jkube/enricher-default
@@ -101,3 +101,6 @@ org.eclipse.jkube.enricher.generic.openshift.ImageChangeTriggerEnricher
 
 # Add an ingress on demand when on Kubernetes
 org.eclipse.jkube.enricher.generic.IngressEnricher
+
+# Merge JAVA_OPTIONS environment variables from Image Build Configurations and enriched Containers
+org.eclipse.jkube.enricher.generic.ContainerEnvJavaOptionsMergeEnricher

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.enricher.generic;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.eclipse.jkube.kit.config.resource.PlatformMode;
+import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
+import org.eclipse.jkube.kit.enricher.api.model.Configuration;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("ResultOfMethodCallIgnored")
+public class ContainerEnvJavaOptionsMergeTest {
+
+  @SuppressWarnings("unused")
+  @Mocked
+  private ImageConfiguration imageConfiguration;
+
+  @Mocked
+  private JKubeEnricherContext context;
+
+  private ContainerEnvJavaOptionsMergeEnricher containerEnvJavaOptionsMergeEnricher;
+  private KubernetesListBuilder kubernetesListBuilder;
+  private Properties properties;
+
+  @Before
+  public void setUp() {
+    containerEnvJavaOptionsMergeEnricher = new ContainerEnvJavaOptionsMergeEnricher(context);
+    kubernetesListBuilder = new KubernetesListBuilder();
+    properties = new Properties();
+    // @formatter:off
+    kubernetesListBuilder.addToItems(new DeploymentBuilder().withNewSpec()
+        .withNewTemplate()
+          .withNewSpec()
+            .addToContainers(new ContainerBuilder()
+                .withImage("the-image:latest")
+                .addToEnv(new EnvVar("JAVA_OPTIONS", "val-from-container", null))
+                .build())
+          .endSpec()
+        .endTemplate()
+      .endSpec().build());
+    new Expectations() {{
+      context.getConfiguration(); result = Configuration.builder().image(imageConfiguration).build();
+      context.getProperties(); result = properties;
+    }};
+    // @formatter:on
+  }
+
+  @Test
+  public void enrichWithDefaultsShouldMergeValues() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      imageConfiguration.getName(); result = "the-image:latest"; minTimes = 0;
+      imageConfiguration.getBuild().getEnv(); result = Collections.singletonMap("JAVA_OPTIONS", "val-from-ic"); minTimes = 0;
+    }};
+    // @formatter:on
+    // When
+    containerEnvJavaOptionsMergeEnricher.enrich(PlatformMode.kubernetes, kubernetesListBuilder);
+    // Then
+    assertThat(containerList(kubernetesListBuilder))
+        .flatExtracting("env")
+        .hasSize(1)
+        .containsOnly(new EnvVar("JAVA_OPTIONS", "val-from-ic val-from-container", null));
+  }
+
+  @Test
+  public void enrichWithDisabledShouldDoNothing() {
+    // Given
+    properties.put("jkube.enricher.jkube-container-env-java-options.disable", "true");
+    // When
+    containerEnvJavaOptionsMergeEnricher.enrich(PlatformMode.kubernetes, kubernetesListBuilder);
+    // Then
+    assertThat(containerList(kubernetesListBuilder))
+        .flatExtracting("env")
+        .hasSize(1)
+        .containsOnly(new EnvVar("JAVA_OPTIONS", "val-from-container", null));
+  }
+
+  static List<Container> containerList(KubernetesListBuilder kubernetesListBuilder) {
+    return kubernetesListBuilder.build().getItems().stream()
+        .map(Deployment.class::cast)
+        .flatMap(d -> d.getSpec().getTemplate().getSpec().getContainers().stream())
+        .collect(Collectors.toList());
+  }
+
+}

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeVisitorTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeVisitorTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.enricher.generic;
+
+import java.util.Collections;
+
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jkube.enricher.generic.ContainerEnvJavaOptionsMergeTest.containerList;
+
+@SuppressWarnings("ResultOfMethodCallIgnored")
+public class ContainerEnvJavaOptionsMergeVisitorTest {
+
+  @SuppressWarnings("unused")
+  @Mocked
+  private ImageConfiguration imageConfiguration;
+
+  private KubernetesListBuilder kubernetesListBuilder;
+
+  @Before
+  public void setUp() {
+    kubernetesListBuilder = new KubernetesListBuilder();
+  }
+
+  @Test
+  public void noImageConfigurationsNoContainersShouldDoNothing() {
+    // When
+    kubernetesListBuilder.accept(new ContainerEnvJavaOptionsMergeEnricher.ContainerEnvJavaOptionsMergeVisitor(Collections.emptyList()));
+    // Then
+    assertThat(kubernetesListBuilder.build().getItems()).isEmpty();
+  }
+
+  @Test
+  public void imageConfigurationsNoContainersShouldDoNothing() {
+    // When
+    kubernetesListBuilder.accept(new ContainerEnvJavaOptionsMergeEnricher
+        .ContainerEnvJavaOptionsMergeVisitor(Collections.singletonList(imageConfiguration)));
+    // Then
+    assertThat(kubernetesListBuilder.build().getItems()).isEmpty();
+  }
+
+  @Test
+  public void imageConfigurationAndContainersWithMatchingImageNameAndNoEnvShouldDoNothing() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      imageConfiguration.getName(); result = "the-image:latest";
+    }};
+    // @formatter:on
+    initDeployments(new ContainerBuilder()
+        .withImage("the-image:latest")
+        .build());
+    // When
+    kubernetesListBuilder.accept(new ContainerEnvJavaOptionsMergeEnricher
+        .ContainerEnvJavaOptionsMergeVisitor(Collections.singletonList(imageConfiguration)));
+    // Then
+    assertThat(kubernetesListBuilder.build().getItems()).asList()
+        .hasSize(1)
+        .flatExtracting("spec.template.spec.containers")
+        .flatExtracting("env").isEmpty();
+  }
+
+  @Test
+  public void imageConfigurationWithJavaOptionsEnvAndContainersWithMatchingImageNameShouldDoNothing() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      imageConfiguration.getName(); result = "the-image:latest";
+      imageConfiguration.getBuild().getEnv(); result = Collections.singletonMap("JAVA_OPTIONS", "-DsomeOption");
+    }};
+    // @formatter:on
+    initDeployments(new ContainerBuilder()
+        .withImage("the-image:latest")
+        .build());
+    // When
+    kubernetesListBuilder.accept(new ContainerEnvJavaOptionsMergeEnricher
+        .ContainerEnvJavaOptionsMergeVisitor(Collections.singletonList(imageConfiguration)));
+    // Then
+    assertThat(kubernetesListBuilder.build().getItems()).asList()
+        .hasSize(1)
+        .flatExtracting("spec.template.spec.containers")
+        .flatExtracting("env").isEmpty();
+  }
+
+  @Test
+  public void imageConfigurationWithJavaOptionsEnvAndContainersWithMatchingImageNameAndEnvShouldAdd() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      imageConfiguration.getName(); result = "the-image:latest";
+      imageConfiguration.getBuild().getEnv(); result = Collections.singletonMap("JAVA_OPTIONS", "-DsomeOption");
+    }};
+    // @formatter:on
+    initDeployments(new ContainerBuilder()
+        .withImage("the-image:latest")
+        .addToEnv(new EnvVar("JAVA_OPTIONS", "-DotherOption", null))
+        .addToEnv(new EnvVar("OTHER", "OTHER_VALUE", null))
+        .build(), new ContainerBuilder()
+        .withImage("other-image:latest")
+        .addToEnv(new EnvVar("JAVA_OPTIONS", "-DnotMerged", null))
+        .build());
+    // When
+    kubernetesListBuilder.accept(new ContainerEnvJavaOptionsMergeEnricher
+        .ContainerEnvJavaOptionsMergeVisitor(Collections.singletonList(imageConfiguration)));
+    // Then
+    assertThat(containerList(kubernetesListBuilder)).asList()
+        .hasSize(2)
+        .filteredOn("image", "the-image:latest")
+        .hasSize(1)
+        .flatExtracting("env")
+        .contains(
+            new EnvVar("JAVA_OPTIONS", "-DsomeOption -DotherOption", null),
+            new EnvVar("OTHER", "OTHER_VALUE", null)
+        );
+    assertThat(containerList(kubernetesListBuilder)).asList()
+        .filteredOn("image", "other-image:latest")
+        .hasSize(1)
+        .flatExtracting("env")
+        .contains(
+            new EnvVar("JAVA_OPTIONS", "-DnotMerged", null)
+        );
+  }
+
+
+  private void initDeployments(Container... containers) {
+    // @formatter:off
+    kubernetesListBuilder.addToItems(new DeploymentBuilder().withNewSpec()
+        .withNewTemplate()
+          .withNewSpec()
+            .addToContainers(containers)
+          .endSpec()
+        .endTemplate()
+      .endSpec().build());
+    // @formatter:on
+  }
+}

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -46,6 +46,11 @@ This plugin comes with a set of default enrichers. In addition custom enrichers 
 | <<jkube-configmap-file>>
 | Add ConfigMap elements defined as XML or as annotation.
 
+| <<jkube-container-env-java-options>>
+| Merges `JAVA_OPTIONS` environment variable defined in <<config-image-build>>
+  environment (`env`) with `Container` `JAVA_OPTIONS` environment variable added
+  by other enrichers, XML configuration or fragment.
+
 | <<jkube-controller>>
 | Create default controller (replication controller, replica set or deployment https://kubernetes.io/docs/concepts/workloads/controllers/[Kubernetes doc]) if missing.
 
@@ -103,6 +108,8 @@ Default generic enrichers are used for adding missing resources or adding metada
 The following default enhancers are available out of the box.
 
 include::enricher/_jkube_configmap_file.adoc[]
+
+include::enricher/_jkube_container_env_java_options.adoc[]
 
 include::enricher/_jkube_controller.adoc[]
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_container_env_java_options.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_container_env_java_options.adoc
@@ -1,0 +1,21 @@
+
+[[jkube-container-env-java-options]]
+==== jkube-container-env-java-options
+
+Merges `JAVA_OPTIONS` environment variable defined in <<config-image-build>>
+environment (`env`) with `Container` `JAVA_OPTIONS` environment variable added
+by other enrichers, XML configuration or fragment.
+
+
+[cols="1,6,1"]
+|===
+| Option | Description | Property
+
+| *disable*
+| Disabled the enricher, any `JAVA_OPTIONS` environment variable defined by an enricher,
+  XML configuration or YAML fragment will override the one defined by the generator
+  or Image Build configuration.
+
+  Defaults to `false`.
+| `jkube.enricher.jkube-container-env-java-options.disable`
+|===

--- a/kubernetes-maven-plugin/it/src/it/custom-environment/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/custom-environment/pom.xml
@@ -35,6 +35,7 @@
 
     <vertx.verticle>io.vertx.example.SimpleWebVerticle</vertx.verticle>
     <vertx-maven-plugin.version>1.0.18</vertx-maven-plugin.version>
+    <jkube.enricher.jkube-container-env-java-options.disable>true</jkube.enricher.jkube-container-env-java-options.disable>
   </properties>
 
   <dependencyManagement>
@@ -60,8 +61,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-dropwizard-metrics</artifactId>
     </dependency>
-
-
 
   </dependencies>
 

--- a/kubernetes-maven-plugin/it/src/it/java-options-env-merge/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/java-options-env-merge/expected/kubernetes.yml
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: java-options-env-merge
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    template:
+      spec:
+        containers:
+        - env:
+          - name: JAVA_OPTIONS
+            value: valueFromImage valueFromResources
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: test:latest
+          imagePullPolicy: IfNotPresent
+          name: orgeclipsejkube-java-options-env-merge
+          securityContext:
+            privileged: false

--- a/kubernetes-maven-plugin/it/src/it/java-options-env-merge/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/java-options-env-merge/invoker.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+invoker.goals.1=clean package
+invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/java-options-env-merge/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/java-options-env-merge/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>java-options-env-merge</artifactId>
+  <groupId>org.eclipse.jkube</groupId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+        <version>@jkube.version@</version>
+        <executions>
+          <execution>
+            <id>jkube</id>
+            <phase>package</phase>
+            <goals>
+              <goal>resource</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <images>
+            <image>
+              <name>test:latest</name>
+              <build>
+                <env>
+                  <JAVA_OPTIONS>valueFromImage</JAVA_OPTIONS>
+                </env>
+              </build>
+            </image>
+          </images>
+          <resources>
+            <env>
+              <JAVA_OPTIONS>valueFromResources</JAVA_OPTIONS>
+            </env>
+          </resources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kubernetes-maven-plugin/it/src/it/java-options-env-merge/verify.groovy
+++ b/kubernetes-maven-plugin/it/src/it/java-options-env-merge/verify.groovy
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+import org.eclipse.jkube.maven.it.Verify
+
+["kubernetes"].each {
+  Verify.verifyResourceDescriptors(
+          new File(basedir, sprintf("/target/classes/META-INF/jkube/%s.yml",it)),
+          new File(basedir, sprintf("/expected/%s.yml",it)))
+}
+
+true

--- a/kubernetes-maven-plugin/it/src/it/remote-resources/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/remote-resources/expected/kubernetes.yml
@@ -57,7 +57,9 @@ items:
         containers:
         - env:
           - name: JAVA_OPTIONS
-            value: -Xmx1500m
+            value: -Dvertx.cacheDirBase=/tmp -Dvertx.disableDnsResolver=true -Dvertx.metrics.options.enabled=true
+              -Dvertx.metrics.options.jmxEnabled=true -Dvertx.metrics.options.jmxDomain=vertx
+              -Xmx1500m
           - name: KUBERNETES_NAMESPACE
             valueFrom:
               fieldRef:

--- a/kubernetes-maven-plugin/it/src/it/vertx/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/vertx/expected/kubernetes.yml
@@ -57,7 +57,9 @@ items:
         containers:
         - env:
           - name: JAVA_OPTIONS
-            value: -Xmx1500m
+            value: -Dvertx.cacheDirBase=/tmp -Dvertx.disableDnsResolver=true -Dvertx.metrics.options.enabled=true
+              -Dvertx.metrics.options.jmxEnabled=true -Dvertx.metrics.options.jmxDomain=vertx
+              -Xmx1500m
           - name: KUBERNETES_NAMESPACE
             valueFrom:
               fieldRef:

--- a/kubernetes-maven-plugin/it/src/it/vertx/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/vertx/pom.xml
@@ -73,7 +73,7 @@
         <version>@jkube.version@</version>
         <executions>
           <execution>
-            <id>fmp</id>
+            <id>jkube</id>
             <goals>
               <goal>resource</goal>
               <goal>build</goal>

--- a/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/kind-filename-type-mapping-default.adoc
+++ b/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/kind-filename-type-mapping-default.adoc
@@ -1,5 +1,5 @@
 // =========================================================
-// Mapping file for K8s/OpenShift reource kind to filename extension.
+// Mapping file for K8s/OpenShift resource kind to filename extension.
 //
 // I.e for fragments the resource kind is inferred from the filename type"
 // myapp-deployment.yml maps to a Kubernetes Deployment

--- a/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -64,6 +64,10 @@
     - jkube-healthcheck-docker
     - jkube-healthcheck-webapp
     - jkube-prometheus
+
+    # Value merge enrichers
+    - jkube-container-env-java-options
+
     # Dependencies shouldn't be enriched anymore, therefore it's last in the list
     - jkube-dependency
     - jkube-revision-history

--- a/openshift-maven-plugin/it/src/it/custom-environment/pom.xml
+++ b/openshift-maven-plugin/it/src/it/custom-environment/pom.xml
@@ -35,6 +35,7 @@
 
     <vertx.verticle>io.vertx.example.SimpleWebVerticle</vertx.verticle>
     <vertx-maven-plugin.version>1.0.18</vertx-maven-plugin.version>
+    <jkube.enricher.jkube-container-env-java-options.disable>true</jkube.enricher.jkube-container-env-java-options.disable>
   </properties>
 
   <dependencyManagement>

--- a/openshift-maven-plugin/it/src/it/remote-resources/expected/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/remote-resources/expected/openshift.yml
@@ -62,7 +62,9 @@ items:
         containers:
         - env:
           - name: JAVA_OPTIONS
-            value: -Xmx1500m
+            value: -Dvertx.cacheDirBase=/tmp -Dvertx.disableDnsResolver=true -Dvertx.metrics.options.enabled=true
+              -Dvertx.metrics.options.jmxEnabled=true -Dvertx.metrics.options.jmxDomain=vertx
+              -Xmx1500m
           - name: KUBERNETES_NAMESPACE
             valueFrom:
               fieldRef:

--- a/openshift-maven-plugin/it/src/it/vertx/expected/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/vertx/expected/openshift.yml
@@ -62,7 +62,9 @@ items:
         containers:
         - env:
           - name: JAVA_OPTIONS
-            value: -Xmx1500m
+            value: -Dvertx.cacheDirBase=/tmp -Dvertx.disableDnsResolver=true -Dvertx.metrics.options.enabled=true
+              -Dvertx.metrics.options.jmxEnabled=true -Dvertx.metrics.options.jmxDomain=vertx
+              -Xmx1500m
           - name: KUBERNETES_NAMESPACE
             valueFrom:
               fieldRef:

--- a/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -61,7 +61,11 @@
     - jkube-healthcheck-docker
     - jkube-healthcheck-webapp
     - jkube-prometheus
-    # Dependencies shouldn't be enriched anymore, therefor it's last in the list
+
+    # Value merge enrichers
+    - jkube-container-env-java-options
+
+    # Dependencies shouldn't be enriched anymore, therefore it's last in the list
     - jkube-dependency
     - jkube-revision-history
     - jkube-docker-registry-secret


### PR DESCRIPTION
## Description
fix #384: Enricher defined Container env vars get merged with vars defined in Image Build Configuration

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->