### PR TITLE
issue-513: Assign default name for the port number only if no explici…

### DIFF
--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
@@ -602,7 +602,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
     }
 
     private void ensurePortName(ServicePort port, String protocol) {
-        if (port.getName() != null && !port.getName().isEmpty()) {
+        if (port.getName() == null || port.getName().isEmpty()) {
             port.setName(getDefaultPortName(port.getPort(), getProtocol(protocol)));
         }
     }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
@@ -85,7 +85,7 @@ public class DefaultServiceEnricherAddMissingPartsTest {
     imageConfigurationWithPort("80");
     final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(
         new ServiceBuilder().editOrNewSpec().addNewPort()
-            .withName("iana-replaced").withProtocol("TCP").withPort(1337).endPort().endSpec().build());
+            .withProtocol("TCP").withPort(1337).endPort().endSpec().build());
     // When
     enricher.create(null, klb);
     // Then


### PR DESCRIPTION
Fixes #513 by only assigning a default name (based on port number) if there is no explicit name provided.

I am unable to execute tests (I don't have the infrastructure to do so) and it is inevitable there will be a test failure resulting from this change.  Fix the test by removing the explicit name, so that the default name for the port number is assigned instead.

I have built this locally and can confirm that it does solve my problem as described in #513.  Specifically, my deployed "cache" service exposes two named ports, "http" TCP 80 -> 8080 and "hazelcast" TCP 5701 -> 5701.

![ServiceFragment](https://user-images.githubusercontent.com/13133023/101552761-500aad80-39ab-11eb-9298-79871505c9ad.PNG)

![ServicePortMapping](https://user-images.githubusercontent.com/13133023/101552768-513bda80-39ab-11eb-9ca5-b4dc220f86b9.PNG)

