### PR TITLE
issue-513: Assign default name for the port number only if no explici…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Usage:
 * Fix #509: Port of ServiceDiscoveryEnricher from FMP
 * Fix #511: Namespace as resource fragment results in NullPointerException
 * Fix #521: NPE on Buildconfig#getContextDir if `<dockerFile>` references a file with no directory
+* Fix #513: openshift-maven-plugin: service.yml fragment with ports creates service with unnamed port mapping
 
 ### 1.0.2 (2020-10-30)
 * Fix #429: Added quickstart for Micronaut framework

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
@@ -529,7 +530,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
 
     private String getDefaultServiceName(Service defaultService) {
         String defaultServiceName = KubernetesHelper.getName(defaultService);
-        if (defaultServiceName != null && !defaultServiceName.isEmpty()) {
+        if (StringUtils.isBlank(defaultServiceName)) {
             defaultServiceName = getContext().getGav().getSanitizedArtifactId();
         }
         return defaultServiceName;
@@ -562,7 +563,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
 
     private String ensureServiceName(ObjectMeta serviceMetadata, ServiceBuilder service, String defaultServiceName) {
         String serviceName = KubernetesHelper.getName(serviceMetadata);
-        if (serviceName != null && !serviceName.isEmpty()) {
+        if (StringUtils.isBlank(serviceName)) {
             service.buildMetadata().setName(defaultServiceName);
             serviceName = KubernetesHelper.getName(service.buildMetadata());
         }
@@ -602,14 +603,14 @@ public class DefaultServiceEnricher extends BaseEnricher {
     }
 
     private void ensurePortName(ServicePort port, String protocol) {
-        if (port.getName() == null || port.getName().isEmpty()) {
+        if (StringUtils.isBlank(port.getName())) {
             port.setName(getDefaultPortName(port.getPort(), getProtocol(protocol)));
         }
     }
 
     private String ensureProtocol(ServicePort port) {
         String protocol = port.getProtocol();
-        if (protocol != null && !protocol.isEmpty()) {
+        if (StringUtils.isBlank(protocol)) {
             port.setProtocol("TCP");
             return "TCP";
         }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
@@ -602,7 +602,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
     }
 
     private void ensurePortName(ServicePort port, String protocol) {
-        if (port.getName() != null && !port.getName().isEmpty()) {
+        if (port.getName() == null || port.getName().isEmpty()) {
             port.setName(getDefaultPortName(port.getPort(), getProtocol(protocol)));
         }
     }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
@@ -85,7 +85,7 @@ public class DefaultServiceEnricherAddMissingPartsTest {
     imageConfigurationWithPort("80");
     final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(
         new ServiceBuilder().editOrNewSpec().addNewPort()
-            .withName("iana-replaced").withProtocol("TCP").withPort(1337).endPort().endSpec().build());
+            .withProtocol("TCP").withPort(1337).endPort().endSpec().build());
     // When
     enricher.create(null, klb);
     // Then


### PR DESCRIPTION
Fixes #513 by only assigning a default name (based on port number) if there is no explicit name provided.

I am unable to execute tests (I don't have the infrastructure to do so) and it is inevitable there will be a test failure resulting from this change.  Fix the test by removing the explicit name, so that the default name for the port number is assigned instead.

I have built this locally and can confirm that it does solve my problem as described in #513.  Specifically, my deployed "cache" service exposes two named ports, "http" TCP 80 -> 8080 and "hazelcast" TCP 5701 -> 5701.

![ServiceFragment](https://user-images.githubusercontent.com/13133023/101552761-500aad80-39ab-11eb-9298-79871505c9ad.PNG)

![ServicePortMapping](https://user-images.githubusercontent.com/13133023/101552768-513bda80-39ab-11eb-9ca5-b4dc220f86b9.PNG)