### PR TITLE
Fix #455: Use OpenShiftServer with JUnit rule instead of directly instantiating the OpenShiftMockServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.1.0-SNAPSHOT
+* Fix #455: Use OpenShiftServer with JUnit rule instead of directly instantiating the OpenShiftMockServer
 * Fix #467: Upgrade assertj-core to 3.18.0
 * Fix #460: Added a Quickstart for implementing and using a Custom Enricher based on Eclipse JKube Kit Enricher API
 * Fix #240: No Ports exposed inside Deployment in case of Zero Config Dockerfile Mode

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
@@ -53,10 +53,10 @@ public class ApplyServiceTest {
     }
 
     @Test
-    public void testCreateRoute() throws Exception {
+    public void testCreateRoute() {
         Route route = buildRoute();
 
-        WebServerEventCollector<OpenShiftServer> collector = new WebServerEventCollector<>(mockServer);
+        WebServerEventCollector collector = new WebServerEventCollector();
         mockServer.expect().get()
                 .withPath("/apis/route.openshift.io/v1/namespaces/default/routes/route")
                 .andReply(collector.record("get-route").andReturn(HTTP_NOT_FOUND, ""))
@@ -72,7 +72,7 @@ public class ApplyServiceTest {
     }
 
     @Test
-    public void testUpdateRoute() throws Exception {
+    public void testUpdateRoute() {
         Route oldRoute = buildRoute();
         Route newRoute = new RouteBuilder()
                 .withNewMetadataLike(oldRoute.getMetadata())
@@ -81,7 +81,7 @@ public class ApplyServiceTest {
                 .withSpec(oldRoute.getSpec())
                 .build();
 
-        WebServerEventCollector<OpenShiftServer> collector = new WebServerEventCollector<>(mockServer);
+        WebServerEventCollector collector = new WebServerEventCollector();
         mockServer.expect().get()
                 .withPath("/apis/route.openshift.io/v1/namespaces/default/routes/route")
                 .andReply(collector.record("get-route").andReturn(HTTP_OK, oldRoute))
@@ -101,10 +101,10 @@ public class ApplyServiceTest {
     }
 
     @Test
-    public void testCreateRouteInServiceOnlyMode() throws Exception {
+    public void testCreateRouteInServiceOnlyMode() {
         Route route = buildRoute();
 
-        WebServerEventCollector<OpenShiftServer> collector = new WebServerEventCollector<>(mockServer);
+        WebServerEventCollector collector = new WebServerEventCollector();
         mockServer.expect().get()
                 .withPath("/apis/route.openshift.io/v1/namespaces/default/routes/route")
                 .andReply(collector.record("get-route").andReturn(HTTP_NOT_FOUND, ""))
@@ -118,10 +118,10 @@ public class ApplyServiceTest {
     }
 
     @Test
-    public void testCreateRouteNotAllowed() throws Exception {
+    public void testCreateRouteNotAllowed() {
         Route route = buildRoute();
 
-        WebServerEventCollector<OpenShiftServer> collector = new WebServerEventCollector<>(mockServer);
+        WebServerEventCollector collector = new WebServerEventCollector();
         mockServer.expect().get()
                 .withPath("/apis/route.openshift.io/v1/namespaces/default/routes/route")
                 .andReply(collector.record("get-route").andReturn(HTTP_NOT_FOUND, ""))
@@ -141,7 +141,7 @@ public class ApplyServiceTest {
         crdNames.add("virtualservices.networking.istio.io");
         crdNames.add("gateways.networking.istio.io");
         File crFragmentDir = new File(getClass().getResource("/gateway-cr.yml").getFile()).getParentFile();
-        WebServerEventCollector<OpenShiftServer> collector = new WebServerEventCollector<>(mockServer);
+        WebServerEventCollector collector = new WebServerEventCollector();
         mockServer.expect().get()
                 .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/virtualservices.networking.istio.io")
                 .andReply(collector.record("get-crd-virtualservice").andReturn(HTTP_OK, getVirtualServiceIstioCRD()))
@@ -174,7 +174,7 @@ public class ApplyServiceTest {
         crdNames.add("virtualservices.networking.istio.io");
         crdNames.add("gateways.networking.istio.io");
         File crFragmentDir = new File(getClass().getResource("/gateway-cr.yml").getFile()).getParentFile();
-        WebServerEventCollector<OpenShiftServer> collector = new WebServerEventCollector<>(mockServer);
+        WebServerEventCollector collector = new WebServerEventCollector();
         mockServer.expect().get()
                 .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/virtualservices.networking.istio.io")
                 .andReply(collector.record("get-crd-virtualservice").andReturn(HTTP_OK, getVirtualServiceIstioCRD()))
@@ -215,7 +215,7 @@ public class ApplyServiceTest {
         crdNames.add("virtualservices.networking.istio.io");
         crdNames.add("gateways.networking.istio.io");
         File crFragmentDir = new File(getClass().getResource("/gateway-cr.yml").getFile()).getParentFile();
-        WebServerEventCollector<OpenShiftServer> collector = new WebServerEventCollector<>(mockServer);
+        WebServerEventCollector collector = new WebServerEventCollector();
         mockServer.expect().get()
                 .withPath("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/virtualservices.networking.istio.io")
                 .andReply(collector.record("get-crd-virtualservice").andReturn(HTTP_OK, getVirtualServiceIstioCRD()))

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServiceTest.java
@@ -20,12 +20,13 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.ProcessUtil;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.Closeable;
@@ -42,6 +43,9 @@ public class PortForwardServiceTest {
     @Mocked
     private ClientToolsService clientToolsService;
 
+    @Rule
+    public final OpenShiftServer mockServer = new OpenShiftServer(false);
+
     @Before
     public void init() throws Exception {
         new Expectations() {{
@@ -52,7 +56,6 @@ public class PortForwardServiceTest {
     @Test
     public void testSimpleScenario() throws Exception {
         // Cannot test more complex scenarios due to errors in mockwebserver
-        OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
 
         Pod pod1 = new PodBuilder()
                 .withNewMetadata()
@@ -86,7 +89,7 @@ public class PortForwardServiceTest {
                 .andEmit(new WatchEvent(pod1, "MODIFIED"))
                 .done().always();
 
-        OpenShiftClient client = mockServer.createOpenShiftClient();
+        OpenShiftClient client = mockServer.getOpenshiftClient();
         PortForwardService service = new PortForwardService(client, logger) {
             @Override
             public ProcessUtil.ProcessExecutionContext forwardPortAsync(KitLogger externalProcessLogger, String pod, String namespace, int remotePort, int localPort) throws JKubeServiceException {

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceTest.java
@@ -332,7 +332,6 @@ public class OpenshiftBuildServiceTest {
             jKubeServiceHub.getBuildServiceConfig(); result = config;
         }};
         // @formatter:off
-        WebServerEventCollector collector = createMockServer(config, false, 50, false, false);
 
         OpenShiftClient client = mockServer.getOpenshiftClient();
         OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
@@ -347,7 +346,6 @@ public class OpenshiftBuildServiceTest {
             jKubeServiceHub.getBuildServiceConfig(); result = config;
         }};
         // @formatter:off
-        WebServerEventCollector collector = createMockServer(config, false, 50, false, false);
 
         OpenShiftClient client = mockServer.getOpenshiftClient();
         OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
@@ -384,7 +382,6 @@ public class OpenshiftBuildServiceTest {
                 jKubeServiceHub.getBuildServiceConfig(); result = config;
             }};
             // @formatter:off
-            WebServerEventCollector collector = createMockServer(config, true, 50, true, true);
 
             OpenShiftClient client = mockServer.getOpenshiftClient();
             final OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
@@ -433,7 +430,6 @@ public class OpenshiftBuildServiceTest {
                 jKubeServiceHub.getBuildServiceConfig(); result = config;
             }};
             // @formatter:off
-            WebServerEventCollector collector = createMockServer(config, true, 50, true, true);
 
             OpenShiftClient client = mockServer.getOpenshiftClient();
             final OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
@@ -641,7 +637,7 @@ public class OpenshiftBuildServiceTest {
                 .always();
 
         mockServer.expect().withPath("/apis/build.openshift.io/v1/namespaces/test/builds/" + projectName).andReturn(200, build).always();
-        mockServer.expect().withPath("/apis/build.openshift.io/v1/namespaces/test/builds/" + projectName + "?watch=true")
+        mockServer.expect().withPath("/apis/build.openshift.io/v1/namespaces/test/builds?fieldSelector=metadata.name%3D" + projectName + "&watch=true")
                 .andUpgradeToWebSocket().open()
                 .waitFor(buildDelay)
                 .andEmit(new WatchEvent(build, "MODIFIED"))

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/PatchServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/PatchServiceTest.java
@@ -22,12 +22,13 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
-import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.UserConfigurationCompare;
 import org.eclipse.jkube.kit.config.service.PatchService;
 import mockit.Mocked;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -39,13 +40,14 @@ public class PatchServiceTest {
     @Mocked
     private KitLogger log;
 
-    private OpenShiftMockServer mockServer = new OpenShiftMockServer(false);
+    @Rule
+    public final OpenShiftServer mockServer = new OpenShiftServer(false);
 
     private PatchService patchService;
 
     @Before
     public void setUp() {
-        patchService = new PatchService(mockServer.createOpenShiftClient(), log);
+        patchService = new PatchService(mockServer.getOpenshiftClient(), log);
     }
 
     @Test
@@ -85,7 +87,7 @@ public class PatchServiceTest {
                 .withNewMetadata().withName("secret").endMetadata()
                 .addToStringData("test", "test")
                 .build();
-        WebServerEventCollector<OpenShiftMockServer> collector = new WebServerEventCollector<>(mockServer);
+        WebServerEventCollector<OpenShiftServer> collector = new WebServerEventCollector<>(mockServer);
         mockServer.expect().get().withPath("/api/v1/namespaces/test/secrets/secret")
                 .andReply(collector.record("get-secret").andReturn(200, oldSecret)).always();
         mockServer.expect().patch().withPath("/api/v1/namespaces/test/secrets/secret")

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/PatchServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/PatchServiceTest.java
@@ -87,7 +87,7 @@ public class PatchServiceTest {
                 .withNewMetadata().withName("secret").endMetadata()
                 .addToStringData("test", "test")
                 .build();
-        WebServerEventCollector<OpenShiftServer> collector = new WebServerEventCollector<>(mockServer);
+        WebServerEventCollector collector = new WebServerEventCollector();
         mockServer.expect().get().withPath("/api/v1/namespaces/test/secrets/secret")
                 .andReply(collector.record("get-secret").andReturn(200, oldSecret)).always();
         mockServer.expect().patch().withPath("/api/v1/namespaces/test/secrets/secret")

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/WebServerEventCollector.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/WebServerEventCollector.java
@@ -13,7 +13,6 @@
  */
 package org.eclipse.jkube.kit.config.service.openshift;
 
-import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.mockwebserver.utils.ResponseProvider;
 import okhttp3.Headers;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -29,7 +28,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 /**
  * A utility class to record http request events.
  */
-public class WebServerEventCollector<C extends KubernetesMockServer> {
+public class WebServerEventCollector<C> {
 
     private C mockServer;
 

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/WebServerEventCollector.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/WebServerEventCollector.java
@@ -28,25 +28,19 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 /**
  * A utility class to record http request events.
  */
-public class WebServerEventCollector<C> {
+public class WebServerEventCollector {
 
-    private C mockServer;
+    private final Queue<String> events;
+    private final List<String> bodies;
 
-    private Queue<String> events = new ConcurrentLinkedQueue<>();
-    private List<String> bodies = new ArrayList<>();
-
-    public WebServerEventCollector(C mockServer) {
-        this.mockServer = mockServer;
-    }
-
-    public C getMockServer() {
-        return mockServer;
+    public WebServerEventCollector() {
+        events = new ConcurrentLinkedQueue<>();
+        bodies = new ArrayList<>();
     }
 
     public List<String> getBodies() {
         return bodies;
     }
-
 
     public void assertEventsRecorded(String... expectedEvents) {
         for (String exp : expectedEvents) {
@@ -85,7 +79,7 @@ public class WebServerEventCollector<C> {
 
     public class WebServerEventRecorder {
 
-        private String event;
+        private final String event;
 
         public WebServerEventRecorder(String event) {
             this.event = event;


### PR DESCRIPTION
Fix #455 
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->