### PR TITLE
RouteEnricher doesn't merge route fragment when it's the only fragment

### DIFF
--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
@@ -113,7 +113,7 @@ public class RouteEnricher extends BaseEnricher {
                     isRouteWithTLS());
             if (opinionatedRoute != null) {
                 int routeFromFragmentIndex = getRouteIndexWithName(listBuilder, name);
-                if (routeFromFragmentIndex > 0) { // Merge fragment with Opinionated Route
+                if (routeFromFragmentIndex >= 0) { // Merge fragment with Opinionated Route
                     Route routeFragment = (Route) listBuilder.buildItems().get(routeFromFragmentIndex);
                     Route mergedRoute = mergeRoute(routeFragment, opinionatedRoute);
                     removeItemFromKubernetesBuilder(listBuilder, listBuilder.getItems().get(routeFromFragmentIndex));


### PR DESCRIPTION
Fix bug in merge fragment with opinionated route regarding array indexing, 0th index wasn't considered while doing the comparison

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->