### PR TITLE
fix: wildfly-jar doesn't depend on common-maven module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ Usage:
 ```
 ### 1.1.0-SNAPSHOT
 * Fix #467: Upgrade assertj-core to 3.18.0
-* Added a Quickstart for implementing and using a Custom Enricher based on Eclipse JKube Kit Enricher API
-* Fix #240: No Ports exposed inside Deployment in case of Zero Config Dockerfile Mode 
+* Fix #460: Added a Quickstart for implementing and using a Custom Enricher based on Eclipse JKube Kit Enricher API
+* Fix #240: No Ports exposed inside Deployment in case of Zero Config Dockerfile Mode
+* Fix #480: wildfly-jar doesn't depend on common-maven module
 
 ### 1.0.2 (2020-10-30)
 * Fix #429: Added quickstart for Micronaut framework

--- a/jkube-kit/jkube-kit-wildfly-jar/pom.xml
+++ b/jkube-kit/jkube-kit-wildfly-jar/pom.xml
@@ -32,11 +32,6 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jkube</groupId>
-            <artifactId>jkube-kit-common-maven</artifactId>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.eclipse.jkube</groupId>
             <artifactId>jkube-kit-generator-java-exec</artifactId>
         </dependency>
 
@@ -44,7 +39,7 @@
             <groupId>org.eclipse.jkube</groupId>
             <artifactId>jkube-kit-enricher-specific</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>


### PR DESCRIPTION
## Description

fix: wildfly-jar doesn't depend on common-maven module

For some reason wildfly-jar depends on common-maven module. This module should **only** be used in Maven plugins.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] ~I have implemented unit tests to cover my changes~
 - [ ] ~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] ~I tested my code in Kubernetes~
 - [ ] ~I tested my code in OpenShift~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->