### PR TITLE
fix: CI fail-fast, install JKube and persist in ActionsCache

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,8 +28,37 @@ env:
   JKUBE_IT_DIR: jkube-integration-tests
 
 jobs:
+  build-jKube:
+    name: Build JKube
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Cache .m2 registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Install JKube
+        run: ./mvnw -f pom.xml -B -DskipTests clean install
+      - name: Checkout JKube Integration Tests Repository
+        run: |
+          git clone "$JKUBE_IT_REPOSITORY" \
+          && cd $JKUBE_IT_DIR \
+          && git checkout "$JKUBE_IT_REVISION"
+      - name: Install Integration Tests (Downloads dependencies)
+        run: |
+          cd $JKUBE_IT_DIR \
+          && ./mvnw -B -DskipTests clean install
+
   minikube:
     name: K8S
+    needs: build-jKube
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -39,18 +68,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Restore cache for .m2 registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.0.1
         with:
           minikube version: v1.9.2
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Java 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: '11'
-      - name: Install JKube
-        run: ./mvnw -f pom.xml -B -DskipTests clean install
       - name: Checkout JKube Integration Tests Repository
         run: |
           git clone "$JKUBE_IT_REPOSITORY" \
@@ -60,7 +93,7 @@ jobs:
         run: |
           JKUBE_VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && cd $JKUBE_IT_DIR \
-          && ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION"
+          && ./mvnw -B -PKubernetes,${{ matrix.suite }} verify -Djkube.version="$JKUBE_VERSION"
       - name: Consolidate reports
         if: always()
         run: |
@@ -74,6 +107,7 @@ jobs:
           path: ./reports
   openshift:
     name: OpenShift
+    needs: build-jKube
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -103,17 +137,21 @@ jobs:
           df -h
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Restore cache for .m2 registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.1.2
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Java 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: '11'
-      - name: Install JKube
-        run: ./mvnw -f pom.xml -B -DskipTests clean install
       - name: Checkout JKube Integration Tests Repository
         run: |
           git clone "$JKUBE_IT_REPOSITORY" \
@@ -123,7 +161,7 @@ jobs:
         run: |
           JKUBE_VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && cd $JKUBE_IT_DIR \
-          && ./mvnw -B -POpenShift,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
+          && ./mvnw -B -POpenShift,${{ matrix.suite }} verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
       - name: Consolidate reports
         if: always()
         run: |


### PR DESCRIPTION
## Description
Port of https://github.com/fabric8io/kubernetes-client/pull/2553 to install JKube for all CI runs and cache the generated artifacts.

There shouldn't be any performance gain. Main reason is to allow tests to fail fast in case there are problems when installing JKube (we are getting many issues when downloading artifacts from maven central).

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] ~~I Added [CHANGELOG](../CHANGELOG.md) entry~~
 - [ ] ~~I have implemented unit tests to cover my changes~~
 - [ ] ~~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] ~~I tested my code in Kubernetes~~
 - [ ] ~~I tested my code in OpenShift~~

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->