### PR TITLE
fix: Controller enricher replica count can be set to `0` when ResourceConfig is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Usage:
 * Fix #240: No Ports exposed inside Deployment in case of Zero Config Dockerfile Mode
 * Fix #480: wildfly-jar doesn't depend on common-maven module
 * Fix #268: Generator and HealthCheck enrichers for Micronaut framework (JVM)
+* Fix #488: Controller enricher replica count can be set to `0` when ResourceConfig is provided
 
 ### 1.0.2 (2020-10-30)
 * Fix #429: Added quickstart for Micronaut framework

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
@@ -71,7 +71,7 @@ public class ResourceConfig {
   /**
    * Number of replicas to create.
    */
-  private int replicas = 1;
+  private Integer replicas;
   private String namespace;
   private String serviceAccount;
   @Singular

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/BaseEnricher.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/BaseEnricher.java
@@ -176,7 +176,8 @@ public class BaseEnricher implements Enricher {
      */
     protected static int getReplicaCount(KubernetesListBuilder builder, ResourceConfig xmlResourceConfig, int defaultValue) {
         if (xmlResourceConfig != null) {
-            List<HasMetadata> items = builder.buildItems();
+            final List<HasMetadata> items = Optional.ofNullable(builder)
+                .map(KubernetesListBuilder::buildItems).orElse(Collections.emptyList());
             for (HasMetadata item : items) {
                 if (item instanceof Deployment && ((Deployment)item).getSpec().getReplicas() != null) {
                     return ((Deployment)item).getSpec().getReplicas();
@@ -185,7 +186,7 @@ public class BaseEnricher implements Enricher {
                     return ((DeploymentConfig)item).getSpec().getReplicas();
                 }
             }
-            return xmlResourceConfig.getReplicas() > 0 ? xmlResourceConfig.getReplicas() : defaultValue;
+            return xmlResourceConfig.getReplicas() != null ? xmlResourceConfig.getReplicas() : defaultValue;
         }
         return defaultValue;
     }

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/BaseEnricherGetReplicaCountTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/BaseEnricherGetReplicaCountTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.enricher.api;
+
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jkube.kit.enricher.api.BaseEnricher.getReplicaCount;
+
+public class BaseEnricherGetReplicaCountTest {
+
+  @Test
+  public void withNoListBuilderAndNoResourceConfigShouldReturnDefault() {
+    // When
+    final int result = getReplicaCount(null, null, 1337);
+    // Then
+    assertThat(result).isEqualTo(1337);
+  }
+
+  @Test
+  public void withNoListBuilderAndEmptyResourceConfigShouldReturnDefault() {
+    // When
+    final int result = getReplicaCount(null, new ResourceConfig(), 1337);
+    // Then
+    assertThat(result).isEqualTo(1337);
+  }
+
+  @Test
+  public void withNoListBuilderAndConfiguredResourceConfigShouldReturnResourceConfig() {
+    // Given
+    final ResourceConfig resourceConfig = ResourceConfig.builder().replicas(313373).build();
+    // When
+    final int result = getReplicaCount(null, resourceConfig, 1337);
+    // Then
+    assertThat(result).isEqualTo(313373);
+  }
+
+  @Test
+  public void withEmptyListBuilderAndEmptyResourceConfigShouldReturnDefault() {
+    // When
+    final int result = getReplicaCount(
+        new KubernetesListBuilder().addToItems(new ConfigMapBuilder()), new ResourceConfig(), 1337);
+    // Then
+    assertThat(result).isEqualTo(1337);
+  }
+
+  @Test
+  public void withDeploymentConfigInListBuilderAndEmptyResourceConfigShouldReturnDeploymentConfig() {
+    // Given
+    final KubernetesListBuilder klb = new KubernetesListBuilder()
+        .addToItems(new DeploymentConfigBuilder().withNewSpec().withReplicas(1).endSpec());
+    final ResourceConfig resourceConfig = ResourceConfig.builder().replicas(313373).build();
+    // When
+    final int result = getReplicaCount(klb, resourceConfig, 1337);
+    // Then
+    assertThat(result).isEqualTo(1);
+  }
+
+  @Test
+  public void withDeploymentConfigAndDeploymentInListBuilderAndEmptyResourceConfigShouldReturnValueInFirstItem() {
+    // Given
+    final KubernetesListBuilder klb = new KubernetesListBuilder()
+        .addToItems(new DeploymentBuilder().withNewSpec().withReplicas(2).endSpec())
+        .addToItems(new DeploymentConfigBuilder().withNewSpec().withReplicas(1).endSpec());
+    final ResourceConfig resourceConfig = ResourceConfig.builder().replicas(313373).build();
+    // When
+    final int result = getReplicaCount(klb, resourceConfig, 1337);
+    // Then
+    assertThat(result).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
## Description
* Fix #488: Controller enricher replica count can be set to `0` when ResourceConfig is provided

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->