### PR TITLE
ServiceDiscoveryEnricher from FMP

### DIFF
--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricher.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.enricher.specific;
+
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.config.resource.PlatformMode;
+import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
+import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ServiceDiscoveryEnricher extends BaseEnricher {
+    static final String ENRICHER_NAME = "jkube-service-discovery";
+
+    //Default Prefix
+    static final String PREFIX = "discovery.3scale.net";
+    //Service Annotations
+    static final String DISCOVERY_VERSION = "discovery-version";
+    static final String SCHEME            = "scheme";
+    static final String PATH              = "path";
+    static final String PORT              = "port";
+    static final String DESCRIPTION_PATH  = "description-path";
+
+    private File springConfigDir;
+    private String path             = null;
+    private String port             = "80";
+    private String scheme           = "http";
+    private String descriptionPath  = null;
+    private String discoverable     = null;
+    private String discoveryVersion = "v1";
+
+    private enum Config implements Configs.Config {
+        descriptionPath,
+        discoverable,
+        discoveryVersion,
+        path,
+        port,
+        scheme,
+        springDir;
+    }
+
+    public ServiceDiscoveryEnricher(JKubeEnricherContext buildContext) {
+        super(buildContext, ENRICHER_NAME);
+
+        File baseDir = getContext().getProjectDirectory();
+        springConfigDir = new File(getConfig(Config.springDir, baseDir + "/src/main/resources/spring"));
+        discoverable = getConfig(Config.discoverable, null);
+    }
+
+    @Override
+    public void create(PlatformMode platformMode, final KubernetesListBuilder listBuilder) {
+        listBuilder.accept(new TypedVisitor<ServiceBuilder>() {
+
+            @Override
+            public void visit(ServiceBuilder serviceBuilder) {
+                addAnnotations(serviceBuilder);
+            }
+
+        });
+    }
+
+    protected void addAnnotations(ServiceBuilder serviceBuilder) {
+        if (serviceBuilder.buildSpec() != null) {
+            List<ServicePort> ports = serviceBuilder.buildSpec().getPorts();
+            if (! ports.isEmpty()) {
+                ServicePort firstServicePort = ports.iterator().next();
+                port = firstServicePort.getPort().toString();
+                log.info("Using first mentioned service port '%s' " , port);
+            } else {
+                log.warn("No service port was found");
+            }
+        }
+
+        tryCamelDSLProject();
+
+        if (discoverable != null) {
+            String labelName = PREFIX;
+            String labelValue = getConfig(Config.discoverable, discoverable);
+            serviceBuilder.editOrNewMetadata().addToLabels(labelName, labelValue).and().buildMetadata();
+
+            log.info("Add %s label: \"%s\" : \"%s\"", PREFIX, labelName, labelValue);
+
+            Map<String, String> annotations = new HashMap<>();
+            annotations.put(PREFIX + "/" + DISCOVERY_VERSION, getConfig(Config.discoveryVersion, discoveryVersion));
+            annotations.put(PREFIX + "/" + SCHEME, getConfig(Config.scheme, scheme));
+
+            String resolvedPath = getConfig(Config.path, path);
+            if (resolvedPath != null) {
+                if (! resolvedPath.startsWith("/")) {
+                    resolvedPath = "/" + resolvedPath;
+                }
+                annotations.put(PREFIX + "/" + PATH, resolvedPath);
+            }
+            annotations.put(PREFIX + "/" + PORT, getConfig(Config.port, port));
+
+            String resolvedDescriptionPath = getConfig(Config.descriptionPath, descriptionPath);
+            if (resolvedDescriptionPath != null) {
+                if (! resolvedDescriptionPath.toLowerCase().startsWith("http") && ! resolvedDescriptionPath.startsWith("/")) {
+                    resolvedDescriptionPath = "/" + resolvedDescriptionPath;
+                }
+                annotations.put(PREFIX + "/" + DESCRIPTION_PATH , resolvedDescriptionPath);
+            }
+            for (String annotationName : annotations.keySet()) {
+                log.info("Add %s annotation: \"%s\" : \"%s\"", PREFIX, annotationName, annotations.get(annotationName));
+            }
+            serviceBuilder.editMetadata().addToAnnotations(annotations).and().buildMetadata();
+        }
+    }
+
+    public void tryCamelDSLProject(){
+        File camelContextXmlFile = new File(springConfigDir.getAbsoluteFile() + "/camel-context.xml");
+        if (camelContextXmlFile.exists()) {
+            try {
+                DocumentBuilderFactory df = DocumentBuilderFactory.newInstance();
+                df.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                df.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                Document doc = df.newDocumentBuilder().parse(camelContextXmlFile);
+                XPath xPath = XPathFactory.newInstance().newXPath();
+                Node nl = (Node) xPath.evaluate("/beans/camelContext/restConfiguration", doc, XPathConstants.NODE);
+                if (nl != null) {
+                    discoverable = "true";
+                    if (nl.getAttributes().getNamedItem("scheme") != null) {
+                        scheme = nl.getAttributes().getNamedItem("scheme").getNodeValue();
+                        log.verbose("Obtained scheme '%s' from camel-context.xml ", scheme);
+                    }
+                    if (nl.getAttributes().getNamedItem("contextPath") != null) {
+                        path = nl.getAttributes().getNamedItem("contextPath").getNodeValue();
+                        log.verbose("Obtained path '%s' from camel-context.xml ", path);
+                    }
+                    if (nl.getAttributes().getNamedItem("apiContextPath") != null) {
+                        descriptionPath = nl.getAttributes().getNamedItem("apiContextPath").getNodeValue();
+                        log.verbose("Obtained descriptionPath '%s' from camel-context.xml ", descriptionPath);
+                    }
+                }
+            } catch (Exception ex) {
+                log.warn("Failed to load camel context file: %s", ex);
+            }
+        }
+    }
+
+}

--- a/jkube-kit/enricher/specific/src/main/resources/META-INF/jkube/enricher-default
+++ b/jkube-kit/enricher/specific/src/main/resources/META-INF/jkube/enricher-default
@@ -15,5 +15,5 @@ org.eclipse.jkube.kit.enricher.specific.DockerHealthCheckEnricher,510
 
 # Other enrichers
 org.eclipse.jkube.kit.enricher.specific.PrometheusEnricher
-
+org.eclipse.jkube.kit.enricher.specific.ServiceDiscoveryEnricher
 

--- a/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricherTest.java
+++ b/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricherTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.enricher.specific;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
+import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
+import mockit.Expectations;
+import mockit.Mocked;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.eclipse.jkube.kit.enricher.specific.ServiceDiscoveryEnricher.*;
+import static org.junit.Assert.assertEquals;
+
+public class ServiceDiscoveryEnricherTest {
+
+    // configured properties
+    private static final String path = "/rest-3scale";
+    private static final String port = "8080";
+    private static final String scheme = "http";
+    private static final String descriptionPath = "/api-doc";
+    private static final String discoverable = "true";
+    private static final String discoveryVersion = "v1";
+
+    @Mocked
+    private JKubeEnricherContext context;
+
+    private ServiceDiscoveryEnricher enricher;
+
+    private ServiceBuilder builder;
+
+
+    @Before
+    public void setUp() {
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("path", path);
+        configMap.put("port", port);
+        configMap.put("scheme", scheme);
+        configMap.put("descriptionPath", descriptionPath);
+        configMap.put("discoverable", discoverable);
+        configMap.put("discoveryVersion", discoveryVersion);
+
+        ProcessorConfig processorConfig = new ProcessorConfig(
+            null, null, Collections.singletonMap(ENRICHER_NAME, configMap)
+        );
+
+        // Setup mock behaviour
+        new Expectations() {{
+            context.getConfiguration().getProcessorConfig(); result = processorConfig;
+        }};
+
+        enricher = new ServiceDiscoveryEnricher(context);
+        builder = new ServiceBuilder();
+    }
+
+    @Test
+    public void testDiscoveryLabel() {
+        enricher.addAnnotations(builder);
+        String label = label();
+        String value = builder.buildMetadata().getLabels().get(label);
+        assertEquals(discoverable, value);
+    }
+
+    @Test
+    public void testDescriptionPathAnnotation() {
+        enricher.addAnnotations(builder);
+        String annotation = annotation(DESCRIPTION_PATH);
+        String value = builder.buildMetadata().getAnnotations().get(annotation);
+        assertEquals(descriptionPath, value);
+    }
+
+    @Test
+    public void testDiscoveryVersionAnnotation() {
+        enricher.addAnnotations(builder);
+        String annotation = annotation(DISCOVERY_VERSION);
+        String value = builder.buildMetadata().getAnnotations().get(annotation);
+        assertEquals(discoveryVersion, value);
+    }
+
+    @Test
+    public void testPathAnnotation() {
+        enricher.addAnnotations(builder);
+        String annotation = annotation(PATH);
+        String value = builder.buildMetadata().getAnnotations().get(annotation);
+        assertEquals("/rest-3scale", value);
+    }
+
+    @Test
+    public void testPortAnnotation() {
+        enricher.addAnnotations(builder);
+        String annotation = annotation(PORT);
+        String value = builder.buildMetadata().getAnnotations().get(annotation);
+        assertEquals(port, value);
+    }
+
+    @Test
+    public void testSchemeAnnotation() {
+        enricher.addAnnotations(builder);
+        String annotation = annotation(SCHEME);
+        String value = builder.buildMetadata().getAnnotations().get(annotation);
+        assertEquals(scheme, value);
+    }
+
+    private String label() {
+        return ServiceDiscoveryEnricher.PREFIX;
+    }
+
+    private String annotation(String name) {
+        return ServiceDiscoveryEnricher.PREFIX + "/" + name;
+    }
+
+}

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -174,6 +174,8 @@ include::enricher/_jkube_healthcheck_wildfly_swarm.adoc[]
 
 include::enricher/_jkube_healthcheck_wildfly_jar.adoc[]
 
+include::enricher/_jkube_service_discovery.adoc[]
+
 == Enricher API
 
 _How to write your own enrichers and install them._

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_service_discovery.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_service_discovery.adoc
@@ -1,0 +1,100 @@
+
+[[jkube-service-discovery]]
+==== jkube-service-discovery
+
+This enricher can be used to add service annotations to facilitate automated discovery of
+the service by 3scale for Camel RestDSL projects. Other project types may follow at a later time.
+The enricher extracts the needed information from the camel-context.xml, and the restConfiguration element in particular.
+
+-----
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring       http://camel.apache.org/schema/spring/camel-spring.xsd">
+     <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <restConfiguration component="servlet" scheme="https"
+              contextPath="myapi" apiContextPath="myapi/openapi.json"/>
+...
+-----
+The enricher looks for the `scheme`, `contextPath` and `apiContextPath` attributes, and it will add the following
+label and annotations:
+
+LABEL
+    discovery.3scale.net/discoverable. The value of the label can be set to "true" or "false", and was added to take part in the selector definition executed by 3scale to find all services that need discovery. Also it can act as a switch as well, to temporary turn off 3scale discovery integration by setting it to "false".
+
+ANNOTATIONS
+    discovery.3scale.net/discovery-version: the version of the 3scale discovery process.
+    discovery.3scale.net/scheme: this can be "http" or "https"
+    discovery.3scale.net/path: (optional) the contextPath of the service if it's not at the root.
+    discovery.3scale.net/description-path: (optional) the path to the service description document (OpenAPI/Swagger). The path can either be relative or an external full URL.
+
+The following configuration parameters can be used to override the behavior of this enricher:
+
+[[enricher-jkube-service-discovery]]
+.JKube service discovery enricher
+[cols="1,6,1"]
+|===
+| Element | Description | Default
+
+| *springDir*
+| Path to the spring configuration directory where the `camel-context.xml` file lives.
+| `/src/main/resources/spring` which is used to recognize a Camel RestDSL project.
+
+| *scheme*
+| The `scheme` part of the URL where the service is hosted.
+| `http`
+
+| *path*
+| The `path` part of the URL where the service is hosted.
+| `/`
+
+| *descriptionPath*
+| The path to a location where the service description document is hosted. This path can be either a relative path if the document is self-hosted, or a full URL if the document is hosted externally.
+|
+
+| *discoveryVersion*
+| The version of the 3scale discovery implementation.
+| `v1`
+
+| *discoverable*
+| Sets the discoverable label to either true or false. If it's set to "false" 3scale will not try to discover this service.
+| `true`
+
+|===
+
+You specify the properties like for any enricher within the enrichers configuration like in
+
+.Example
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+-----
+<configuration>
+  ..
+  <enricher>
+    <config>
+      <jkube-service-discovery>
+        <scheme>https</scheme>
+        <path>/api</path>
+        <descriptionPath>/api/openapi.json</descriptionPath>
+      </jkube-service-discovery>
+    </config>
+  </enricher>
+</configuration>
+-----
+
+Alternatively you can us a `src/main/jkube/service.yml` fragment to override the values. For example
+-----
+kind: Service
+name:
+metadata:
+  labels:
+    discovery.3scale.net/discoverable : "true"
+  annotations:
+    discovery.3scale.net/discovery-version : "v1"
+    discovery.3scale.net/scheme : "https"
+    discovery.3scale.net/path : "/api"
+    discovery.3scale.net/description-path : "/api/openapi.json"
+spec:
+  type: LoadBalancer
+-----

--- a/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -65,6 +65,7 @@
     - jkube-healthcheck-webapp
     - jkube-healthcheck-micronaut
     - jkube-prometheus
+    - jkube-service-discovery
 
     # Value merge enrichers
     - jkube-container-env-java-options

--- a/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -62,6 +62,7 @@
     - jkube-healthcheck-webapp
     - jkube-healthcheck-micronaut
     - jkube-prometheus
+    - jkube-service-discovery
 
     # Value merge enrichers
     - jkube-container-env-java-options


### PR DESCRIPTION
This is a port of ServiceDiscoveryEnricher from former Fabric8 Maven Plugin that adds 3scale discovery annotations to services.

Related to:
- https://issues.redhat.com/browse/ENTESB-15034
- https://github.com/fabric8io/fabric8-maven-plugin/pull/1394
