### PR TITLE
fix: resource validation works with new json-schema-validator version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Usage:
 * Fix #365: jkube.watch.postGoal property/parameter/configuration is ignored
 * Fix #384: Enricher defined Container environment variables get merged with vars defined in Image Build Configuration
 * Fix #385: WildFly Bootable JAR - Add native support for slim Bootable JAR
+* Fix #415: Fixed resource validation for new json-schema-validator version
 
 ### 1.0.0 (2020-09-09)
 * Fix #351: Fix AutoTLSEnricher - add annotation + volume config to resource

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/validator/ResourceValidatorTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/validator/ResourceValidatorTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util.validator;
+
+import mockit.Mocked;
+import org.assertj.core.api.Condition;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.util.ResourceClassifier;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class ResourceValidatorTest {
+
+  @Mocked
+  private KitLogger logger;
+
+  @Test
+  public void validateWithValidResource() throws Exception {
+    // Given
+    final ResourceValidator validator = new ResourceValidator(
+        Paths.get(ResourceValidatorTest.class.getResource("/util/validator/valid-service.yml").toURI()).toFile(),
+        ResourceClassifier.KUBERNETES,
+        logger
+    );
+    // When
+    final int result = validator.validate();
+    // Then
+    assertThat(result).isEqualTo(1);
+  }
+
+  @Test
+  public void validateWithInvalidResource() throws Exception {
+    // Given
+    final ResourceValidator validator = new ResourceValidator(
+        Paths.get(ResourceValidatorTest.class.getResource("/util/validator/invalid-deployment.yml").toURI()).toFile(),
+        ResourceClassifier.KUBERNETES,
+        logger
+    );
+    // When
+    final ConstraintViolationException result = assertThrows(ConstraintViolationException.class, validator::validate);
+    // Then
+    assertThat(result).isNotNull()
+        .hasMessageStartingWith("Invalid Resource :")
+        .hasMessageContaining("invalid-deployment.yml")
+        .has(new HasErrMessage("$.spec.replicas: string found, integer expected"));
+  }
+
+  private static final class HasErrMessage extends Condition<Throwable> {
+
+    private final String message;
+
+    private HasErrMessage(String message) {
+      this.message = message;
+    }
+
+    @Override
+    public boolean matches(Throwable value) {
+      if (value instanceof ConstraintViolationException) {
+        final ConstraintViolationException ex = (ConstraintViolationException)value;
+        return ex.getConstraintViolations().stream().map(ConstraintViolation::getMessage).anyMatch(m -> m.equals(message));
+      }
+      return false;
+    }
+  }
+}

--- a/jkube-kit/common/src/test/resources/util/validator/invalid-deployment.yml
+++ b/jkube-kit/common/src/test/resources/util/validator/invalid-deployment.yml
@@ -1,0 +1,103 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    jkube.io/git-url: git@github.com:manusa/jkube.git
+    jkube.io/git-commit: 082bc465b1e51433bfc14065b440ad8cf4a0b7c2
+    jkube.io/git-branch: master
+    jkube.io/scm-url: https://github.com/spring-projects/spring-boot/spring-boot-starter-parent/external-resources
+    jkube.io/scm-tag: HEAD
+  labels:
+    app: external-resources
+    provider: jkube
+    version: 1.33.7
+    group: org.eclipse.jkube.quickstarts.maven
+  name: external-resources
+spec:
+  replicas: NOT-AN-INT
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: external-resources
+      provider: jkube
+      group: org.eclipse.jkube.quickstarts.maven
+  template:
+    metadata:
+      annotations:
+        jkube.io/scm-url: https://github.com/spring-projects/spring-boot/spring-boot-starter-parent/external-resources
+        jkube.io/git-url: git@github.com:manusa/jkube.git
+        jkube.io/scm-tag: HEAD
+        jkube.io/git-commit: 082bc465b1e51433bfc14065b440ad8cf4a0b7c2
+        jkube.io/git-branch: master
+      labels:
+        app: external-resources
+        provider: jkube
+        version: 1.33.7
+        group: org.eclipse.jkube.quickstarts.maven
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          image: maven/external-resources:latest
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 180
+            successThreshold: 1
+          name: spring-boot
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+            - containerPort: 9779
+              name: prometheus
+              protocol: TCP
+            - containerPort: 8778
+              name: jolokia
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            successThreshold: 1
+          securityContext:
+            privileged: false
+          volumeMounts:
+            - mountPath: /deployments/config
+              name: config
+      serviceAccount: ribbon
+      volumes:
+        - configMap:
+            items:
+              - key: application.properties
+                path: application.properties
+            name: external-resources
+          name: config

--- a/jkube-kit/common/src/test/resources/util/validator/valid-service.yml
+++ b/jkube-kit/common/src/test/resources/util/validator/valid-service.yml
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    api.service.kubernetes.io/path: /hello
+    app.openshift.io/vcs-ref: master
+    jkube.io/git-url: git@github.com:manusa/jkube.git
+    app.openshift.io/vcs-uri: git@github.com:manusa/jkube.git
+    jkube.io/git-commit: 082bc465b1e51433bfc14065b440ad8cf4a0b7c2
+    jkube.io/git-branch: master
+    jkube.io/scm-url: https://github.com/spring-projects/spring-boot/spring-boot-starter-parent/external-resources
+    jkube.io/scm-tag: HEAD
+    prometheus.io/path: /metrics
+    prometheus.io/port: "1337"
+    prometheus.io/scrape: "true"
+  labels:
+    app: external-resources
+    provider: jkube
+    version: 1.33.7-SNAPSHOT
+    group: org.eclipse.jkube.quickstarts.maven
+  name: external-resources
+spec:
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: external-resources
+    provider: jkube
+    group: org.eclipse.jkube.quickstarts.maven
+  type: LoadBalancer


### PR DESCRIPTION
## Description

Fix #415: Fixed resource validation for new json-schema-validator version

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->