### PR TITLE
Fix #511: Namespace as resource fragment results in NullPointerException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Usage:
 * Fix #181: Refactor PortForwardService to use Kubernetes Client Port Forwarding instead of kubectl binary
 * Fix #535: Bump JKube base images to 0.0.9
 * Fix #509: Port of ServiceDiscoveryEnricher from FMP
+* Fix #511: Namespace as resource fragment results in NullPointerException
 
 ### 1.0.2 (2020-10-30)
 * Fix #429: Added quickstart for Micronaut framework

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
@@ -80,7 +80,7 @@ public class KubernetesUndeployServiceTest {
   }
 
   @Test
-  public void undeployWithManifestShouldDeleteApplicableEntities(@Mocked File file) throws Exception {
+  public void undeployWithManifestShouldDeleteAllEntities(@Mocked File file) throws Exception {
     // Given
     final Namespace namespace = new NamespaceBuilder().withNewMetadata().withName("default").endMetadata().build();
     final Pod pod = new PodBuilder().withNewMetadata().withName("MrPoddington").endMetadata().build();
@@ -113,7 +113,7 @@ public class KubernetesUndeployServiceTest {
   }
 
   @Test
-  public void undeployWithManifestAndCustomResourcesShouldDeleteApplicableEntities(
+  public void undeployWithManifestAndCustomResourcesShouldDeleteAllEntities(
       @Mocked ResourceConfig resourceConfig) throws Exception {
     // Given
     final File manifest = temporaryFolder.newFile("temp.yml");

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
@@ -98,12 +98,15 @@ public class KubernetesUndeployServiceTest {
     // Then
     // @formatter:off
     new Verifications() {{
-      kubernetesHelper.getKind((HasMetadata)any); times = 2;
+      kubernetesHelper.getKind((HasMetadata)any); times = 3;
       jKubeServiceHub.getClient().resource(pod).inNamespace("default")
           .withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
       times = 1;
       jKubeServiceHub.getClient().resource(service).inNamespace("default")
           .withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
+      times = 1;
+      jKubeServiceHub.getClient().resource(namespace)
+              .withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
       times = 1;
     }};
     // @formatter:on

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricher.java
@@ -18,10 +18,12 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.NamespaceStatus;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.api.model.ProjectBuilder;
+import io.fabric8.openshift.api.model.ProjectStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
@@ -134,18 +136,26 @@ public class DefaultNamespaceEnricher extends BaseEnricher {
         builder.accept(new TypedVisitor<NamespaceBuilder>() {
             @Override
             public void visit(NamespaceBuilder builder) {
-                if (builder.buildStatus().getPhase().equals("active")) {
+                // Set status as empty
+                NamespaceStatus status = builder.buildStatus();
+                if (status != null && status.getPhase().equals("active")) {
                     builder.editOrNewStatus().endStatus().build();
                 }
+                // Set metadata.namespace as null
+                builder.editOrNewMetadata().withNamespace(null).endMetadata();
             }
         });
 
         builder.accept(new TypedVisitor<ProjectBuilder>() {
             @Override
             public void visit(ProjectBuilder builder) {
-                if (builder.buildStatus().getPhase().equals("active")) {
+                // Set status as empty
+                ProjectStatus status = builder.buildStatus();
+                if (status != null && status.getPhase().equals("active")) {
                     builder.editOrNewStatus().endStatus().build();
                 }
+                // Set metadata.namespace as null
+                builder.editOrNewMetadata().withNamespace(null).endMetadata();
             }
         });
     }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricherTest.java
@@ -13,11 +13,13 @@
  */
 package org.eclipse.jkube.enricher.generic;
 
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.openshift.api.model.Project;
+import io.fabric8.openshift.api.model.ProjectBuilder;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -30,6 +32,7 @@ import java.util.Collections;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNull;
 
 public class DefaultNamespaceEnricherTest {
 
@@ -108,18 +111,71 @@ public class DefaultNamespaceEnricherTest {
   }
 
   @Test
-  public void enrichWithPropertiesInKubernetesShouldAddNamespace() {
+  public void enrichWithPropertiesInKubernetesShouldAddNamespaceWithStatus() {
     // Given
     properties.put("jkube.enricher.jkube-namespace.namespace", "example");
     final KubernetesListBuilder klb = new KubernetesListBuilder();
-    klb.addToItems(new NamespaceBuilder()
-        .editOrNewMetadata().withName("name").withNamespace("to-be-overwritten").endMetadata()
-        .editOrNewStatus().withPhase("active").endStatus().build());
+    Namespace namespace = new NamespaceBuilder()
+            .editOrNewMetadata().withName("name").withNamespace("to-be-overwritten").endMetadata()
+            .editOrNewStatus().withPhase("active").endStatus().build();
+    Deployment deployment = new DeploymentBuilder().withNewMetadata().withName("d1").endMetadata().build();
+    klb.addToItems(namespace, deployment);
     // When
     new DefaultNamespaceEnricher(context).enrich(PlatformMode.kubernetes, klb);
     // Then
+    assertThat(klb.build().getItems()).hasSize(2);
+    assertThat(klb.build().getItems().get(1))
+        .hasFieldOrPropertyWithValue("metadata.namespace", "example");
+  }
+
+  @Test
+  public void enrichWithPropertiesInKubernetesShouldAddProjectWithStatus() {
+    // Given
+    final KubernetesListBuilder klb = new KubernetesListBuilder();
+    klb.addToItems(new ProjectBuilder()
+            .withNewMetadata().withName("name").endMetadata()
+            .withNewStatus().withPhase("active").endStatus().build());
+    // When
+    new DefaultNamespaceEnricher(context).enrich(PlatformMode.openshift, klb);
+    // Then
     assertThat(klb.build().getItems()).hasSize(1);
     assertThat(klb.build().getItems().iterator().next())
-        .hasFieldOrPropertyWithValue("metadata.namespace", "example");
+            .hasFieldOrPropertyWithValue("metadata.namespace", null);
+  }
+
+  @Test
+  public void enrichWithNamespaceFragmentWithNoStatus() {
+    // Given
+    final KubernetesListBuilder kubernetesListBuilder = new KubernetesListBuilder();
+    kubernetesListBuilder.addToItems(new NamespaceBuilder()
+            .withNewMetadata().withName("test-jkube").endMetadata()
+            .build());
+
+    // When
+    new DefaultNamespaceEnricher(context).enrich(PlatformMode.kubernetes, kubernetesListBuilder);
+
+    // Then
+    assertThat(kubernetesListBuilder.build().getItems()).hasSize(1);
+    assertThat(kubernetesListBuilder.build().getItems().iterator().next())
+            .hasFieldOrPropertyWithValue("metadata.name", "test-jkube");
+    assertNull(kubernetesListBuilder.build().getItems().get(0).getMetadata().getNamespace());
+  }
+
+  @Test
+  public void enrichWithOpenShiftProjectFragmentWithNoStatus() {
+    // Given
+    final KubernetesListBuilder kubernetesListBuilder = new KubernetesListBuilder();
+    kubernetesListBuilder.addToItems(new ProjectBuilder()
+            .withNewMetadata().withName("test-jkube").endMetadata()
+            .build());
+
+    // When
+    new DefaultNamespaceEnricher(context).enrich(PlatformMode.openshift, kubernetesListBuilder);
+
+    // Then
+    assertThat(kubernetesListBuilder.build().getItems()).hasSize(1);
+    assertThat(kubernetesListBuilder.build().getItems().iterator().next())
+            .hasFieldOrPropertyWithValue("metadata.name", "test-jkube");
+    assertNull(kubernetesListBuilder.build().getItems().get(0).getMetadata().getNamespace());
   }
 }


### PR DESCRIPTION
Fix #511 

+ DefaultNamespaceEnricher should handle case when status is not provided in resource spec.
+ `.metadata.namespace` should be omitted from Project/Namespace resources since they are Cluster scoped
+ UndeployService should consider Project/Namespace resource while deletion phase

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->