### PR TITLE
fix: Service.spec.type added from config if existing Service fragment doesn't specify it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Usage:
 * Fix #370: Replacing anonymous Runnables with lambdas in WatchService
 * Fix 440: Added quickstart for MicroProfile running on OpenLiberty
 * Fix: Valid content type for REST docker API requests with body
+* Fix #448: Service.spec.type added from config if existing Service fragment doesn't specify it
 
 ### 1.0.1 (2020-10-05)
 * Fix #381: Remove root as default user in AssemblyConfigurationUtils#getAssemblyConfigurationOrCreateDefault

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.enricher.generic;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
+
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.assertj.core.groups.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings({"unused", "ResultOfMethodCallIgnored"})
+public class DefaultServiceEnricherAddMissingPartsTest {
+
+  @Mocked
+  private JKubeEnricherContext context;
+
+  private Properties properties;
+  private List<ImageConfiguration> images;
+  private DefaultServiceEnricher enricher;
+
+  @Before
+  public void setUp() {
+    properties = new Properties();
+    images = new ArrayList<>();
+    images.add(ImageConfiguration.builder()
+        .name("test-image")
+        .build(new BuildConfiguration())
+        .build());
+    // @formatter:off
+    new Expectations() {{
+      context.getProperties(); result = properties;
+      context.getConfiguration().getImages(); result = images;
+      context.getGav().getSanitizedArtifactId(); result = "artifact-id";
+    }};
+    // @formatter:on
+    enricher = new DefaultServiceEnricher(context);
+  }
+
+  @Test
+  public void defaultValuesAndEmptyOriginal() {
+    // Given
+    imageConfigurationWithPort("80");
+    final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(
+        new ServiceBuilder().build());
+    // When
+    enricher.create(null, klb);
+    // Then
+    assertThat(klb.buildItem(0))
+        .isInstanceOf(Service.class)
+        .hasFieldOrPropertyWithValue("spec.type", null)
+        .extracting("spec")
+        .flatExtracting("ports")
+        .extracting("name", "port", "protocol")
+        .containsOnly(new Tuple("http", 80, "TCP"));
+  }
+
+  @Test
+  public void defaultValuesAndOriginalWithPorts() {
+    // Given
+    imageConfigurationWithPort("80");
+    final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(
+        new ServiceBuilder().editOrNewSpec().addNewPort()
+            .withName("iana-replaced").withProtocol("TCP").withPort(1337).endPort().endSpec().build());
+    // When
+    enricher.create(null, klb);
+    // Then
+    assertThat(klb.buildItem(0))
+        .isInstanceOf(Service.class)
+        .hasFieldOrPropertyWithValue("spec.type", null)
+        .extracting("spec")
+        .flatExtracting("ports")
+        .extracting("name", "port", "protocol")
+        .containsOnly(new Tuple("menandmice-dns", 1337, "TCP"));
+  }
+
+  @Test
+  public void configuredTypeAndOriginalWithNoType() {
+    // Given
+    imageConfigurationWithPort("80");
+    final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(
+        new ServiceBuilder().editOrNewSpec().withClusterIP("1.3.3.7").endSpec().build());
+    properties.put("jkube.enricher.jkube-service.type", "NodePort");
+    // When
+    enricher.create(null, klb);
+    // Then
+    assertThat(klb.buildItem(0))
+        .isInstanceOf(Service.class)
+        .hasFieldOrPropertyWithValue("spec.clusterIP", "1.3.3.7")
+        .hasFieldOrPropertyWithValue("spec.type", "NodePort");
+  }
+
+  @Test
+  public void configuredTypeAndOriginalWithType() {
+    // Given
+    imageConfigurationWithPort("80");
+    final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(
+        new ServiceBuilder().editOrNewSpec().withType("LoadBalancer").endSpec().build());
+    properties.put("jkube.enricher.jkube-service.type", "NodePort");
+    // When
+    enricher.create(null, klb);
+    // Then
+    assertThat(klb.buildItem(0))
+        .isInstanceOf(Service.class)
+        .hasFieldOrPropertyWithValue("spec.type", "LoadBalancer");
+  }
+
+  @Test
+  public void configuredHeadlessAndOriginalWithNoClusterIP() {
+    // Given
+    properties.put("jkube.enricher.jkube-service.headless", "true");
+    final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(
+        new ServiceBuilder().editOrNewSpec().withType("LoadBalancer").endSpec().build());
+    // When
+    enricher.create(null, klb);
+    // Then
+    assertThat(klb.buildItem(0))
+        .isInstanceOf(Service.class)
+        .hasFieldOrPropertyWithValue("spec.clusterIP", "None");
+  }
+
+  @Test
+  public void configuredHeadlessAndOriginalWithClusterIP() {
+    // Given
+    properties.put("jkube.enricher.jkube-service.headless", "true");
+    final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(
+        new ServiceBuilder().editOrNewSpec().withClusterIP("1.3.3.7").endSpec().build());
+    // When
+    enricher.create(null, klb);
+    // Then
+    assertThat(klb.buildItem(0))
+        .isInstanceOf(Service.class)
+        .hasFieldOrPropertyWithValue("spec.clusterIP", "1.3.3.7");
+  }
+
+  private void imageConfigurationWithPort(String... ports) {
+    images.get(0).setBuild(BuildConfiguration.builder().ports(Arrays.asList(ports)).build());
+  }
+}


### PR DESCRIPTION
## Description

fix #448 : Service.spec.type added from config if existing Service fragment doesn't specify it

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->