### PR TITLE
Returns "./" if <dockerFile> doesn't include a directory to avoid NPE

### DIFF
--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/BuildConfiguration.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/BuildConfiguration.java
@@ -252,7 +252,8 @@ public class BuildConfiguration implements Serializable {
   }
 
   public File getContextDir() {
-    return contextDir != null ? new File(contextDir) : getDockerFile().getParentFile();
+    return contextDir != null ? new File(contextDir)
+        : Optional.ofNullable(getDockerFile().getParentFile()).orElse(new File("."));
   }
 
   public String getContextDirRaw() {
@@ -289,7 +290,6 @@ public class BuildConfiguration implements Serializable {
   public List<String> getRunCmds() {
     return removeEmptyEntries(runCmds);
   }
-
 
   public boolean optimise() {
     return Optional.ofNullable(optimise).orElse(false);


### PR DESCRIPTION
## Description

Prevents NPE thrown when `<dockerFile>` has no directory included (#518 )

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
