### PR TITLE
Fix #382: Add support for merging fragment Route spec with default generated Route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 ### 1.0.1-SNAPSHOT
 * Fix #381: Remove root as default user in AssemblyConfigurationUtils#getAssemblyConfigurationOrCreateDefault
+* Fix #382: Add support for merging fragment Route spec with default generated Route
 * Fix #358: Prometheus is enabled by default, opt-out via AB_PROMETHEUS_OFF required to disable (like in FMP)
 * Fix #365: jkube.watch.postGoal property/parameter/configuration is ignored
 * Fix #384: Enricher defined Container environment variables get merged with vars defined in Image Build Configuration

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
@@ -120,6 +120,23 @@ public class KubernetesResourceUtil {
 
     protected static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssX";
 
+    static {
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(String.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Double.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Float.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Long.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Integer.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Short.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Character.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Byte.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(double.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(float.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(long.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(int.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(short.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(char.class);
+        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(byte.class);
+    }
 
     /**
      * Read all Kubernetes resource fragments from a directory and create a {@link KubernetesListBuilder} which
@@ -566,7 +583,7 @@ public class KubernetesResourceUtil {
             }
 
             Class<?> fieldType = targetGetMethod.getReturnType();
-            if (!SIMPLE_FIELD_TYPES.contains(fieldType)) {
+            if (!isSimpleFieldType(fieldType)) {
                 continue;
             }
 
@@ -725,6 +742,10 @@ public class KubernetesResourceUtil {
             }
         }
         ports.add(port);
+    }
+
+    private static boolean isSimpleFieldType(Class<?> type) {
+        return SIMPLE_FIELD_TYPES.contains(type);
     }
 
     public static String getSourceUrlAnnotation(HasMetadata item) {
@@ -965,7 +986,7 @@ public class KubernetesResourceUtil {
         }
     }
 
-    protected static void mergeMetadata(HasMetadata item1, HasMetadata item2) {
+    public static void mergeMetadata(HasMetadata item1, HasMetadata item2) {
         if (item1 != null && item2 != null) {
             ObjectMeta metadata1 = item1.getMetadata();
             ObjectMeta metadata2 = item2.getMetadata();
@@ -984,12 +1005,14 @@ public class KubernetesResourceUtil {
      */
     private static Map<String, String> mergeMapsAndRemoveEmptyStrings(Map<String, String> overrideMap, Map<String, String> originalMap) {
         Map<String, String> answer = MapUtil.mergeMaps(overrideMap, originalMap);
-        Set<Map.Entry<String, String>> entries = overrideMap.entrySet();
-        for (Map.Entry<String, String> entry : entries) {
-            String value = entry.getValue();
-            if (value == null || value.isEmpty()) {
-                String key = entry.getKey();
-                answer.remove(key);
+        if (overrideMap != null && originalMap != null) {
+            Set<Map.Entry<String, String>> entries = overrideMap.entrySet();
+            for (Map.Entry<String, String> entry : entries) {
+                String value = entry.getValue();
+                if (value == null || value.isEmpty()) {
+                    String key = entry.getKey();
+                    answer.remove(key);
+                }
             }
         }
         return answer;

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
@@ -166,22 +166,4 @@ public class DefaultControllerEnricher extends BaseEnricher {
         return containerNames;
     }
 
-    static {
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(String.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Double.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Float.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Long.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Integer.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Short.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Character.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(Byte.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(double.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(float.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(long.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(int.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(short.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(char.class);
-        KubernetesResourceUtil.SIMPLE_FIELD_TYPES.add(byte.class);
-    }
-
 }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherTest.java
@@ -15,19 +15,24 @@ package org.eclipse.jkube.enricher.generic.openshift;
 
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings({"unused", "ResultOfMethodCallIgnored"})
 public class RouteEnricherTest {
@@ -39,27 +44,12 @@ public class RouteEnricherTest {
     private ProcessorConfig processorConfig;
     private KubernetesListBuilder klb;
 
-    @Before
-    public void setUp() {
+    public void setUpExpectations() {
         properties = new Properties();
         processorConfig = new ProcessorConfig();
         klb = new KubernetesListBuilder();
         // @formatter:off
-        klb.addToItems(new ServiceBuilder()
-                .editOrNewMetadata()
-                    .withName("test-svc")
-                    .addToLabels("expose", "true")
-                .endMetadata()
-                .editOrNewSpec()
-                    .addNewPort()
-                        .withName("http")
-                        .withPort(8080)
-                        .withProtocol("TCP")
-                        .withTargetPort(new IntOrString(8080))
-                    .endPort()
-                    .addToSelector("group", "test")
-                    .withType("LoadBalancer")
-                .endSpec()
+        klb.addToItems(getMockServiceBuilder()
             .build());
         new Expectations() {{
             context.getProperties(); result = properties;
@@ -70,6 +60,8 @@ public class RouteEnricherTest {
 
     @Test
     public void testCreateWithDefaultsInOpenShiftShouldAddRoute() {
+        // Given
+        setUpExpectations();
         // When
         new RouteEnricher(context).create(PlatformMode.openshift, klb);
         // Then
@@ -85,6 +77,7 @@ public class RouteEnricherTest {
     @Test
     public void testCreateWithDefaultsInKubernetesShouldNotAddRoute() {
         // Given
+        setUpExpectations();
         // @formatter:off
         new Expectations() {{
             context.getProperties(); minTimes = 0;
@@ -103,6 +96,7 @@ public class RouteEnricherTest {
     @Test
     public void testCreateWithGenerateExtraPropertyInOpenShiftShouldNotAddRoute() {
         // Given
+        setUpExpectations();
         properties.put("jkube.openshift.generateRoute", "false");
         // When
         new RouteEnricher(context).create(PlatformMode.openshift, klb);
@@ -116,6 +110,7 @@ public class RouteEnricherTest {
     @Test
     public void testCreateWithGenerateEnricherPropertyInOpenShiftShouldNotAddRoute() {
         // Given
+        setUpExpectations();
         properties.put("jkube.enricher.jkube-openshift-route.generateRoute", "false");
         // When
         new RouteEnricher(context).create(PlatformMode.openshift, klb);
@@ -129,6 +124,7 @@ public class RouteEnricherTest {
     @Test
     public void testCreateWithDefaultsAndRouteDomainInOpenShiftShouldAddRouteWithDomainPostfix() {
         // Given
+        setUpExpectations();
         // @formatter:off
         new Expectations() {{
             context.getProperties(); minTimes = 0;
@@ -150,6 +146,7 @@ public class RouteEnricherTest {
     @Test
     public void testCreateWithDefaultsAndExistingRouteWithMatchingNameInBuilderInOpenShiftShouldReuseExistingRoute() {
         // Given
+        setUpExpectations();
         klb.addToItems(new RouteBuilder()
             .editOrNewMetadata()
                 .withName("test-svc")
@@ -170,12 +167,129 @@ public class RouteEnricherTest {
             .containsExactly("Service", "Route");
         assertThat(klb.build().getItems().get(1))
             .extracting("metadata.name", "spec.host", "spec.to.kind", "spec.to.name", "spec.port.targetPort.intVal")
-            .contains("test-svc", "example.com", null, null, 1337);
+            .contains("test-svc", "example.com", "Service", "test-svc", 1337);
+    }
+
+    @Test
+    public void testCreateOpinionatedRouteFromService() {
+        // Given
+        ServiceBuilder serviceBuilder = getMockServiceBuilder();
+
+        // When
+        Route route = RouteEnricher.createOpinionatedRouteFromService(serviceBuilder, "example.com", "edge", "Allow", false);
+
+        // Then
+        assertNotNull(route);
+        assertThat(route)
+                .extracting("metadata.name", "spec.host", "spec.to.kind", "spec.to.name", "spec.port.targetPort.intVal")
+                .contains("test-svc", "example.com", "Service", "test-svc", 8080);
+    }
+
+    @Test
+    public void testCreateOpinionatedRouteFromServiceWithNullService() {
+        // Given
+        ServiceBuilder serviceBuilder = new ServiceBuilder();
+
+        // When
+        Route route = RouteEnricher.createOpinionatedRouteFromService(serviceBuilder, "example.com", "edge", "Allow", false);
+
+        // Then
+        assertNull(route);
+    }
+
+    @Test
+    public void testIsExposedService() {
+       assertTrue(RouteEnricher.isExposedService(new ObjectMetaBuilder().addToLabels("expose", "true").build()));
+       assertTrue(RouteEnricher.isExposedService(new ObjectMetaBuilder().addToLabels("jkube.io/exposeUrl", "true").build()));
+    }
+
+    @Test
+    public void testMergeRouteWithEmptyFragment() {
+        // Given
+        Route opinionatedRoute = getMockOpinionatedRoute();
+        Route fragmentRoute = new RouteBuilder().build();
+
+        // When
+        Route result = RouteEnricher.mergeRoute(fragmentRoute, opinionatedRoute);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(opinionatedRoute, result);
+    }
+
+    @Test
+    public void testMergeRouteWithNonEmptyFragment() {
+        // Given
+        Route opinionatedRoute = getMockOpinionatedRoute();
+        Route fragmentRoute = new RouteBuilder()
+                .withNewSpec()
+                .withNewTls()
+                .withInsecureEdgeTerminationPolicy("Redirect")
+                .withTermination("edge")
+                .endTls()
+                .endSpec()
+                .build();
+
+        // When
+        Route result = RouteEnricher.mergeRoute(fragmentRoute, opinionatedRoute);
+
+        // Then
+        assertNotNull(result);
+        assertThat(result)
+                .extracting("metadata.name", "spec.host", "spec.to.kind", "spec.to.name",
+                        "spec.port.targetPort.intVal", "spec.tls.insecureEdgeTerminationPolicy", "spec.tls.termination")
+                .contains("test-svc", "example.com", "Service", "test-svc",
+                        8080, "Redirect", "edge");
+    }
+
+    private Route getMockOpinionatedRoute() {
+        // @formatter:off
+        return new RouteBuilder()
+                .withNewMetadata().withName("test-svc").endMetadata()
+                .withNewSpec()
+                    .withNewPort()
+                        .withNewTargetPort().withIntVal(8080).endTargetPort()
+                    .endPort()
+                    .withHost("example.com")
+                    .withNewTo().withKind("Service").withName("test-svc").endTo()
+                    .withNewTls()
+                        .withInsecureEdgeTerminationPolicy("Redirect")
+                        .withTermination("edge")
+                    .endTls()
+                    .addNewAlternateBackend()
+                        .withKind("Service")
+                        .withName("test-svc-2")
+                        .withWeight(10)
+                    .endAlternateBackend()
+                    .endSpec()
+                .build();
+        // @formatter:on
+    }
+
+    private ServiceBuilder getMockServiceBuilder() {
+        // @formatter:off
+        return new ServiceBuilder()
+                .editOrNewMetadata()
+                    .withName("test-svc")
+                    .addToLabels("expose", "true")
+                .endMetadata()
+                .editOrNewSpec()
+                    .addNewPort()
+                    .withName("http")
+                    .withPort(8080)
+                        .withProtocol("TCP")
+                        .withTargetPort(new IntOrString(8080))
+                    .endPort()
+                    .addToSelector("group", "test")
+                    .withType("LoadBalancer")
+                .endSpec();
+        // @formatter:on
     }
 
     @Test
     public void testEnrichNoTls(){
         // Given
+        setUpExpectations();
         properties.put("jkube.openshift.generateRoute", "true");
         // When
         new RouteEnricher(context).create(PlatformMode.openshift, klb);
@@ -194,6 +308,7 @@ public class RouteEnricherTest {
     @Test
     public void testEnrichWithTls(){
         // Given
+        setUpExpectations();
         properties.put("jkube.enricher.jkube-openshift-route.tlsTermination", "edge");
         properties.put("jkube.enricher.jkube-openshift-route.tlsInsecureEdgeTerminationPolicy", "Allow");
         // When


### PR DESCRIPTION
Fix #382 & #383 

RouteEnricher now considers merging opinionated route with route provided in resource fragments(if any). Earlier RouteEnricher used to skip a generation of the opinionated route if it found a route corresponding to target Service inside KubernetesListBuilder

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->