### PR TITLE
Fix CustomResource apply logic, should consider Kind too while checking CustomResourceDefinitionContext

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -84,6 +84,7 @@ import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.api.model.HasMetadataComparator;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.DeploymentConfig;
@@ -882,12 +883,15 @@ public class KubernetesHelper {
             if (file.getName().endsWith("cr.yml") || file.getName().endsWith("cr.yaml")) {
                 Map<String, Object> customResource = unmarshalCustomResourceFile(file);
                 String apiVersion = customResource.get("apiVersion").toString();
-                if (apiVersion.contains("/")) {
-                    fileToCrdGroupMap.put(file, apiVersion.split("/")[0]);
-                }
+                String kind = customResource.get("kind").toString();
+                fileToCrdGroupMap.put(file, apiVersion + "#" + kind);
             }
         }
         return fileToCrdGroupMap;
+    }
+
+    public static String getFullyQualifiedApiGroupWithKind(CustomResourceDefinitionContext crdContext) {
+        return crdContext.getGroup() + "/" + crdContext.getVersion() + "#" + crdContext.getKind();
     }
 
     public static String getNewestApplicationPodName(KubernetesClient client, String namespace, Set<HasMetadata> resources) {

--- a/jkube-kit/common/src/test/resources/crontab-cr.yml
+++ b/jkube-kit/common/src/test/resources/crontab-cr.yml
@@ -1,0 +1,7 @@
+apiVersion: "stable.example.com/v1"
+kind: CronTab
+metadata:
+  name: my-new-cron-object
+spec:
+  cronSpec: "* * * * */5"
+  image: my-awesome-cron-image

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesClientUtil.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesClientUtil.java
@@ -293,6 +293,7 @@ public class KubernetesClientUtil {
                         .withPlural(customResourceDefinition.getSpec().getNames().getPlural())
                         .withVersion(customResourceDefinition.getSpec().getVersion())
                         .withScope(customResourceDefinition.getSpec().getScope())
+                        .withKind(customResourceDefinition.getSpec().getNames().getKind())
                         .build());
             }
         }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
@@ -98,7 +98,7 @@ public class KubernetesUndeployService implements UndeployService {
 
     for(CustomResourceDefinitionContext customResourceDefinitionContext : crdContexts) {
       for(Map.Entry<File, String> entry : fileToCrdMap.entrySet()) {
-        if(entry.getValue().equals(customResourceDefinitionContext.getGroup())) {
+        if(entry.getValue().equals(KubernetesHelper.getFullyQualifiedApiGroupWithKind(customResourceDefinitionContext))) {
             deleteCustomResource(entry.getKey(), namespace, customResourceDefinitionContext);
         }
       }
@@ -121,7 +121,7 @@ public class KubernetesUndeployService implements UndeployService {
     Map<String, Object> customResource = unmarshalCustomResourceFile(customResourceFile);
     Map<String, Object> objectMeta = (Map<String, Object>)customResource.get("metadata");
     String name = objectMeta.get("name").toString();
-    logger.info("Deleting Custom Resource %s", name);
+    logger.info("Deleting Custom Resource %s %s", KubernetesHelper.getFullyQualifiedApiGroupWithKind(crdContext), name);
     KubernetesClientUtil.doDeleteCustomResource(jKubeServiceHub.getClient(), crdContext, namespace, name);
   }
 

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.jkube.kit.config.service;
 
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
@@ -23,7 +25,14 @@ import org.eclipse.jkube.kit.config.service.openshift.WebServerEventCollector;
 import org.junit.Before;
 import org.junit.Test;
 
-import static java.net.HttpURLConnection.*;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.Assert.assertEquals;
 
 public class ApplyServiceTest {
@@ -31,7 +40,7 @@ public class ApplyServiceTest {
     @Mocked
     private KitLogger log;
 
-    private OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
+    private final OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
 
     private ApplyService applyService;
 
@@ -122,6 +131,136 @@ public class ApplyServiceTest {
         assertEquals(2, mockServer.getRequestCount());
     }
 
+    @Test
+    public void testProcessCustomEntities() throws Exception {
+        // Given
+        List<String> crdNames = new ArrayList<>();
+        crdNames.add("virtualservices.networking.istio.io");
+        crdNames.add("gateways.networking.istio.io");
+        File crFragmentDir = new File(getClass().getResource("/gateway-cr.yml").getFile()).getParentFile();
+        WebServerEventCollector<OpenShiftMockServer> collector = new WebServerEventCollector<>(mockServer);
+        mockServer.expect().get()
+                .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/virtualservices.networking.istio.io")
+                .andReply(collector.record("get-crd-virtualservice").andReturn(HTTP_OK, getVirtualServiceIstioCRD()))
+                .always();
+        mockServer.expect().get()
+                .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/gateways.networking.istio.io")
+                .andReply(collector.record("get-crd-gateway").andReturn(HTTP_OK, getGatewayIstioCRD()))
+                .always();
+        mockServer.expect().post()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/virtualservices")
+                .andReply(collector.record("post-cr-virtualservice").andReturn(HTTP_OK, "{}"))
+                .once();
+        mockServer.expect().post()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/gateways")
+                .andReply(collector.record("post-cr-gateway").andReturn(HTTP_OK, "{}"))
+                .once();
+
+        // When
+        applyService.processCustomEntities(crdNames, crFragmentDir, null, Collections.emptyList());
+
+        // Then
+        collector.assertEventsRecordedInOrder("get-crd-virtualservice", "get-crd-gateway", "post-cr-virtualservice", "post-cr-gateway");
+        assertEquals(7, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testProcessCustomEntitiesReplaceCustomResources() throws Exception {
+        // Given
+        List<String> crdNames = new ArrayList<>();
+        crdNames.add("virtualservices.networking.istio.io");
+        crdNames.add("gateways.networking.istio.io");
+        File crFragmentDir = new File(getClass().getResource("/gateway-cr.yml").getFile()).getParentFile();
+        WebServerEventCollector<OpenShiftMockServer> collector = new WebServerEventCollector<>(mockServer);
+        mockServer.expect().get()
+                .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/virtualservices.networking.istio.io")
+                .andReply(collector.record("get-crd-virtualservice").andReturn(HTTP_OK, getVirtualServiceIstioCRD()))
+                .always();
+        mockServer.expect().get()
+                .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/gateways.networking.istio.io")
+                .andReply(collector.record("get-crd-gateway").andReturn(HTTP_OK, getGatewayIstioCRD()))
+                .always();
+        mockServer.expect().get()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/virtualservices/reviews-route")
+                .andReply(collector.record("get-cr-virtualservice").andReturn(HTTP_OK, "{}"))
+                .once();
+        mockServer.expect().put()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/virtualservices/reviews-route")
+                .andReply(collector.record("put-cr-virtualservice").andReturn(HTTP_OK, "{}"))
+                .once();
+        mockServer.expect().get()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/gateways/mygateway-https")
+                .andReply(collector.record("get-cr-gateway").andReturn(HTTP_OK, "{}"))
+                .once();
+        mockServer.expect().put()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/gateways/mygateway-https")
+                .andReply(collector.record("put-cr-gateway").andReturn(HTTP_OK, "{}"))
+                .once();
+
+        // When
+        applyService.processCustomEntities(crdNames, crFragmentDir, null, Collections.emptyList());
+
+        // Then
+        collector.assertEventsRecordedInOrder("get-crd-virtualservice", "get-crd-gateway", "get-cr-virtualservice", "put-cr-virtualservice", "get-cr-gateway", "put-cr-gateway");
+        assertEquals(7, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testProcessCustomEntitiesRecreateModeTrue() throws Exception {
+        // Given
+        List<String> crdNames = new ArrayList<>();
+        crdNames.add("virtualservices.networking.istio.io");
+        crdNames.add("gateways.networking.istio.io");
+        File crFragmentDir = new File(getClass().getResource("/gateway-cr.yml").getFile()).getParentFile();
+        WebServerEventCollector<OpenShiftMockServer> collector = new WebServerEventCollector<>(mockServer);
+        mockServer.expect().get()
+                .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/virtualservices.networking.istio.io")
+                .andReply(collector.record("get-crd-virtualservice").andReturn(HTTP_OK, getVirtualServiceIstioCRD()))
+                .always();
+        mockServer.expect().get()
+                .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/gateways.networking.istio.io")
+                .andReply(collector.record("get-crd-gateway").andReturn(HTTP_OK, getGatewayIstioCRD()))
+                .always();
+        mockServer.expect().delete()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/virtualservices/reviews-route")
+                .andReply(collector.record("delete-cr-virtualservice").andReturn(HTTP_OK, "{}"))
+                .once();
+        mockServer.expect().delete()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/gateways/mygateway-https")
+                .andReply(collector.record("delete-cr-gateway").andReturn(HTTP_OK, "{}"))
+                .once();
+        mockServer.expect().post()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/virtualservices")
+                .andReply(collector.record("post-cr-virtualservice").andReturn(HTTP_OK, "{}"))
+                .once();
+        mockServer.expect().post()
+                .withPath("/apis/networking.istio.io/v1alpha3/namespaces/default/gateways")
+                .andReply(collector.record("post-cr-gateway").andReturn(HTTP_OK, "{}"))
+                .once();
+        applyService.setRecreateMode(true);
+
+        // When
+        applyService.processCustomEntities(crdNames, crFragmentDir, null, Collections.emptyList());
+        applyService.setRecreateMode(false);
+
+        // Then
+        collector.assertEventsRecordedInOrder("get-crd-virtualservice", "get-crd-gateway",
+                "delete-cr-virtualservice", "post-cr-virtualservice", "delete-cr-gateway", "post-cr-gateway");
+        assertEquals(7, mockServer.getRequestCount());
+    }
+
+    @Test
+    public void testProcessCustomEntitiesWithNullCustomResourceList() throws Exception {
+        // Given
+        File crFragmentDir = new File(getClass().getResource("/gateway-cr.yml").getFile()).getParentFile();
+
+        // When
+        applyService.processCustomEntities(null, crFragmentDir, null, Collections.emptyList());
+
+        // Then
+        assertEquals(1, mockServer.getRequestCount()); // This one is just /apis check
+    }
+
     private Route buildRoute() {
         return new RouteBuilder()
                 .withNewMetadata()
@@ -134,6 +273,36 @@ public class ApplyServiceTest {
                         .withKind("Service")
                         .withName("frontend")
                     .endTo()
+                .endSpec()
+                .build();
+    }
+
+    private CustomResourceDefinition getVirtualServiceIstioCRD() {
+        return new CustomResourceDefinitionBuilder()
+                .withNewMetadata().withName("virtualservices.networking.istio.io").endMetadata()
+                .withNewSpec()
+                .withGroup("networking.istio.io")
+                .withVersion("v1alpha3")
+                .withNewNames()
+                .withKind("VirtualService")
+                .withPlural("virtualservices")
+                .endNames()
+                .withScope("Namespaced")
+                .endSpec()
+                .build();
+    }
+
+    private CustomResourceDefinition getGatewayIstioCRD() {
+        return new CustomResourceDefinitionBuilder()
+                .withNewMetadata().withName("gateways.networking.istio.io").endMetadata()
+                .withNewSpec()
+                .withGroup("networking.istio.io")
+                .withVersion("v1alpha3")
+                .withNewNames()
+                .withKind("Gateway")
+                .withPlural("gateways")
+                .endNames()
+                .withScope("Namespaced")
                 .endSpec()
                 .build();
     }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
@@ -115,11 +115,15 @@ public class KubernetesUndeployServiceTest {
     // Given
     final File manifest = temporaryFolder.newFile("temp.yml");
     final File crManifest = temporaryFolder.newFile("temp-cr.yml");
-    final String crdId = "crd";
+    final String crdId = "org.eclipse.jkube/v1alpha1#Crd";
     final Service service = new Service();
     final CustomResourceDefinition crd = new CustomResourceDefinitionBuilder()
         .withNewMetadata().withName(crdId).endMetadata()
-        .withNewSpec().withGroup(crdId).withNewNames().endNames().endSpec()
+        .withNewSpec().withGroup("org.eclipse.jkube").withVersion("v1alpha1").withScope("Cluster")
+            .withNewNames()
+            .withKind("Crd")
+            .withPlural("crds")
+            .endNames().endSpec()
         .withKind(crdId).build();
     // @formatter:off
     new Expectations() {{
@@ -130,6 +134,8 @@ public class KubernetesUndeployServiceTest {
       result = Collections.singletonMap(crManifest, crdId);
       kubernetesHelper.unmarshalCustomResourceFile(crManifest);
       result = Collections.singletonMap("metadata", Collections.singletonMap("name", "my-cr"));
+      kubernetesHelper.getFullyQualifiedApiGroupWithKind((CustomResourceDefinitionContext)any);
+      result = crdId;
     }};
     // @formatter:on
     // When

--- a/jkube-kit/config/service/src/test/resources/gateway-cr.yml
+++ b/jkube-kit/config/service/src/test/resources/gateway-cr.yml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: mygateway-https
+spec:
+  selector:
+    istio: ingressgateway # use istio default ingress gateway
+  servers:
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: minibin-credential # must be the same as secret
+      hosts:
+        - mini.example.com

--- a/jkube-kit/config/service/src/test/resources/virtualservice-cr.yml
+++ b/jkube-kit/config/service/src/test/resources/virtualservice-cr.yml
@@ -1,0 +1,25 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+    - reviews.prod.svc.cluster.local
+  http:
+    - name: "reviews-v2-routes"
+      match:
+        - uri:
+            prefix: "/wpcatalog"
+        - uri:
+            prefix: "/consumercatalog"
+      rewrite:
+        uri: "/newcatalog"
+      route:
+        - destination:
+            host: reviews.prod.svc.cluster.local
+            subset: v2
+    - name: "reviews-v1-route"
+      route:
+        - destination:
+            host: reviews.prod.svc.cluster.local
+            subset: v1


### PR DESCRIPTION
While testing #427 , I found out that ApplyMojo is not able to handle the case when there
is more than one CustomResource present with same ApiGroup and ApiVersion but different Kinds.
We should also consider Kind while comparing CustomResourceDefinitionContexts, not just
groups.

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->