### PR TITLE
chore: Upgrade assertj-core to 3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.1.0-SNAPSHOT
+* Fix #467: Upgrade assertj-core to 3.18.0
 
 ### 1.0.2 (2020-10-30)
 * Fix #429: Added quickstart for Micronaut framework

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/ApacheHttpClientDelegateTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/ApacheHttpClientDelegateTest.java
@@ -97,8 +97,7 @@ public class ApacheHttpClientDelegateTest {
           .containsOnly(new Tuple("Accept", "*/*"));
       assertThat(responseHandler)
           .extracting("delegate")
-          .hasSize(1)
-          .hasOnlyElementsOfType(ApacheHttpClientDelegate.BodyResponseHandler.class);
+          .isInstanceOf(ApacheHttpClientDelegate.BodyResponseHandler.class);
     });
   }
 

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
@@ -73,8 +73,8 @@ public class DefaultServiceEnricherAddMissingPartsTest {
     assertThat(klb.buildItem(0))
         .isInstanceOf(Service.class)
         .hasFieldOrPropertyWithValue("spec.type", null)
-        .extracting("spec")
-        .flatExtracting("ports")
+        .extracting("spec.ports")
+        .asList()
         .extracting("name", "port", "protocol")
         .containsOnly(new Tuple("http", 80, "TCP"));
   }
@@ -92,8 +92,8 @@ public class DefaultServiceEnricherAddMissingPartsTest {
     assertThat(klb.buildItem(0))
         .isInstanceOf(Service.class)
         .hasFieldOrPropertyWithValue("spec.type", null)
-        .extracting("spec")
-        .flatExtracting("ports")
+        .extracting("spec.ports")
+        .asList()
         .extracting("name", "port", "protocol")
         .containsOnly(new Tuple("menandmice-dns", 1337, "TCP"));
   }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherTest.java
@@ -283,7 +283,7 @@ public class RouteEnricherTest {
 
         assertThat(klb.build().getItems().stream().filter(h -> h.getKind().equals("Route")).findFirst().orElse(null))
                 .extracting("spec.tls")
-                .containsNull();
+                .isNull();
 
     }
 

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -36,7 +36,7 @@
 
     <version.asciidoctor-maven-plugin>1.5.5</version.asciidoctor-maven-plugin>
     <version.asciidoctorj>1.5.4</version.asciidoctorj>
-    <version.assertj-core>2.4.1</version.assertj-core>
+    <version.assertj-core>3.18.0</version.assertj-core>
     <version.bouncycastle.bcpkix>1.61</version.bouncycastle.bcpkix>
     <version.commons-codec>1.15</version.commons-codec>
     <version.commons-compress>1.19</version.commons-compress>


### PR DESCRIPTION
## Description

chore: Upgrade assertj-core to 3.18.0

- [x] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22763

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] ~~I have implemented unit tests to cover my changes~~
 - [ ] ~~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] ~~I tested my code in Kubernetes~~
 - [ ] ~~I tested my code in OpenShift~~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->