### PR TITLE
Fix #231: IngressEnricher ignores IngressRules defined in XML config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Usage:
 * Fix #511: Namespace as resource fragment results in NullPointerException
 * Fix #521: NPE on Buildconfig#getContextDir if `<dockerFile>` references a file with no directory
 * Fix #513: openshift-maven-plugin: service.yml fragment with ports creates service with unnamed port mapping
+* Fix #231: IngressEnricher ignores IngressRules defined in XML config
 
 ### 1.0.2 (2020-10-30)
 * Fix #429: Added quickstart for Micronaut framework

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressRuleConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressRuleConfig.java
@@ -18,6 +18,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Singular;
 
 import java.util.List;
 
@@ -28,5 +29,6 @@ import java.util.List;
 @EqualsAndHashCode
 public class IngressRuleConfig {
     private String host;
+    @Singular
     private List<IngressRulePathConfig> paths;
 }

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressRuleConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressRuleConfig.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.resource;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class IngressRuleConfig {
+    private String host;
+    private List<IngressRulePathConfig> paths;
+}

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressRulePathConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressRulePathConfig.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.resource;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class IngressRulePathConfig {
+    private String pathType;
+    private String path;
+    private String serviceName;
+    private int servicePort;
+    private IngressRulePathResourceConfig resource;
+}

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressRulePathResourceConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressRulePathResourceConfig.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.resource;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class IngressRulePathResourceConfig {
+    private String apiGroup;
+    private String kind;
+    private String name;
+}

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressTlsConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressTlsConfig.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.resource;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class IngressTlsConfig {
+    private List<String> hosts;
+    private String secretName;
+}

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressTlsConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/IngressTlsConfig.java
@@ -18,6 +18,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Singular;
 
 import java.util.List;
 
@@ -27,6 +28,7 @@ import java.util.List;
 @Getter
 @EqualsAndHashCode
 public class IngressTlsConfig {
+    @Singular
     private List<String> hosts;
     private String secretName;
 }

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
@@ -13,7 +13,6 @@
  */
 package org.eclipse.jkube.kit.config.resource;
 
-import io.fabric8.kubernetes.api.model.extensions.IngressRule;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -79,7 +78,10 @@ public class ResourceConfig {
   @Singular
   private List<ServiceAccountConfig> serviceAccounts;
   @Singular
-  private List<IngressRule> ingressRules;
+  private List<IngressRuleConfig> ingressRules;
+
+  @Singular
+  private List<IngressTlsConfig> ingressTlsConfigs;
   private OpenshiftBuildConfig openshiftBuildConfig;
   private String routeDomain;
 

--- a/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/resource/IngressRuleConfigTest.java
+++ b/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/resource/IngressRuleConfigTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.resource;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.jkube.kit.common.AssemblyConfiguration;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IngressRuleConfigTest {
+  /**
+   * Verifies that deserialization works for raw deserialization (Maven-Plexus).
+   */
+  @Test
+  public void rawDeserialization() throws IOException {
+    // Given
+    final ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(MapperFeature.USE_ANNOTATIONS, false);
+    // When
+    final IngressRuleConfig result = mapper.readValue(
+        IngressRuleConfigTest.class.getResourceAsStream("/ingress-rule-config.json"),
+        IngressRuleConfig.class);
+    // Then
+    assertThat(result).isEqualTo(IngressRuleConfig.builder()
+        .host("example.com")
+        .path(IngressRulePathConfig.builder()
+            .pathType("ImplementationSpecific")
+            .path("/path")
+            .serviceName("service-name")
+            .servicePort(8080)
+            .resource(IngressRulePathResourceConfig.builder()
+                .apiGroup("group.k8s.io")
+                .kind("ResourceKind")
+                .name("resource-name")
+                .build())
+        .build())
+      .build()
+    );
+  }
+}

--- a/jkube-kit/config/resource/src/test/resources/ingress-rule-config.json
+++ b/jkube-kit/config/resource/src/test/resources/ingress-rule-config.json
@@ -1,0 +1,14 @@
+{
+  "host": "example.com",
+  "paths": [{
+    "pathType": "ImplementationSpecific",
+    "path": "/path",
+    "serviceName": "service-name",
+    "servicePort": 8080,
+    "resource": {
+      "apiGroup": "group.k8s.io",
+      "kind": "ResourceKind",
+      "name": "resource-name"
+    }
+  }]
+}

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
@@ -75,6 +75,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.Template;
+import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,6 +99,7 @@ public class KubernetesResourceUtil {
     public static final String OPENSHIFT_V1_VERSION = "apps.openshift.io/v1";
     public static final String CRONJOB_VERSION = "batch/v1beta1";
     public static final String RBAC_VERSION = "rbac.authorization.k8s.io/v1";
+    public static final String EXPOSE_LABEL = "expose";
 
     public static final ResourceVersioning DEFAULT_RESOURCE_VERSIONING = new ResourceVersioning()
             .withCoreVersion(API_VERSION)
@@ -933,5 +935,10 @@ public class KubernetesResourceUtil {
             }
         }
         return true;
+    }
+
+    public static boolean isExposedService(ObjectMeta objectMeta) {
+        return containsLabelInMetadata(objectMeta, EXPOSE_LABEL, "true") ||
+                containsLabelInMetadata(objectMeta, JKubeAnnotations.SERVICE_EXPOSE_URL.value(), "true");
     }
 }

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtilTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtilTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.kit.enricher.api.util;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -264,6 +265,12 @@ public class KubernetesResourceUtilTest {
         assertEquals("networking.k8s.io/v1", result.getApiVersion());
         assertEquals("Ingress", result.getKind());
         assertEquals("my-ingress", result.getMetadata().getName());
+    }
+
+    @Test
+    public void testIsExposedService() {
+        assertTrue(KubernetesResourceUtil.isExposedService(new ObjectMetaBuilder().addToLabels("expose", "true").build()));
+        assertTrue(KubernetesResourceUtil.isExposedService(new ObjectMetaBuilder().addToLabels("jkube.io/exposeUrl", "true").build()));
     }
 
     private PodSpec getDefaultGeneratedPodSpec() {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
@@ -14,32 +14,46 @@
 package org.eclipse.jkube.enricher.generic;
 
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.extensions.HTTPIngressPath;
 import io.fabric8.kubernetes.api.model.extensions.HTTPIngressPathBuilder;
+import io.fabric8.kubernetes.api.model.extensions.HTTPIngressRuleValueBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.extensions.IngressBackend;
 import io.fabric8.kubernetes.api.model.extensions.IngressBackendBuilder;
 import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
+import io.fabric8.kubernetes.api.model.extensions.IngressRule;
+import io.fabric8.kubernetes.api.model.extensions.IngressRuleBuilder;
+import io.fabric8.kubernetes.api.model.extensions.IngressSpec;
 import io.fabric8.kubernetes.api.model.extensions.IngressSpecBuilder;
+import io.fabric8.kubernetes.api.model.extensions.IngressTLS;
+import io.fabric8.kubernetes.api.model.extensions.IngressTLSBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.config.resource.IngressRuleConfig;
+import org.eclipse.jkube.kit.config.resource.IngressRulePathConfig;
+import org.eclipse.jkube.kit.config.resource.IngressRulePathResourceConfig;
+import org.eclipse.jkube.kit.config.resource.IngressTlsConfig;
 import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.containsLabelInMetadata;
-import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.removeLabel;
+import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.isExposedService;
 
 /**
  * Enricher which generates an Ingress for each exposed Service
@@ -63,7 +77,7 @@ public class IngressEnricher extends BaseEnricher {
             listBuilder.accept(new TypedVisitor<ServiceBuilder>() {
                 @Override
                 public void visit(ServiceBuilder serviceBuilder) {
-                    Ingress ingress = addIngress(listBuilder, serviceBuilder, getRouteDomain(resourceConfig), log);
+                    Ingress ingress = addIngress(listBuilder, serviceBuilder, getRouteDomain(resourceConfig), getIngressRuleXMLConfig(resourceConfig), getIngressTlsXMLConfig(resourceConfig), log);
                     if (ingress != null) {
                         listBuilder.addToItems(ingress);
                     }
@@ -72,7 +86,7 @@ public class IngressEnricher extends BaseEnricher {
         }
     }
 
-    protected static Ingress addIngress(KubernetesListBuilder listBuilder, ServiceBuilder serviceBuilder, String routeDomainPostfix, KitLogger log) {
+    protected static Ingress addIngress(KubernetesListBuilder listBuilder, ServiceBuilder serviceBuilder, String routeDomainPostfix, List<IngressRuleConfig> ingressRuleConfigs, List<IngressTlsConfig> ingressTlsConfigs, KitLogger log) {
         ObjectMeta serviceMetadata = serviceBuilder.buildMetadata();
         if (serviceMetadata == null) {
             log.info("No Metadata for service! ");
@@ -83,45 +97,127 @@ public class IngressEnricher extends BaseEnricher {
             if (!hasIngress(listBuilder, serviceName)) {
                 Integer servicePort = getServicePort(serviceBuilder);
                 if (servicePort != null) {
+                    return new IngressBuilder()
+                            .withMetadata(getIngressMetadata(serviceMetadata))
+                            .withSpec(getIngressSpec(routeDomainPostfix, serviceName, servicePort, ingressRuleConfigs, ingressTlsConfigs))
+                            .build();
 
-                    IngressBuilder ingressBuilder = new IngressBuilder().
-                            withMetadata(serviceMetadata).
-                            withNewSpec().
-                            endSpec();
-
-                    // removing `expose : true` label from metadata.
-                    removeLabel(ingressBuilder.buildMetadata(), EXPOSE_LABEL, "true");
-                    removeLabel(ingressBuilder.buildMetadata(), JKubeAnnotations.SERVICE_EXPOSE_URL.value(), "true");
-                    ingressBuilder.withNewMetadataLike(ingressBuilder.buildMetadata());
-
-                    if (StringUtils.isNotBlank(routeDomainPostfix)) {
-                        routeDomainPostfix = serviceName + "." + FileUtil.stripPrefix(routeDomainPostfix, ".");
-                        ingressBuilder = ingressBuilder.withSpec(new IngressSpecBuilder().addNewRule().
-                                withHost(routeDomainPostfix).
-                                withNewHttp().
-                                withPaths(new HTTPIngressPathBuilder()
-                                        .withNewBackend()
-                                        .withServiceName(serviceName)
-                                        .withServicePort(KubernetesHelper.createIntOrString(getServicePort(serviceBuilder)))
-                                        .endBackend()
-                                        .build())
-                                .endHttp().
-                                        endRule().build());
-                    } else {
-                        ingressBuilder.withSpec(new IngressSpecBuilder().withBackend(new IngressBackendBuilder().
-                                withNewServiceName(serviceName)
-                                .withNewServicePort(getServicePort(serviceBuilder))
-                                .build()).build());
-                    }
-
-                    return ingressBuilder.build();
                 }
             }
         }
         return null;
     }
 
-    private static Integer getServicePort(ServiceBuilder serviceBuilder) {
+    private static ObjectMeta getIngressMetadata(ObjectMeta serviceMetadata) {
+        ObjectMetaBuilder ingressMetadataBuilder = new ObjectMetaBuilder(serviceMetadata);
+
+        // removing `expose : true` label from metadata.
+        ingressMetadataBuilder.removeFromLabels(Collections.singletonMap(EXPOSE_LABEL, "true"));
+        ingressMetadataBuilder.removeFromLabels(Collections.singletonMap(JKubeAnnotations.SERVICE_EXPOSE_URL.value(), "true"));
+
+        return ingressMetadataBuilder.build();
+    }
+
+    private static IngressSpec getIngressSpec(String routeDomainPostfix, String serviceName, Integer servicePort, List<IngressRuleConfig> ingressRuleConfig, List<IngressTlsConfig> ingressTlsConfigs) {
+        if (ingressRuleConfig == null || ingressRuleConfig.isEmpty()) {
+            return getOpinionatedIngressSpec(routeDomainPostfix, serviceName, servicePort);
+        }
+        return getXmlConfiguredIngressSpec(ingressRuleConfig, ingressTlsConfigs);
+    }
+
+    private static IngressSpec getXmlConfiguredIngressSpec(List<IngressRuleConfig> ingressRuleConfigs, List<IngressTlsConfig> ingressTlsConfigs) {
+        IngressSpecBuilder ingressSpecBuilder = new IngressSpecBuilder();
+        for (IngressRuleConfig ingressRuleConfig: ingressRuleConfigs) {
+            IngressRule ingressRule = getIngressRuleFromXmlConfig(ingressRuleConfig);
+            ingressSpecBuilder.addToRules(ingressRule);
+        }
+
+        for (IngressTlsConfig ingressTlsConfig : ingressTlsConfigs) {
+            IngressTLS ingressTLS = getIngressTlsFromXMLConfig(ingressTlsConfig);
+            ingressSpecBuilder.addToTls(ingressTLS);
+        }
+        return ingressSpecBuilder.build();
+    }
+
+    private static IngressTLS getIngressTlsFromXMLConfig(IngressTlsConfig ingressTlsConfig) {
+        IngressTLSBuilder ingressTLSBuilder = new IngressTLSBuilder();
+        if (ingressTlsConfig.getHosts() != null && !ingressTlsConfig.getHosts().isEmpty()) {
+            ingressTLSBuilder.withHosts(ingressTlsConfig.getHosts());
+        }
+        if (ingressTlsConfig.getSecretName() != null) {
+            ingressTLSBuilder.withSecretName(ingressTlsConfig.getSecretName());
+        }
+        return ingressTLSBuilder.build();
+    }
+
+    private static IngressSpec getOpinionatedIngressSpec(String routeDomainPostfix, String serviceName, Integer servicePort) {
+        IngressSpecBuilder ingressSpecBuilder = new IngressSpecBuilder();
+        if (StringUtils.isNotBlank(routeDomainPostfix)) {
+            routeDomainPostfix = serviceName + "." + FileUtil.stripPrefix(routeDomainPostfix, ".");
+            ingressSpecBuilder.addNewRule()
+                    .withHost(routeDomainPostfix)
+                        .withNewHttp()
+                            .withPaths(new HTTPIngressPathBuilder()
+                            .withNewBackend()
+                            .withServiceName(serviceName)
+                            .withServicePort(KubernetesHelper.createIntOrString(servicePort))
+                            .endBackend()
+                            .build())
+                        .endHttp()
+                    .endRule().build();
+        } else {
+            ingressSpecBuilder.withBackend(new IngressBackendBuilder().
+                    withNewServiceName(serviceName)
+                    .withNewServicePort(servicePort)
+                    .build());
+        }
+        return ingressSpecBuilder.build();
+    }
+
+    private static IngressRule getIngressRuleFromXmlConfig(IngressRuleConfig ingressRuleConfig) {
+        IngressRuleBuilder ingressRuleBuilder = new IngressRuleBuilder();
+        if (ingressRuleConfig.getHost() != null) {
+            ingressRuleBuilder.withHost(ingressRuleConfig.getHost());
+        }
+        if (ingressRuleConfig.getPaths() != null && !ingressRuleConfig.getPaths().isEmpty()) {
+            HTTPIngressRuleValueBuilder httpIngressPathBuilder = new HTTPIngressRuleValueBuilder();
+            for (IngressRulePathConfig ingressRulePathConfig : ingressRuleConfig.getPaths()) {
+                httpIngressPathBuilder.addToPaths(getHTTPIngressPath(ingressRulePathConfig));
+            }
+            ingressRuleBuilder.withHttp(httpIngressPathBuilder.build());
+        }
+        return ingressRuleBuilder.build();
+    }
+
+    private static HTTPIngressPath getHTTPIngressPath(IngressRulePathConfig ingressRulePathConfig) {
+        HTTPIngressPathBuilder httpIngressPathBuilder = new HTTPIngressPathBuilder();
+        if (ingressRulePathConfig.getPath() != null) {
+            httpIngressPathBuilder.withPath(ingressRulePathConfig.getPath());
+        }
+        if (ingressRulePathConfig.getPathType() != null) {
+            httpIngressPathBuilder.withPathType(ingressRulePathConfig.getPathType());
+        }
+        return httpIngressPathBuilder.withBackend(getIngressBackend(ingressRulePathConfig))
+                .build();
+    }
+
+    private static IngressBackend getIngressBackend(IngressRulePathConfig ingressRulePathConfig) {
+        IngressBackendBuilder ingressBackendBuilder = new IngressBackendBuilder();
+        if (ingressRulePathConfig.getServiceName() != null) {
+            ingressBackendBuilder.withServiceName(ingressRulePathConfig.getServiceName());
+        }
+        if (ingressRulePathConfig.getServicePort() > 0) {
+            ingressBackendBuilder.withServicePort(new IntOrString(ingressRulePathConfig.getServicePort()));
+        }
+        if (ingressRulePathConfig.getResource() != null) {
+            IngressRulePathResourceConfig resource = ingressRulePathConfig.getResource();
+            ingressBackendBuilder.withNewResource(resource.getApiGroup(), resource.getKind(), resource.getName());
+        }
+
+        return ingressBackendBuilder.build();
+    }
+
+    static Integer getServicePort(ServiceBuilder serviceBuilder) {
         ServiceSpec spec = serviceBuilder.buildSpec();
         if (spec != null) {
             List<ServicePort> ports = spec.getPorts();
@@ -165,7 +261,7 @@ public class IngressEnricher extends BaseEnricher {
      *
      * @return true if we should create an Ingress for this service.
      */
-    private static boolean shouldCreateExternalURLForService(ServiceBuilder service, KitLogger log) {
+    static boolean shouldCreateExternalURLForService(ServiceBuilder service, KitLogger log) {
         String serviceName = service.buildMetadata().getName();
         ServiceSpec spec = service.buildSpec();
         if (spec != null && !isKuberentesSystemService(serviceName)) {
@@ -188,7 +284,7 @@ public class IngressEnricher extends BaseEnricher {
         return "kubernetes".equals(serviceName) || "kubernetes-ro".equals(serviceName);
     }
 
-    private String getRouteDomain(ResourceConfig resourceConfig) {
+    protected String getRouteDomain(ResourceConfig resourceConfig) {
         if (resourceConfig != null && resourceConfig.getRouteDomain() != null) {
             return resourceConfig.getRouteDomain();
         }
@@ -199,8 +295,17 @@ public class IngressEnricher extends BaseEnricher {
         return null;
     }
 
-    private static boolean isExposedService(ObjectMeta objectMeta) {
-        return containsLabelInMetadata(objectMeta, EXPOSE_LABEL, "true") ||
-                containsLabelInMetadata(objectMeta, JKubeAnnotations.SERVICE_EXPOSE_URL.value(), "true");
+    static List<IngressRuleConfig> getIngressRuleXMLConfig(ResourceConfig resourceConfig) {
+        if (resourceConfig != null) {
+            return resourceConfig.getIngressRules();
+        }
+        return Collections.emptyList();
+    }
+
+    static List<IngressTlsConfig> getIngressTlsXMLConfig(ResourceConfig resourceConfig) {
+        if (resourceConfig != null) {
+            return resourceConfig.getIngressTlsConfigs();
+        }
+        return Collections.emptyList();
     }
 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
@@ -77,7 +77,7 @@ public class IngressEnricher extends BaseEnricher {
             listBuilder.accept(new TypedVisitor<ServiceBuilder>() {
                 @Override
                 public void visit(ServiceBuilder serviceBuilder) {
-                    Ingress ingress = addIngress(listBuilder, serviceBuilder, getRouteDomain(resourceConfig), getIngressRuleXMLConfig(resourceConfig), getIngressTlsXMLConfig(resourceConfig), log);
+                    Ingress ingress = generateIngress(listBuilder, serviceBuilder, getRouteDomain(resourceConfig), getIngressRuleXMLConfig(resourceConfig), getIngressTlsXMLConfig(resourceConfig), log);
                     if (ingress != null) {
                         listBuilder.addToItems(ingress);
                     }
@@ -86,7 +86,7 @@ public class IngressEnricher extends BaseEnricher {
         }
     }
 
-    protected static Ingress addIngress(KubernetesListBuilder listBuilder, ServiceBuilder serviceBuilder, String routeDomainPostfix, List<IngressRuleConfig> ingressRuleConfigs, List<IngressTlsConfig> ingressTlsConfigs, KitLogger log) {
+    protected static Ingress generateIngress(KubernetesListBuilder listBuilder, ServiceBuilder serviceBuilder, String routeDomainPostfix, List<IngressRuleConfig> ingressRuleConfigs, List<IngressTlsConfig> ingressTlsConfigs, KitLogger log) {
         ObjectMeta serviceMetadata = serviceBuilder.buildMetadata();
         if (serviceMetadata == null) {
             log.info("No Metadata for service! ");
@@ -256,15 +256,15 @@ public class IngressEnricher extends BaseEnricher {
 
     /**
      * Should we try to create an external URL for the given service?
-     * <p>
-     * By default lets ignore the kubernetes services and any service which does not expose ports 80 and 443
+     *
+     * <p> By default let's ignore the kubernetes services and any service which does not expose ports 80 and 443
      *
      * @return true if we should create an Ingress for this service.
      */
     static boolean shouldCreateExternalURLForService(ServiceBuilder service, KitLogger log) {
         String serviceName = service.buildMetadata().getName();
         ServiceSpec spec = service.buildSpec();
-        if (spec != null && !isKuberentesSystemService(serviceName)) {
+        if (spec != null && !isKubernetesSystemService(serviceName)) {
             List<ServicePort> ports = spec.getPorts();
             log.debug("Service " + serviceName + " has ports: " + ports);
             if (ports.size() == 1) {
@@ -280,7 +280,7 @@ public class IngressEnricher extends BaseEnricher {
         return false;
     }
 
-    private static boolean isKuberentesSystemService(String serviceName) {
+    private static boolean isKubernetesSystemService(String serviceName) {
         return "kubernetes".equals(serviceName) || "kubernetes-ro".equals(serviceName);
     }
 

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
@@ -41,7 +41,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
-import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.containsLabelInMetadata;
+import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.isExposedService;
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.mergeMetadata;
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.mergeSimpleFields;
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.removeItemFromKubernetesBuilder;
@@ -280,10 +280,5 @@ public class RouteEnricher extends BaseEnricher {
             }
         }
         return null;
-    }
-
-    static boolean isExposedService(ObjectMeta objectMeta) {
-        return containsLabelInMetadata(objectMeta, EXPOSE_LABEL, "true") ||
-                containsLabelInMetadata(objectMeta, JKubeAnnotations.SERVICE_EXPOSE_URL.value(), "true");
     }
 }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/IngressEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/IngressEnricherTest.java
@@ -13,21 +13,36 @@
  */
 package org.eclipse.jkube.enricher.generic;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
+import io.fabric8.kubernetes.api.model.extensions.IngressTLSBuilder;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.resource.IngressRuleConfig;
+import org.eclipse.jkube.kit.config.resource.IngressRulePathConfig;
+import org.eclipse.jkube.kit.config.resource.IngressRulePathResourceConfig;
+import org.eclipse.jkube.kit.config.resource.IngressTlsConfig;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.List;
+
 import static org.eclipse.jkube.kit.enricher.api.BaseEnricher.CREATE_EXTERNAL_URLS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class IngressEnricherTest {
     @Mocked
@@ -37,7 +52,21 @@ public class IngressEnricherTest {
     private KitLogger logger;
 
     @Test
-    public void testCreate() {
+    public void testCreateShouldNotCreateAnyIngress() {
+        // Given
+        Service providedService = getTestService().build();
+        KubernetesListBuilder kubernetesListBuilder = new KubernetesListBuilder().addToItems(providedService);
+        IngressEnricher ingressEnricher = new IngressEnricher(context);
+
+        // When
+        ingressEnricher.create(PlatformMode.kubernetes, kubernetesListBuilder);
+
+        // Then
+        assertEquals(1, kubernetesListBuilder.buildItems().size());
+    }
+
+    @Test
+    public void testCreateWithExternalUrlsSetTrue() {
         // Given
         new Expectations() {{
             // Enable creation of Ingress for Service of type LoadBalancer
@@ -63,19 +92,313 @@ public class IngressEnricherTest {
     }
 
     @Test
+    public void testCreateIngressFromXMLConfigWithConfiguredServiceName() {
+        // Given
+        ResourceConfig resourceConfig = ResourceConfig.builder()
+                .ingressRule(IngressRuleConfig.builder()
+                        .host("foo.bar.com")
+                        .paths(Collections.singletonList(IngressRulePathConfig.builder()
+                                .pathType("ImplementationSpecific")
+                                .path("/icons")
+                                .serviceName("hello-k8s")
+                                .servicePort(80)
+                                .build()))
+                        .build())
+                .ingressRule(IngressRuleConfig.builder()
+                        .host("*.foo.com")
+                        .paths(Collections.singletonList(IngressRulePathConfig.builder()
+                                .path("/icons-storage")
+                                .pathType("Exact")
+                                .resource(IngressRulePathResourceConfig.builder()
+                                        .apiGroup("k8s.example.com")
+                                        .kind("StorageBucket")
+                                        .name("icon-assets")
+                                        .build())
+                                .build()))
+                        .build())
+                .ingressTlsConfig(IngressTlsConfig.builder()
+                        .hosts(Collections.singletonList("https-example.foo.com"))
+                        .secretName("testsecret-tls")
+                        .build())
+                .build();
+        new Expectations() {{
+            // Enable creation of Ingress for Service of type LoadBalancer
+            context.getProperty(CREATE_EXTERNAL_URLS);
+            result = "true";
+
+            context.getConfiguration().getResource();
+            result = resourceConfig;
+        }};
+
+        Service providedService = getTestService().build();
+        KubernetesListBuilder kubernetesListBuilder = new KubernetesListBuilder().addToItems(providedService);
+        IngressEnricher ingressEnricher = new IngressEnricher(context);
+
+        // When
+        ingressEnricher.create(PlatformMode.kubernetes, kubernetesListBuilder);
+
+        // Then
+        assertEquals(2, kubernetesListBuilder.buildItems().size());
+        HasMetadata lastItem = kubernetesListBuilder.buildLastItem();
+        assertTrue(lastItem instanceof Ingress);
+        Ingress ingress = (Ingress) lastItem;
+        assertNotNull(ingress);
+        assertEquals(providedService.getMetadata().getName(), ingress.getMetadata().getName());
+        assertNotNull(ingress.getSpec());
+        assertEquals(resourceConfig.getIngressTlsConfigs().get(0).getHosts(), ingress.getSpec().getTls().get(0).getHosts());
+        assertEquals(resourceConfig.getIngressTlsConfigs().get(0).getSecretName(), ingress.getSpec().getTls().get(0).getSecretName());
+        assertEquals(resourceConfig.getIngressRules().get(0).getHost(), ingress.getSpec().getRules().get(0).getHost());
+        assertEquals(resourceConfig.getIngressRules().get(0).getPaths().get(0).getServiceName(), ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServiceName());
+        assertEquals(resourceConfig.getIngressRules().get(0).getPaths().get(0).getServicePort(), ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getBackend().getServicePort().getIntVal().intValue());
+        assertEquals(resourceConfig.getIngressRules().get(0).getPaths().get(0).getPath(), ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPath());
+        assertEquals(resourceConfig.getIngressRules().get(0).getPaths().get(0).getPathType(), ingress.getSpec().getRules().get(0).getHttp().getPaths().get(0).getPathType());
+        assertEquals(resourceConfig.getIngressRules().get(1).getHost(), ingress.getSpec().getRules().get(1).getHost());
+        assertEquals(resourceConfig.getIngressRules().get(1).getPaths().get(0).getResource().getApiGroup(), ingress.getSpec().getRules().get(1).getHttp().getPaths().get(0).getBackend().getResource().getApiGroup());
+        assertEquals(resourceConfig.getIngressRules().get(1).getPaths().get(0).getResource().getKind(), ingress.getSpec().getRules().get(1).getHttp().getPaths().get(0).getBackend().getResource().getKind());
+        assertEquals(resourceConfig.getIngressRules().get(1).getPaths().get(0).getResource().getName(), ingress.getSpec().getRules().get(1).getHttp().getPaths().get(0).getBackend().getResource().getName());
+        assertEquals(resourceConfig.getIngressRules().get(1).getPaths().get(0).getPathType(), ingress.getSpec().getRules().get(1).getHttp().getPaths().get(0).getPathType());
+        assertEquals(resourceConfig.getIngressRules().get(1).getPaths().get(0).getPath(), ingress.getSpec().getRules().get(1).getHttp().getPaths().get(0).getPath());
+    }
+
+    @Test
+    public void testCreateIngressFromResourceFragment() {
+        // Given
+        new Expectations() {{
+            // Enable creation of Ingress for Service of type LoadBalancer
+            context.getProperty(CREATE_EXTERNAL_URLS);
+            result = "true";
+        }};
+
+        Service providedService = getTestService().build();
+        Ingress providedIngress = getTestIngressFragment().build();
+        KubernetesListBuilder kubernetesListBuilder = new KubernetesListBuilder().addToItems(providedService, providedIngress);
+        IngressEnricher ingressEnricher = new IngressEnricher(context);
+
+        // When
+        ingressEnricher.create(PlatformMode.kubernetes, kubernetesListBuilder);
+
+        // Then
+        HasMetadata hasMetadata = kubernetesListBuilder.buildLastItem();
+        assertEquals(2, kubernetesListBuilder.buildItems().size());
+        assertTrue(hasMetadata instanceof Ingress);
+        Ingress ingress = (Ingress) hasMetadata;
+        assertEquals(providedIngress, ingress);
+    }
+
+    @Test
     public void testAddIngress() {
         // Given
         ServiceBuilder testSvcBuilder = getTestService();
         KubernetesListBuilder kubernetesListBuilder = new KubernetesListBuilder().addToItems(testSvcBuilder);
 
         // When
-        Ingress ingress = IngressEnricher.addIngress(kubernetesListBuilder, testSvcBuilder, "org.eclipse.jkube", logger);
+        Ingress ingress = IngressEnricher.addIngress(kubernetesListBuilder, testSvcBuilder, "org.eclipse.jkube", Collections.emptyList(), Collections.emptyList(), logger);
 
         // Then
         assertNotNull(ingress);
         assertEquals(testSvcBuilder.buildMetadata().getName(), ingress.getMetadata().getName());
         assertEquals(1, ingress.getSpec().getRules().size());
         assertEquals(testSvcBuilder.buildMetadata().getName() + "." + "org.eclipse.jkube", ingress.getSpec().getRules().get(0).getHost());
+    }
+
+    @Test
+    public void testAddIngressWithNullServiceMetadata() {
+        // Given
+        ServiceBuilder serviceBuilder = new ServiceBuilder().withMetadata(null);
+        KubernetesListBuilder kubernetesListBuilder = new KubernetesListBuilder().addToItems(serviceBuilder);
+
+        // When
+        Ingress ingress = IngressEnricher.addIngress(kubernetesListBuilder, serviceBuilder, "org.eclipse.jkube", Collections.emptyList(), Collections.emptyList(), logger);
+
+        // Then
+        assertNull(ingress);
+    }
+
+    @Test
+    public void testGetServicePortWithHttpPort() {
+        // Given
+        ServiceBuilder serviceBuilder = getTestService();
+
+        // When
+        Integer port = IngressEnricher.getServicePort(serviceBuilder);
+
+        // Then
+        assertNotNull(port);
+        assertEquals(8080, port.intValue());
+    }
+
+    @Test
+    public void testGetServiceWithNoHttpPort() {
+        // Given
+        ServiceBuilder serviceBuilder = getTestService()
+                .editSpec()
+                .withPorts(new ServicePortBuilder()
+                        .withName("p1")
+                        .withProtocol("TCP")
+                        .withPort(9001)
+                        .build())
+                .endSpec();
+
+        // When
+        Integer port = IngressEnricher.getServicePort(serviceBuilder);
+
+        // Then
+        assertNotNull(port);
+        assertEquals(9001, port.intValue());
+    }
+
+    @Test
+    public void testGetServiceWithNoPort() {
+        // Given
+        ServiceBuilder serviceBuilder = getTestService()
+                .editSpec()
+                .withPorts(Collections.emptyList())
+                .endSpec();
+
+        // When
+        Integer port = IngressEnricher.getServicePort(serviceBuilder);
+
+        // Then
+        assertNotNull(port);
+        assertEquals(0, port.intValue());
+    }
+
+    @Test
+    public void testShouldCreateExternalURLForService() {
+        assertTrue(IngressEnricher.shouldCreateExternalURLForService(getTestService(), logger));
+        assertFalse(IngressEnricher.shouldCreateExternalURLForService(getTestService().editSpec()
+                .withType("ClusterIP")
+                .endSpec(), logger));
+        assertFalse(IngressEnricher.shouldCreateExternalURLForService(getTestService().editSpec()
+                .addNewPort()
+                .withName("p2")
+                .withProtocol("TCP")
+                .withPort(9090)
+                .endPort()
+                .endSpec(), logger));
+    }
+
+    @Test
+    public void testGetRouteDomainNoConfig() {
+        // Given
+        IngressEnricher ingressEnricher = new IngressEnricher(context);
+
+        // When
+        String result = ingressEnricher.getRouteDomain(ResourceConfig.builder().build());
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetRouteDomainFromResourceConfig() {
+        // Given
+        IngressEnricher ingressEnricher = new IngressEnricher(context);
+        ResourceConfig resourceConfig = ResourceConfig.builder()
+                .routeDomain("org.eclipse.jkube")
+                .build();
+
+        // When
+        String result = ingressEnricher.getRouteDomain(resourceConfig);
+
+        // Then
+        assertEquals("org.eclipse.jkube", result);
+    }
+
+    @Test
+    public void testGetRouteDomainFromProperty() {
+        // Given
+        new Expectations() {{
+            context.getProperty("jkube.domain");
+            result = "org.eclipse.jkube";
+        }};
+        IngressEnricher ingressEnricher = new IngressEnricher(context);
+
+        // When
+        String result = ingressEnricher.getRouteDomain(ResourceConfig.builder().build());
+
+        // Then
+        assertEquals("org.eclipse.jkube", result);
+    }
+
+    @Test
+    public void testGetIngressRuleXMLConfigWithNonNullResourceConfig() {
+        // Given
+        ResourceConfig resourceConfig = ResourceConfig.builder()
+                .ingressRule(IngressRuleConfig.builder()
+                        .host("host1")
+                        .build())
+                .build();
+
+        // When
+        List<IngressRuleConfig> ingressRuleXMLConfig = IngressEnricher.getIngressRuleXMLConfig(resourceConfig);
+
+        // Then
+        assertNotNull(ingressRuleXMLConfig);
+        assertEquals(1, ingressRuleXMLConfig.size());
+    }
+
+    @Test
+    public void testGetIngressRuleXMLConfigWithNullResourceConfig() {
+        // Given + When
+        List<IngressRuleConfig> ingressRuleConfigs = IngressEnricher.getIngressRuleXMLConfig(null);
+
+        // Then
+        assertNotNull(ingressRuleConfigs);
+        assertTrue(ingressRuleConfigs.isEmpty());
+    }
+
+    @Test
+    public void testGetIngressTlsXMLConfigWithNonNullResourceConfig() {
+        // Given
+        ResourceConfig resourceConfig = ResourceConfig.builder()
+                .ingressTlsConfig(IngressTlsConfig.builder()
+                        .secretName("secret1")
+                        .build())
+                .build();
+
+        // When
+        List<IngressTlsConfig> ingressTlsConfig = IngressEnricher.getIngressTlsXMLConfig(resourceConfig);
+
+        // Then
+        assertNotNull(ingressTlsConfig);
+        assertEquals(1, ingressTlsConfig.size());
+    }
+
+    @Test
+    public void testGetIngressTlsXMLConfigWithNullResourceConfig() {
+        // Given + When
+        List<IngressTlsConfig> ingressTlsConfigs = IngressEnricher.getIngressTlsXMLConfig(null);
+
+        // Then
+        assertNotNull(ingressTlsConfigs);
+        assertTrue(ingressTlsConfigs.isEmpty());
+    }
+
+    private IngressBuilder getTestIngressFragment() {
+        return new IngressBuilder()
+                .withNewMetadata()
+                .withName("test-svc")
+                .addToAnnotations("ingress.kubernetes.io/rewrite-target", "/")
+                .endMetadata()
+                .withNewSpec()
+                .withTls(new IngressTLSBuilder()
+                        .addNewHost("my.host.com")
+                        .withSecretName("letsencrypt-pod")
+                        .build())
+                .addNewRule()
+                .withHost("my.host.com")
+                .withNewHttp()
+                .addNewPath()
+                .withPath("/")
+                .withPathType("Prefix")
+                .withNewBackend()
+                .withServiceName("test-svc")
+                .withServicePort(new IntOrString(8080))
+                .endBackend()
+                .endPath()
+                .endHttp()
+                .endRule()
+                .endSpec();
     }
 
     private ServiceBuilder getTestService() {

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherTest.java
@@ -223,12 +223,6 @@ public class RouteEnricherTest {
     }
 
     @Test
-    public void testIsExposedService() {
-       assertTrue(RouteEnricher.isExposedService(new ObjectMetaBuilder().addToLabels("expose", "true").build()));
-       assertTrue(RouteEnricher.isExposedService(new ObjectMetaBuilder().addToLabels("jkube.io/exposeUrl", "true").build()));
-    }
-
-    @Test
     public void testMergeRouteWithEmptyFragment() {
         // Given
         Route opinionatedRoute = getMockOpinionatedRoute();

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/kubernetes.yml
@@ -1,0 +1,124 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      jkube.io/git-commit: "@ignore@"
+      prometheus.io/scrape: "true"
+      jkube.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+    labels:
+      expose: "true"
+      app: ingress-xml-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube
+    name: ingress-xml-config
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: ingress-xml-config
+      provider: jkube
+      group: org.eclipse.jkube
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      provider: jkube
+      app: ingress-xml-config
+      version: "@ignore@"
+      group: org.eclipse.jkube
+    name: ingress-xml-config
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: ingress-xml-config
+        provider: jkube
+        group: org.eclipse.jkube
+    template:
+      metadata:
+        annotations:
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          provider: jkube
+          app: ingress-xml-config
+          version: "@ignore@"
+          group: org.eclipse.jkube
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: "@matches('jkube/ingress-xml-config:.*$')@"
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false
+- apiVersion: extensions/v1beta1
+  kind: Ingress
+  metadata:
+    annotations:
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      provider: jkube
+      app: ingress-xml-config
+      version: "@ignore@"
+      group: org.eclipse.jkube
+    name: ingress-xml-config
+  spec:
+    rules:
+    - host: hello.example.systems
+      http:
+        paths:
+        - backend:
+            serviceName: ingress-xml-config
+            servicePort: 8080
+          path: /
+          pathType: ImplementationSpecific
+    tls:
+    - hosts:
+      - https-example.foo.com
+      secretName: testsecret-tls

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/invoker.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+invoker.goals.1=clean k8s:resource
+invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>ingress-xml-config</artifactId>
+  <groupId>org.eclipse.jkube</groupId>
+  <version>0.1-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.3.3.RELEASE</version>
+  </parent>
+
+  <properties>
+    <jkube.createExternalUrls>true</jkube.createExternalUrls>
+    <jkube.domain>org.eclipse.jkube.quickstart</jkube.domain>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+        <version>@jkube.version@</version>
+
+        <configuration>
+          <enricher>
+            <config>
+              <jkube-service>
+                <type>LoadBalancer</type>
+              </jkube-service>
+            </config>
+          </enricher>
+          <resources>
+            <ingressTlsConfigs>
+              <ingressTlsConfig>
+                <hosts>
+                  https-example.foo.com
+                </hosts>
+                <secretName>testsecret-tls</secretName>
+              </ingressTlsConfig>
+            </ingressTlsConfigs>
+            <ingressRules>
+              <ingressRule>
+                <host>hello.example.systems</host>
+                <paths>
+                  <path>
+                    <pathType>ImplementationSpecific</pathType>
+                    <path>/</path>
+                    <serviceName>${project.artifactId}</serviceName>
+                    <servicePort>8080</servicePort>
+                  </path>
+                </paths>
+              </ingressRule>
+            </ingressRules>
+          </resources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/src/main/java/zero/Application.java
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/src/main/java/zero/Application.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package zero;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/verify.groovy
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/verify.groovy
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+import org.eclipse.jkube.maven.it.Verify
+import static org.junit.Assert.*;
+
+[ "kubernetes"   ].each {
+  Verify.verifyResourceDescriptors(
+          new File(basedir, sprintf("/target/classes/META-INF/jkube/%s.yml",it)),
+          new File(basedir, sprintf("/expected/%s.yml",it)))
+}
+true

--- a/quickstarts/maven/spring-boot/pom.xml
+++ b/quickstarts/maven/spring-boot/pom.xml
@@ -212,6 +212,29 @@
                   </jkube-service>
                 </config>
               </enricher>
+              <resources>
+                <ingressTlsConfigs>
+                  <ingressTlsConfig>
+                    <hosts>
+                      https-example.foo.com
+                    </hosts>
+                    <secretName>testsecret-tls</secretName>
+                  </ingressTlsConfig>
+                </ingressTlsConfigs>
+                <ingressRules>
+                  <ingressRule>
+                    <host>hello.example.systems</host>
+                    <paths>
+                      <path>
+                        <pathType>ImplementationSpecific</pathType>
+                        <path>/</path>
+                        <serviceName>${project.artifactId}</serviceName>
+                        <servicePort>8080</servicePort>
+                      </path>
+                    </paths>
+                  </ingressRule>
+                </ingressRules>
+              </resources>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fix #231 : IngressEnricher now supports generating Ingress from XML configuration

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->