### PR TITLE
fix: Valid content type for REST docker API requests with body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.0.2-SNAPSHOT
-* Fix: Added quickstart for Micronaut framework
+* Fix 429: Added quickstart for Micronaut framework
 * Fix #370: Replacing anonymous Runnables with lambdas in WatchService
+* Fix 440: Added quickstart for MicroProfile running on OpenLiberty
+* Fix: Valid content type for REST docker API requests with body
 
 ### 1.0.1 (2020-10-05)
 * Fix #381: Remove root as default user in AssemblyConfigurationUtils#getAssemblyConfigurationOrCreateDefault

--- a/jkube-kit/build/service/docker/pom.xml
+++ b/jkube-kit/build/service/docker/pom.xml
@@ -69,6 +69,10 @@
       <artifactId>jmockit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
     </dependency>

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/ApacheHttpClientDelegate.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/ApacheHttpClientDelegate.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.kit.build.service.docker.access.hc;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -68,8 +69,7 @@ public class ApacheHttpClientDelegate {
 
     public static class StatusCodeResponseHandler implements ResponseHandler<Integer> {
         @Override
-        public Integer handleResponse(HttpResponse response)
-            throws IOException {
+        public Integer handleResponse(HttpResponse response) {
             return response.getStatusLine().getStatusCode();
         }
 
@@ -134,31 +134,35 @@ public class ApacheHttpClientDelegate {
 
     // =========================================================================================
 
-    private HttpUriRequest addDefaultHeaders(HttpUriRequest req) {
+    private HttpUriRequest addDefaultHeaders(HttpUriRequest req, Object body) {
         req.addHeader(HttpHeaders.ACCEPT, "*/*");
-        req.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        if (body instanceof File) {
+            req.addHeader(HttpHeaders.CONTENT_TYPE, URLConnection.guessContentTypeFromName(((File)body).getName()));
+        }
+        if (body != null && !req.containsHeader(HttpHeaders.CONTENT_TYPE)) {
+            req.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        }
         return req;
     }
 
-
     private HttpUriRequest newDelete(String url) {
-        return addDefaultHeaders(new HttpDelete(url));
+        return addDefaultHeaders(new HttpDelete(url), null);
     }
 
     private HttpUriRequest newGet(String url) {
-        return addDefaultHeaders(new HttpGet(url));
+        return addDefaultHeaders(new HttpGet(url), null);
     }
 
     private HttpUriRequest newPut(String url, Object body) {
         HttpPut put = new HttpPut(url);
         setEntityIfGiven(put, body);
-        return addDefaultHeaders(put);
+        return addDefaultHeaders(put, body);
     }
 
     private HttpUriRequest newPost(String url, Object body) {
         HttpPost post = new HttpPost(url);
         setEntityIfGiven(post, body);
-        return addDefaultHeaders(post);
+        return addDefaultHeaders(post, body);
     }
 
 

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/ApacheHttpClientDelegateTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/ApacheHttpClientDelegateTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.service.docker.access.hc;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.function.BiConsumer;
+
+import org.eclipse.jkube.kit.build.service.docker.access.hc.util.ClientBuilder;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.assertj.core.groups.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings({"rawtypes", "unused"})
+public class ApacheHttpClientDelegateTest {
+
+  @Mocked
+  private ClientBuilder clientBuilder;
+  @Mocked
+  private CloseableHttpClient httpClient;
+
+  private ApacheHttpClientDelegate apacheHttpClientDelegate;
+
+  @Before
+  public void setUp() throws Exception {
+    // @formatter:off
+    new Expectations() {{
+      clientBuilder.buildBasicClient(); result = httpClient;
+    }};
+    // @formatter:on
+    apacheHttpClientDelegate = new ApacheHttpClientDelegate(clientBuilder, false);
+  }
+
+  @Test
+  public void createBasicClient() {
+    final CloseableHttpClient result = apacheHttpClientDelegate.createBasicClient();
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  public void delete() throws IOException {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      httpClient.execute((HttpUriRequest) any, (ResponseHandler) any); result = 1337;
+    }};
+    // @formatter:on
+    // When
+    final int result = apacheHttpClientDelegate.delete("http://example.com");
+    // Then
+    assertThat(result).isEqualTo(1337);
+    verifyHttpClientExecute((request, responseHandler) ->
+      assertThat(request.getAllHeaders())
+          .hasSize(1)
+          .extracting("name", "value")
+          .containsOnly(new Tuple("Accept", "*/*"))
+    );
+  }
+
+  @Test
+  public void get() throws IOException {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      httpClient.execute((HttpUriRequest) any, (ResponseHandler) any); result = "Response";
+    }};
+    // @formatter:on
+    // When
+    final String response = apacheHttpClientDelegate.get("http://example.com");
+    // Then
+    assertThat(response).isEqualTo("Response");
+    verifyHttpClientExecute((request, responseHandler) ->{
+      assertThat(request.getAllHeaders())
+          .hasSize(1)
+          .extracting("name", "value")
+          .containsOnly(new Tuple("Accept", "*/*"));
+      assertThat(responseHandler)
+          .extracting("delegate")
+          .hasSize(1)
+          .hasOnlyElementsOfType(ApacheHttpClientDelegate.BodyResponseHandler.class);
+    });
+  }
+
+  @Test
+  public void postWithStringBody() throws IOException {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      httpClient.execute((HttpUriRequest) any, (ResponseHandler) any); result = "Response";
+    }};
+    // @formatter:on
+    // When
+    final String response = apacheHttpClientDelegate.post(
+        "http://example.com", "{body}", Collections.singletonMap("EXTRA", "HEADER"), null);
+    // Then
+    assertThat(response).isEqualTo("Response");
+    verifyHttpClientExecute((request, responseHandler) ->
+      assertThat(request.getAllHeaders())
+          .hasSize(3)
+          .extracting("name", "value")
+          .containsOnly(
+              new Tuple("Accept", "*/*"),
+              new Tuple("Content-Type", "application/json"),
+              new Tuple("EXTRA", "HEADER"))
+    );
+  }
+
+  @Test
+  public void postWithFileBody() throws IOException {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      httpClient.execute((HttpUriRequest) any, (ResponseHandler) any); result = "Response";
+    }};
+    // @formatter:on
+    // When
+    final String response = apacheHttpClientDelegate.post(
+        "http://example.com", new File("fake-file.tar"), null);
+    // Then
+    assertThat(response).isEqualTo("Response");
+    verifyHttpClientExecute((request, responseHandler) ->
+      assertThat(request.getAllHeaders())
+          .hasSize(2)
+          .extracting("name", "value")
+          .containsOnly(
+              new Tuple("Accept", "*/*"),
+              new Tuple("Content-Type", "application/x-tar"))
+    );
+  }
+
+  private <H extends ResponseHandler> void verifyHttpClientExecute(BiConsumer<HttpUriRequest, H> consumer) throws IOException {
+    // @formatter:off
+    new Verifications() {{
+      HttpUriRequest request;
+      H responseHandler;
+      httpClient.execute(request = withCapture(), responseHandler = withCapture());
+      consumer.accept(request, responseHandler);
+    }};
+    // @formatter:on
+  }
+
+}


### PR DESCRIPTION
## Description
fix: Valid content type for REST docker API requests with body

Relates to: #66 (https://github.com/eclipse/jkube/issues/66#issuecomment-712732571)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [ ] ~~I tested my code in OpenShift~~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->