### PR TITLE
chore: Maven Plugin ITs run in parallel (10 threads) - improves speed

### DIFF
--- a/kubernetes-maven-plugin/it/pom.xml
+++ b/kubernetes-maven-plugin/it/pom.xml
@@ -98,6 +98,7 @@ for running a single test.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
+          <parallelThreads>5</parallelThreads>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <cloneClean>true</cloneClean>
           <!--<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>-->

--- a/openshift-maven-plugin/it/pom.xml
+++ b/openshift-maven-plugin/it/pom.xml
@@ -97,6 +97,7 @@ for running a single test.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
+          <parallelThreads>5</parallelThreads>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <cloneClean>true</cloneClean>
           <!--<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>-->


### PR DESCRIPTION
## Description
chore: Maven Plugin ITs run in parallel (10 threads) - improves speed

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] ~I Added [CHANGELOG](../CHANGELOG.md) entry~
 - [ ] ~I have implemented unit tests to cover my changes~
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] ~I tested my code in Kubernetes~
 - [ ] ~I tested my code in OpenShift~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->