### PR TITLE
fix: Removed misleading watch-postGoal warning + fixed rolling update in DockerImageWatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,13 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.0.2-SNAPSHOT
-* Fix 429: Added quickstart for Micronaut framework
+* Fix #429: Added quickstart for Micronaut framework
 * Fix #370: Replacing anonymous Runnables with lambdas in WatchService
-* Fix 440: Added quickstart for MicroProfile running on OpenLiberty
-* Fix: Valid content type for REST docker API requests with body
+* Fix #440: Added quickstart for MicroProfile running on OpenLiberty
+* Fix #442: Valid content type for REST docker API requests with body
 * Fix #448: Service.spec.type added from config if existing Service fragment doesn't specify it
-* Fix: Docker push works with Podman REST API
+* Fix #451: Docker push works with Podman REST API
+* Fix: Removed misleading watch-postGoal warning + fixed rolling update in DockerImageWatcher
 
 ### 1.0.1 (2020-10-05)
 * Fix #381: Remove root as default user in AssemblyConfigurationUtils#getAssemblyConfigurationOrCreateDefault

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/WatchService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/WatchService.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BooleanSupplier;
 
 import org.eclipse.jkube.kit.build.api.assembly.AssemblyFiles;
 import org.eclipse.jkube.kit.build.service.docker.access.PortMapping;
@@ -201,13 +200,7 @@ public class WatchService {
 
 
     private void callPostGoal(ImageWatcher watcher) {
-        BooleanSupplier postGoalTask = watcher.getWatchContext().getPostGoalTask();
-        if (postGoalTask != null) {
-            boolean postGoalStatus = postGoalTask.getAsBoolean();
-            if (!postGoalStatus) {
-                log.warn("Unable to run postGoal task");
-            }
-        }
+        Optional.ofNullable(watcher.getWatchContext().getPostGoalTask()).ifPresent(Runnable::run);
     }
 
     private Runnable createRestartWatchTask(final ImageWatcher watcher) {

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/watch/WatchContext.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/watch/WatchContext.java
@@ -15,7 +15,6 @@ package org.eclipse.jkube.kit.build.service.docker.watch;
 
 import java.io.Serializable;
 import java.util.Date;
-import java.util.function.BooleanSupplier;
 
 import org.eclipse.jkube.kit.build.core.GavLabel;
 import org.eclipse.jkube.kit.build.service.docker.ServiceHub;
@@ -60,7 +59,7 @@ public class WatchContext implements Serializable {
   private transient ServiceHub hub;
   private transient ServiceHubFactory serviceHubFactory;
   private transient LogDispatcher dispatcher;
-  private transient BooleanSupplier postGoalTask;
+  private transient Runnable postGoalTask;
 
   private boolean follow;
   private String showLogs;

--- a/jkube-kit/common-maven/src/main/java/org/eclipse/jkube/kit/common/util/MavenUtil.java
+++ b/jkube-kit/common-maven/src/main/java/org/eclipse/jkube/kit/common/util/MavenUtil.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.Dependency;
+import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.Plugin;
 import org.eclipse.jkube.kit.common.RegistryServerConfiguration;
 
@@ -420,13 +421,14 @@ public class MavenUtil {
         return builder.build();
     }
 
-    public static boolean callMavenPluginWithGoal(MavenProject project, MavenSession session, BuildPluginManager pluginManager, String mavenPluginGoal) {
+    public static void callMavenPluginWithGoal(
+        MavenProject project, MavenSession session, BuildPluginManager pluginManager, String mavenPluginGoal, KitLogger log) {
+
         if (mavenPluginGoal != null) {
+            log.info("Calling %s Maven Goal", mavenPluginGoal);
             MojoExecutionService mojoExecutionService = new MojoExecutionService(project, session, pluginManager);
             mojoExecutionService.callPluginGoal(mavenPluginGoal);
-            return true;
         }
-        return false;
     }
 }
 

--- a/jkube-kit/common-maven/src/test/java/org/eclipse/jkube/kit/common/util/MavenUtilTest.java
+++ b/jkube-kit/common-maven/src/test/java/org/eclipse/jkube/kit/common/util/MavenUtilTest.java
@@ -32,6 +32,7 @@ import org.apache.maven.plugin.PluginConfigurationException;
 import org.apache.maven.plugin.PluginManagerException;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.Dependency;
+import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.Plugin;
 
 import mockit.Expectations;
@@ -60,11 +61,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class MavenUtilTest {
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Mocked
+  private KitLogger log;
 
   @Test
   public void testJKubeProjectConversion() throws DependencyResolutionRequiredException {
@@ -212,10 +214,9 @@ public class MavenUtilTest {
         MavenSession mavenSession = getMavenSession();
 
         // When
-        boolean result = MavenUtil.callMavenPluginWithGoal(mavenProject, mavenSession, pluginManager, "org.apache.maven.plugins:maven-help-plugin:help");
+        MavenUtil.callMavenPluginWithGoal(mavenProject, mavenSession, pluginManager, "org.apache.maven.plugins:maven-help-plugin:help", log);
 
         // Then
-        assertTrue(result);
         new Verifications() {{
             pluginManager.executeMojo(mavenSession, (MojoExecution)any);
             times = 1;

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
@@ -145,38 +145,33 @@ public class DockerImageWatcher extends BaseWatcher {
         if (entity instanceof Deployment) {
             Deployment resource = (Deployment) entity;
             DeploymentSpec spec = resource.getSpec();
-            if (spec != null) {
-                if (updateImageName(entity, spec.getTemplate(), imagePrefix, imageName)) {
-                    kubernetes.apps().deployments().inNamespace(namespace).withName(name).replace(resource);
-                }
+            if (spec != null && updateImageName(entity, spec.getTemplate(), imagePrefix, imageName)) {
+                kubernetes.apps().deployments().inNamespace(namespace).withName(name).replace(resource);
+                kubernetes.apps().deployments().inNamespace(namespace).withName(name).rolling().restart();
             }
         } else if (entity instanceof ReplicaSet) {
             ReplicaSet resource = (ReplicaSet) entity;
             ReplicaSetSpec spec = resource.getSpec();
-            if (spec != null) {
-                if (updateImageName(entity, spec.getTemplate(), imagePrefix, imageName)) {
-                    kubernetes.apps().replicaSets().inNamespace(namespace).withName(name).replace(resource);
-                }
+            if (spec != null && updateImageName(entity, spec.getTemplate(), imagePrefix, imageName)) {
+                kubernetes.apps().replicaSets().inNamespace(namespace).withName(name).replace(resource);
+                kubernetes.apps().replicaSets().inNamespace(namespace).withName(name).rolling().restart();
             }
         } else if (entity instanceof ReplicationController) {
             ReplicationController resource = (ReplicationController) entity;
             ReplicationControllerSpec spec = resource.getSpec();
-            if (spec != null) {
-                if (updateImageName(entity, spec.getTemplate(), imagePrefix, imageName)) {
-                    kubernetes.replicationControllers().inNamespace(namespace).withName(name).replace(resource);
-                }
+            if (spec != null && updateImageName(entity, spec.getTemplate(), imagePrefix, imageName)) {
+                kubernetes.replicationControllers().inNamespace(namespace).withName(name).replace(resource);
+                kubernetes.replicationControllers().inNamespace(namespace).withName(name).rolling().restart();
             }
         } else if (entity instanceof DeploymentConfig) {
             DeploymentConfig resource = (DeploymentConfig) entity;
             DeploymentConfigSpec spec = resource.getSpec();
-            if (spec != null) {
-                if (updateImageName(entity, spec.getTemplate(), imagePrefix, imageName)) {
-                    OpenShiftClient openshiftClient = OpenshiftHelper.asOpenShiftClient(kubernetes);
-                    if (openshiftClient == null) {
-                        log.warn("Ignoring DeploymentConfig %s as not connected to an OpenShift cluster", name);
-                    } else {
-                        openshiftClient.deploymentConfigs().inNamespace(namespace).withName(name).replace(resource);
-                    }
+            if (spec != null && updateImageName(entity, spec.getTemplate(), imagePrefix, imageName)) {
+                OpenShiftClient openshiftClient = OpenshiftHelper.asOpenShiftClient(kubernetes);
+                if (openshiftClient == null) {
+                    log.warn("Ignoring DeploymentConfig %s as not connected to an OpenShift cluster", name);
+                } else {
+                    openshiftClient.deploymentConfigs().inNamespace(namespace).withName(name).replace(resource);
                 }
             }
         }

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
@@ -175,7 +175,7 @@ public class WatchMojo extends AbstractDockerMojo implements ManifestProvider {
                 .serviceHubFactory(serviceHubFactory)
                 .hub(hub)
                 .dispatcher(getLogDispatcher(hub))
-                .postGoalTask(() -> MavenUtil.callMavenPluginWithGoal(project, session, pluginManager, watchPostGoal))
+                .postGoalTask(() -> MavenUtil.callMavenPluginWithGoal(project, session, pluginManager, watchPostGoal, log))
                 .build();
     }
 


### PR DESCRIPTION
## Description

fix: Removed misleading watch-postGoal warning + fixed rolling update in DockerImageWatcher

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] ~~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~~
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [ ] ~~I tested my code in OpenShift~~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->