### PR TITLE
Fix #386: final fat jar is not updated in docker build directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Usage:
 * Fix #358: Prometheus is enabled by default, opt-out via AB_PROMETHEUS_OFF required to disable (like in FMP)
 * Fix #365: jkube.watch.postGoal property/parameter/configuration is ignored
 * Fix #384: Enricher defined Container environment variables get merged with vars defined in Image Build Configuration
+* Fix #386: final fat jar is not updated in docker build directory
 * Fix #385: WildFly Bootable JAR - Add native support for slim Bootable JAR
 * Fix #415: Fixed resource validation for new json-schema-validator version
 * Fix #356: Add further support for tls termination and insecureEdgeTerminationPolicy in pom.xml

--- a/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/JKubeBuildTarArchiver.java
+++ b/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/JKubeBuildTarArchiver.java
@@ -61,17 +61,15 @@ public class JKubeBuildTarArchiver {
                     FileUtil.createDirectory(new File(inputDirectory, parentDirectory.getPath()));
                 }
                 File targetFile = new File(inputDirectory, targetFileName);
-                // Check whether file is not already created.
-                if (!targetFile.exists()) {
-                    FileUtils.copyFile(srcFile, targetFile);
+                if (!srcFile.equals(targetFile)) {
+                    FileUtil.copy(srcFile, targetFile);
                     files.add(targetFile);
                 }
             }
         }
 
         List<File> fileListToAddInTarball = new ArrayList<>();
-        for (int i = 0; i < files.size(); i++) {
-            File currentFile = files.get(i);
+        for (File currentFile : files) {
             if (filesNamesToExclude.contains(currentFile.getName())) {
                 continue;
             }
@@ -80,5 +78,4 @@ public class JKubeBuildTarArchiver {
 
         return JKubeTarArchiver.createTarBall(outputFile, inputDirectory, fileListToAddInTarball, fileModeMap, compression);
     }
-
 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeEnricher.java
@@ -77,6 +77,7 @@ public class ContainerEnvJavaOptionsMergeEnricher extends BaseEnricher {
     public void visit(ContainerBuilder containerBuilder) {
       imageConfigurations.stream()
           .filter(ic -> ImageEnricher.containerImageName(ic).equals(containerBuilder.getImage()))
+          .filter(ic -> ic.getBuild().getEnv() != null)
           .filter(ic -> !ic.getBuild().getEnv().isEmpty())
           .filter(ic -> ic.getBuild().getEnv().containsKey(ENV_KEY))
           .findFirst()

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeTest.java
@@ -104,6 +104,24 @@ public class ContainerEnvJavaOptionsMergeTest {
         .containsOnly(new EnvVar("JAVA_OPTIONS", "val-from-container", null));
   }
 
+  @Test
+  public void enrichWithNullEnvInImageConfiguration() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      imageConfiguration.getName(); result = "the-image:latest"; minTimes = 0;
+      imageConfiguration.getBuild().getEnv(); result = null;
+    }};
+    // @formatter:on
+    // When
+    containerEnvJavaOptionsMergeEnricher.enrich(PlatformMode.kubernetes, kubernetesListBuilder);
+    // Then
+    assertThat(containerList(kubernetesListBuilder))
+            .flatExtracting("env")
+            .hasSize(1)
+            .containsOnly(new EnvVar("JAVA_OPTIONS", "val-from-container", null));
+  }
+
   static List<Container> containerList(KubernetesListBuilder kubernetesListBuilder) {
     return kubernetesListBuilder.build().getItems().stream()
         .map(Deployment.class::cast)


### PR DESCRIPTION
Fix #386 
Updated code in JKubeBuildTarArchiver to allow copying files when already existing.

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->