### PR TITLE
Fix #240: No Ports exposed inside Deployment in case of Zero Config Dockerfile Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ### 1.1.0-SNAPSHOT
 * Fix #467: Upgrade assertj-core to 3.18.0
 * Added a Quickstart for implementing and using a Custom Enricher based on Eclipse JKube Kit Enricher API
+* Fix #240: No Ports exposed inside Deployment in case of Zero Config Dockerfile Mode 
 
 ### 1.0.2 (2020-10-30)
 * Fix #429: Added quickstart for Micronaut framework

--- a/jkube-kit/build/api/src/test/resources/docker/Dockerfile_expose_ports
+++ b/jkube-kit/build/api/src/test/resources/docker/Dockerfile_expose_ports
@@ -1,0 +1,12 @@
+ARG VERSION=latest
+FROM openjdk:$VERSION
+EXPOSE 80
+COPY maven/target/docker-file-simple.jar /deployments/docker-file-simple.jar
+# Copying a file inside project root directory
+COPY maven/static-dir-in-project-root/my-file.txt /deployments/my-file.txt
+EXPOSE 8080
+EXPOSE 80/tcp
+EXPOSE 8080/udp
+EXPOSE 99/udp
+CMD ["java", "-jar", "/deployments/docker-file-simple.jar"]
+EXPOSE 8080

--- a/quickstarts/maven/docker-file-simple/Dockerfile
+++ b/quickstarts/maven/docker-file-simple/Dockerfile
@@ -17,4 +17,5 @@ FROM openjdk:$VERSION
 COPY maven/target/docker-file-simple.jar /deployments/docker-file-simple.jar
 # Copying a file inside project root directory
 COPY maven/static-dir-in-project-root/my-file.txt /deployments/my-file.txt
+EXPOSE 8080
 CMD ["java", "-jar", "/deployments/docker-file-simple.jar"]

--- a/quickstarts/maven/docker-file-simple/pom.xml
+++ b/quickstarts/maven/docker-file-simple/pom.xml
@@ -39,7 +39,6 @@
     <properties>
         <java.version>11</java.version>
         <jkube.version>${project.version}</jkube.version>
-        <jkube.enricher.jkube-service.port>8080</jkube.enricher.jkube-service.port>
         <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
     </properties>
 


### PR DESCRIPTION
Fix #240 
Add ports to ImageConfiguration generated in DockerFileUtil.createSimpleDockerfileConfig
by parsing contents of Dockerfile

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->