### PR TITLE
Fix for issue #385, WildFly Bootable JAR - Add native support for slim Bootable JAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Usage:
 * Fix #381: Remove root as default user in AssemblyConfigurationUtils#getAssemblyConfigurationOrCreateDefault
 * Fix #358: Prometheus is enabled by default, opt-out via AB_PROMETHEUS_OFF required to disable (like in FMP)
 * Fix #384: Enricher defined Container environment variables get merged with vars defined in Image Build Configuration
+* Fix #385: WildFly Bootable JAR - Add native support for slim Bootable JAR
 
 ### 1.0.0 (2020-09-09)
 * Fix #351: Fix AutoTLSEnricher - add annotation + volume config to resource

--- a/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGenerator.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGenerator.java
@@ -13,6 +13,11 @@
  */
 package org.eclipse.jkube.wildfly.jar.generator;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.generator.javaexec.JavaExecGenerator;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
@@ -20,12 +25,32 @@ import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import org.eclipse.jkube.kit.common.AssemblyFileSet;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.Plugin;
 import org.eclipse.jkube.wildfly.jar.enricher.WildflyJARHealthCheckEnricher;
+import static org.eclipse.jkube.wildfly.jar.enricher.WildflyJARHealthCheckEnricher.BOOTABLE_JAR_ARTIFACT_ID;
+import static org.eclipse.jkube.wildfly.jar.enricher.WildflyJARHealthCheckEnricher.BOOTABLE_JAR_GROUP_ID;
 
 public class WildflyJARGenerator extends JavaExecGenerator {
+    static final String JBOSS_MAVEN_DIST = "jboss-maven-dist";
+    static final String JBOSS_MAVEN_REPO = "jboss-maven-repo";
+    static final String PLUGIN_OPTIONS = "plugin-options";
 
+    final Path localRepoCache;
     public WildflyJARGenerator(GeneratorContext context) {
         super(context, "wildfly-jar");
+        JavaProject project = context.getProject();
+        Plugin plugin = JKubeProjectUtil.getPlugin(project, BOOTABLE_JAR_GROUP_ID, BOOTABLE_JAR_ARTIFACT_ID);
+        localRepoCache = Optional.ofNullable(plugin).
+                map(Plugin::getConfiguration).
+                map(c -> (Map<String, Object>) c.get(PLUGIN_OPTIONS)).
+                map(options -> options.containsKey(JBOSS_MAVEN_DIST) && options.containsKey(JBOSS_MAVEN_REPO) ? options : null).
+                map(options -> {
+                   String dist = (String) options.get(JBOSS_MAVEN_DIST);
+                   return dist == null || "true".equals(dist) ? (String) options.get(JBOSS_MAVEN_REPO) : null;
+                }).map(Paths::get).orElse(null);
     }
 
     @Override
@@ -49,5 +74,41 @@ public class WildflyJARGenerator extends JavaExecGenerator {
         // Can be workarounded by setting JAVA_OPTIONS to contain -Djboss.modules.system.pkgs=org.jboss.byteman
         ret.put("AB_JOLOKIA_OFF", "true");
         return ret;
+    }
+
+    @Override
+    public List<AssemblyFileSet> addAdditionalFiles() {
+        List<AssemblyFileSet> set = super.addAdditionalFiles();
+        if (localRepoCache != null) {
+            Path parentDir;
+            Path repoDir = localRepoCache;
+            if (localRepoCache.isAbsolute()) {
+                parentDir = localRepoCache.getParent();
+            } else {
+                repoDir = getProject().getBaseDirectory().toPath().resolve(localRepoCache);
+                parentDir = repoDir.getParent();
+            }
+            if (Files.notExists(repoDir)) {
+               throw new RuntimeException("Error, WildFly bootable JAR generator can't retrieve "
+                       + "generated maven local cache, directory " + repoDir + " doesn't exist."); 
+            }
+            set.add(AssemblyFileSet.builder()
+                    .directory(parentDir.toFile())
+                    .include(localRepoCache.getFileName().toString())
+                    .outputDirectory(new File("."))
+                    .fileMode("0640")
+                    .build());
+        }
+        return set;
+    }
+
+    @Override
+    protected List<String> getExtraJavaOptions() {
+        List<String> properties = new ArrayList<>();
+        properties.add("-Djava.net.preferIPv4Stack=true");
+        if (localRepoCache != null) {
+            properties.add("-Dmaven.repo.local=/deployments/" + localRepoCache.getFileName().toString());
+        }
+        return properties;
     }
 }

--- a/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGeneratorTest.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGeneratorTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.wildfly.jar.generator;
 
+import java.io.File;
 import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import mockit.Expectations;
@@ -22,13 +23,25 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.jkube.kit.common.AssemblyFileSet;
+import org.eclipse.jkube.kit.common.Plugin;
+import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
+import org.eclipse.jkube.wildfly.jar.enricher.WildflyJARHealthCheckEnricher;
+import static org.eclipse.jkube.wildfly.jar.generator.WildflyJARGenerator.JBOSS_MAVEN_DIST;
+import static org.eclipse.jkube.wildfly.jar.generator.WildflyJARGenerator.JBOSS_MAVEN_REPO;
+import static org.eclipse.jkube.wildfly.jar.generator.WildflyJARGenerator.PLUGIN_OPTIONS;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 /**
  * @author roland
@@ -53,7 +66,200 @@ public class WildflyJARGeneratorTest {
         WildflyJARGenerator generator = new WildflyJARGenerator(createGeneratorContext());
         Map<String, String> extraEnv = generator.getEnv(true);
         assertNotNull(extraEnv);
-        assertEquals(3, extraEnv.size());
+        assertEquals(4, extraEnv.size());
+    }
+    
+    @Test
+    public void getExtraOptions() throws IOException {
+        WildflyJARGenerator generator = new WildflyJARGenerator(createGeneratorContext());
+        List<String> extraOptions = generator.getExtraJavaOptions();
+        assertNotNull(extraOptions);
+        assertEquals(1, extraOptions.size());
+        assertEquals("-Djava.net.preferIPv4Stack=true", extraOptions.get(0));
+    }
+    
+    @Test
+    public void slimServer(@Mocked final JavaProject project) throws IOException {
+        Map<String, Object> options = new HashMap<>();
+        Map<String, String> pluginOptions = new HashMap();
+        options.put(PLUGIN_OPTIONS, pluginOptions);
+        pluginOptions.put(JBOSS_MAVEN_DIST, null);
+        pluginOptions.put(JBOSS_MAVEN_REPO, "target" + File.separator + "myrepo");
+        //
+        Path tmpDir = Files.createTempDirectory("bootable-jar-test-project");
+        Path targetDir = tmpDir.resolve("target");
+        Path repoDir = targetDir.resolve("myrepo");
+        Files.createDirectories(repoDir);
+        try {
+            GeneratorContext ctx = contextForSlimServer(project, options, tmpDir);
+            WildflyJARGenerator generator = new WildflyJARGenerator(ctx);
+            List<String> extraOptions = generator.getExtraJavaOptions();
+            assertNotNull(extraOptions);
+            assertEquals(2, extraOptions.size());
+            assertEquals("-Djava.net.preferIPv4Stack=true", extraOptions.get(0));
+            assertEquals("-Dmaven.repo.local=/deployments/myrepo", extraOptions.get(1));
+            List<AssemblyFileSet> files = generator.addAdditionalFiles();
+            assertFalse(files.isEmpty());
+            AssemblyFileSet set = files.get(files.size() - 1);
+            assertEquals(targetDir.toFile(), set.getDirectory());
+            assertEquals(1, set.getIncludes().size());
+            assertEquals("myrepo", set.getIncludes().get(0));
+        } finally {
+            Files.delete(repoDir);
+            Files.delete(targetDir);
+            Files.delete(tmpDir);
+        }
+    }
+    
+    @Test
+    public void slimServerAbsoluteDir(@Mocked final JavaProject project) throws IOException {
+        Map<String, Object> options = new HashMap<>();
+        Map<String, String> pluginOptions = new HashMap();
+        Path tmpDir = Files.createTempDirectory("bootable-jar-test-project2");
+        Path targetDir = tmpDir.resolve("target");
+        Path repoDir = targetDir.resolve("myrepo");
+        Files.createDirectories(repoDir);
+        options.put(PLUGIN_OPTIONS, pluginOptions);
+        pluginOptions.put(JBOSS_MAVEN_DIST, null);
+        pluginOptions.put(JBOSS_MAVEN_REPO, repoDir.toString());
+        try {
+            GeneratorContext ctx = contextForSlimServer(project, options, null);
+            WildflyJARGenerator generator = new WildflyJARGenerator(ctx);
+            List<String> extraOptions = generator.getExtraJavaOptions();
+            assertNotNull(extraOptions);
+            assertEquals(2, extraOptions.size());
+            assertEquals("-Djava.net.preferIPv4Stack=true", extraOptions.get(0));
+            assertEquals("-Dmaven.repo.local=/deployments/myrepo", extraOptions.get(1));
+            List<AssemblyFileSet> files = generator.addAdditionalFiles();
+            assertFalse(files.isEmpty());
+            AssemblyFileSet set = files.get(files.size() - 1);
+            assertEquals(targetDir.toFile(), set.getDirectory());
+            assertEquals(1, set.getIncludes().size());
+            assertEquals("myrepo", set.getIncludes().get(0));
+        } finally {
+            Files.delete(repoDir);
+            Files.delete(targetDir);
+            Files.delete(tmpDir);
+        }
+    }
+    
+    @Test
+    public void slimServerNoDir(@Mocked final JavaProject project) throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        Map<String, String> pluginOptions = new HashMap();
+        Path tmpDir = Files.createTempDirectory("bootable-jar-test-project2");
+        Path targetDir = tmpDir.resolve("target");
+        Path repoDir = targetDir.resolve("myrepo");
+        options.put(PLUGIN_OPTIONS, pluginOptions);
+        pluginOptions.put(JBOSS_MAVEN_DIST, null);
+        pluginOptions.put(JBOSS_MAVEN_REPO, repoDir.toString());
+        try {
+            GeneratorContext ctx = contextForSlimServer(project, options, null);
+            WildflyJARGenerator generator = new WildflyJARGenerator(ctx);
+            List<String> extraOptions = generator.getExtraJavaOptions();
+            assertNotNull(extraOptions);
+            assertEquals(2, extraOptions.size());
+            assertEquals("-Djava.net.preferIPv4Stack=true", extraOptions.get(0));
+            assertEquals("-Dmaven.repo.local=/deployments/myrepo", extraOptions.get(1));
+            Exception result = assertThrows(Exception.class, () -> {
+                generator.addAdditionalFiles();
+                fail("Test should have failed, no directory for maven repo");
+            });
+            assertEquals("Error, WildFly bootable JAR generator can't retrieve "
+                    + "generated maven local cache, directory " + repoDir + " doesn't exist.", result.getMessage());
+        } finally {
+            Files.delete(tmpDir);
+        }
+    }
+    
+    @Test
+    public void slimServerNoRepo(@Mocked final JavaProject project) throws IOException {
+        Map<String, Object> options = new HashMap<>();
+        Map<String, String> pluginOptions = new HashMap();
+        options.put(PLUGIN_OPTIONS, pluginOptions);
+        pluginOptions.put(JBOSS_MAVEN_DIST, null);
+        GeneratorContext ctx = contextForSlimServer(project, options, null);
+        WildflyJARGenerator generator = new WildflyJARGenerator(ctx);
+        List<String> extraOptions = generator.getExtraJavaOptions();
+        assertNotNull(extraOptions);
+        assertEquals(1, extraOptions.size());
+        assertEquals("-Djava.net.preferIPv4Stack=true", extraOptions.get(0));
+    }
+    
+    @Test
+    public void slimServerNoDist(@Mocked final JavaProject project) throws IOException {
+        Map<String, Object> options = new HashMap<>();
+        Map<String, String> pluginOptions = new HashMap();
+        options.put(PLUGIN_OPTIONS, pluginOptions);
+        pluginOptions.put(JBOSS_MAVEN_REPO, "myrepo");
+        GeneratorContext ctx = contextForSlimServer(project, options, null);
+        WildflyJARGenerator generator = new WildflyJARGenerator(ctx);
+        List<String> extraOptions = generator.getExtraJavaOptions();
+        assertNotNull(extraOptions);
+        assertEquals(1, extraOptions.size());
+        assertEquals("-Djava.net.preferIPv4Stack=true", extraOptions.get(0));
+    }
+    
+    @Test
+    public void slimServerFalseDist(@Mocked final JavaProject project) throws IOException {
+        Map<String, Object> options = new HashMap<>();
+        Map<String, String> pluginOptions = new HashMap();
+        options.put(PLUGIN_OPTIONS, pluginOptions);
+        pluginOptions.put(JBOSS_MAVEN_REPO, "myrepo");
+        pluginOptions.put(JBOSS_MAVEN_DIST, "false");
+        GeneratorContext ctx = contextForSlimServer(project, options, null);
+        WildflyJARGenerator generator = new WildflyJARGenerator(ctx);
+        List<String> extraOptions = generator.getExtraJavaOptions();
+        assertNotNull(extraOptions);
+        assertEquals(1, extraOptions.size());
+        assertEquals("-Djava.net.preferIPv4Stack=true", extraOptions.get(0));
+    }
+    
+    @Test
+    public void slimServerTrueDist(@Mocked final JavaProject project) throws IOException {
+        Map<String, Object> options = new HashMap<>();
+        Map<String, String> pluginOptions = new HashMap();
+        options.put(PLUGIN_OPTIONS, pluginOptions);
+        pluginOptions.put(JBOSS_MAVEN_REPO, "myrepo");
+        pluginOptions.put(JBOSS_MAVEN_DIST, "true");
+        GeneratorContext ctx = contextForSlimServer(project, options, null);
+        WildflyJARGenerator generator = new WildflyJARGenerator(ctx);
+        List<String> extraOptions = generator.getExtraJavaOptions();
+        assertNotNull(extraOptions);
+        assertEquals(2, extraOptions.size());
+        assertEquals("-Djava.net.preferIPv4Stack=true", extraOptions.get(0));
+        assertEquals("-Dmaven.repo.local=/deployments/myrepo", extraOptions.get(1));
+    }
+    
+    private GeneratorContext contextForSlimServer(JavaProject project, Map<String, Object> bootableJarconfig, Path dir) {
+        Plugin plugin
+                = Plugin.builder().artifactId(WildflyJARHealthCheckEnricher.BOOTABLE_JAR_ARTIFACT_ID).
+                        groupId(WildflyJARHealthCheckEnricher.BOOTABLE_JAR_GROUP_ID).configuration(bootableJarconfig).build();
+        List<Plugin> lst = new ArrayList<>();
+        lst.add(plugin);
+        ProcessorConfig c = new ProcessorConfig(null, null, Collections.emptyMap());
+        if (dir == null) {
+            new Expectations() {
+                {
+                    project.getPlugins();
+                    result = lst;
+                    context.getProject();
+                    result = project;
+                }
+            };
+        } else {
+            new Expectations() {
+                {
+                    project.getPlugins();
+                    result = lst;
+                    project.getBaseDirectory();
+                    result = dir.toFile();
+                    context.getProject();
+                    result = project;
+                }
+            };
+        }
+        return context;
     }
 
     private GeneratorContext createGeneratorContext() throws IOException {

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_wildfly_jar.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/generator/_wildfly_jar.adoc
@@ -1,6 +1,44 @@
 [[generator-wildfly-jar]]
 === Wildfly JAR Generator
 
-The Wildfly JAR generator detects a WildFly Bootable JAR build and disables the Jolokia and Prometheus Java agent TO BE REVISITED WHEN WE HAVE A SOLUTION.
+The Wildfly JAR generator detects a WildFly Bootable JAR build and disables the Jolokia and Prometheus Java agent.
 
 Otherwise this generator is identical to the <<generator-java-exec,java-exec generator>>. It supports the  <<generator-options-common, common generator options>> and the <<generator-java-exec-options, `java-exec` options>>.
+
+==== Support for slim Bootable JAR
+
+A slim Bootable JAR is a JAR that retrieves JBoss module artifacts from a Maven local cache. Such JAR are smaller and start faster. The WildFly JAR generator
+has a builtin support to install a maven local cache in the image.
+
+In order to build a slim Bootable JAR, configure the _wildfly-jar-maven-plugin_ for slim server and maven local cache generation:
+
+----
+  <plugin>
+    <groupId>org.wildfly.plugins</groupId>
+    <artifactId>wildfly-jar-maven-plugin</artifactId>
+    <configuration>
+      <plugin-options>
+       <!-- Build a slim Bootable JAR -->
+       <jboss-maven-dist/>
+       <!-- Path to the Maven local cache that the plugin generates during build.
+            It contains JBoss module artifacts required by the server. -->
+       <jboss-maven-repo>target/myapp-repo</jboss-maven-repo>
+      </plugin-options>
+      ...
+    </configuration>
+    <executions>
+      <execution>
+        <goals>
+          <goal>package</goal>
+        </goals>
+      </execution>
+    </executions>
+  </plugin>
+----
+
+The generator detects the path of the generated maven local repository directory 
+(value of the _<jboss-maven-repo>_ element) and copies it into the image _/deployments/<repo directory name>_ directory. 
+NB: A relative path is considered relative to the maven project base directory.
+
+In order for the Bootable JAR to retrieve the JBoss modules artifacts, the java 
+option _-Dmaven.repo.local=/deployments/<repo directory name>_ is automatically added to the launch options.

--- a/quickstarts/maven/wildfly-jar/pom.xml
+++ b/quickstarts/maven/wildfly-jar/pom.xml
@@ -32,8 +32,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <jkube.version>${project.version}</jkube.version>
-    <version.wildfly.jar>2.0.0.Alpha6</version.wildfly.jar>
-    <version.wildfly>20.0.0.Final</version.wildfly>
+    <version.wildfly.jar>2.0.0.Beta7</version.wildfly.jar>
+    <version.wildfly>21.0.0.Beta1</version.wildfly>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
Signed-off-by: JF Denise <jdenise@redhat.com>

The quickstart evolution is tracked by https://github.com/eclipse/jkube/issues/399

## Description
* Support for slim server in WildFly bootable JAR.
* In addition the preferIPV4 is now added by default.
* Upgraded WildFly and wildfly-jar plugin versions in quickstart.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->