### PR TITLE
deps: Bump JKube base images to 0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Usage:
 * Fix #473: Debug goals work with QuarkusGenerator generated container images
 * Fix #484: cacheFrom configuration parameter is missing
 * Fix #181: Refactor PortForwardService to use Kubernetes Client Port Forwarding instead of kubectl binary
+* Fix #535: Bump JKube base images to 0.0.9
 
 ### 1.0.2 (2020-10-30)
 * Fix #429: Added quickstart for Micronaut framework

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -76,7 +76,7 @@
     <version.wagon-ssh-external>2.3</version.wagon-ssh-external>
 
     <!-- =======================================================  -->
-    <version.image.jkube-images>0.0.8</version.image.jkube-images>
+    <version.image.jkube-images>0.0.9</version.image.jkube-images>
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
     <!-- Upstream -->
     <version.image.java.upstream.docker>${version.image.jkube-images}</version.image.java.upstream.docker>

--- a/quickstarts/kit/custom-istio-enricher/README.md
+++ b/quickstarts/kit/custom-istio-enricher/README.md
@@ -26,7 +26,7 @@ app : $ mvn k8s:resource
 [INFO] --- kubernetes-maven-plugin:1.1.0-SNAPSHOT:resource (default-cli) @ eclipse-jkube-sample-custom-enricher-app ---
 [WARNING] k8s: Cannot access cluster for detecting mode: No route to host (Host unreachable)
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.8 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.9 as base / builder
 [INFO] k8s: Using resource templates from /home/rohaan/work/repos/jkube/quickstarts/kit/custom-istio-enricher/app/src/main/jkube
 [INFO] k8s: jkube-service: Adding a default service 'eclipse-jkube-sample-custom-enricher-app' with ports [8080]
 [INFO] k8s: jkube-revision-history: Adding revision history limit to 2

--- a/quickstarts/maven/micronaut-customized-image/pom.xml
+++ b/quickstarts/maven/micronaut-customized-image/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <jkube.version>${project.version}</jkube.version>
-    <jkube.image.version>0.0.8</jkube.image.version>
+    <jkube.image.version>0.0.9</jkube.image.version>
     <micronaut.version>${parent.version}</micronaut.version>
     <exec.mainClass>org.eclipse.jkube.quickstart.micronaut.custom.Application</exec.mainClass>
   </properties>

--- a/quickstarts/maven/micronaut/pom.xml
+++ b/quickstarts/maven/micronaut/pom.xml
@@ -36,7 +36,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <jkube.version>${project.version}</jkube.version>
-    <jkube.image.version>0.0.8</jkube.image.version>
+    <jkube.image.version>0.0.9</jkube.image.version>
     <micronaut.version>${parent.version}</micronaut.version>
     <exec.mainClass>org.eclipse.jkube.quickstart.micronaut.custom.Application</exec.mainClass>
   </properties>

--- a/quickstarts/maven/spring-boot-with-jib/README.md
+++ b/quickstarts/maven/spring-boot-with-jib/README.md
@@ -35,16 +35,16 @@ To build project issue this command:
 [INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.5 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.9 as base / builder
 [INFO] k8s: JIB image build started
-JIB> Base image 'quay.io/jkube/jkube-java-binary-s2i:0.0.5' does not use a specific image digest - build may not be reproducible
+JIB> Base image 'quay.io/jkube/jkube-java-binary-s2i:0.0.9' does not use a specific image digest - build may not be reproducible
 JIB> Containerizing application with the following files:                                                                    
 JIB> 	:                                                                                                                      
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/maven/eclipse-jkube-sample-spring-boot-jib/latest/build/Dockerfilek8s: 
 JIB> 	:                                                                                                                      
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/maven/eclipse-jkube-sample-spring-boot-jib/latest/build/deployments8s: 
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/maven/eclipse-jkube-sample-spring-boot-jib/latest/build/deployments/eclipse-jkube-sample-spring-boot-jib-1.0.0-SNAPSHOT.jar
-JIB> Getting manifest for base image quay.io/jkube/jkube-java-binary-s2i:0.0.5...                                            
+JIB> Getting manifest for base image quay.io/jkube/jkube-java-binary-s2i:0.0.9...                                            
 JIB> Building  layer...                                                                                                      
 JIB> Building  layer...                                                                                                      
 JIB> Using base image with digest: sha256:0bdf76ac67d0dc03e8d474edce515ea839810d561b9f1c799ebda1d6e6b7789e                   
@@ -89,16 +89,16 @@ Once we add this property we need to do `mvn k8s:build -PJib-Zero-Config` again 
 [INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.7 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.9 as base / builder
 [INFO] k8s: JIB image build started
-JIB> Base image 'quay.io/jkube/jkube-java-binary-s2i:0.0.7' does not use a specific image digest - build may not be reproducible
+JIB> Base image 'quay.io/jkube/jkube-java-binary-s2i:0.0.9' does not use a specific image digest - build may not be reproducible
 JIB> Containerizing application with the following files:                                                                    
 JIB> 	:                                                                                                                      
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/docker.io/rohankanojia/spring-boot-with-jib/1.0.0-SNAPSHOT/build/Dockerfile
 JIB> 	:                                                                                                                      
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/docker.io/rohankanojia/spring-boot-with-jib/1.0.0-SNAPSHOT/build/deployments
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/docker.io/rohankanojia/spring-boot-with-jib/1.0.0-SNAPSHOT/build/deployments/eclipse-jkube-sample-spring-boot-jib-1.0.0-SNAPSHOT.jar
-JIB> Getting manifest for base image quay.io/jkube/jkube-java-binary-s2i:0.0.7...                                            
+JIB> Getting manifest for base image quay.io/jkube/jkube-java-binary-s2i:0.0.9...                                            
 JIB> Building  layer...                                                                                                      
 JIB> Building  layer...                                                                                                      
 JIB> Using base image with digest: sha256:c834f2b076488a81bd4f59397712940b1187681e190f008ffe2c91ae4787290f                   
@@ -125,7 +125,7 @@ JIB> [==============================] 100.0% complete
 [INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.7 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.9 as base / builder
 [INFO] k8s: This push refers to: docker.io/rohankanojia/spring-boot-with-jib:1.0.0-SNAPSHOT
 JIB> Containerizing application with the following files:                                                                    
 JIB> Retrieving registry credentials for registry-1.docker.io...                                                             
@@ -168,7 +168,7 @@ Once image has been loaded in your docker daemon. You can generate and apply man
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:resource (default-cli) @ eclipse-jkube-sample-spring-boot-jib ---
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.5 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.9 as base / builder
 [INFO] k8s: jkube-controller: Adding a default Deployment
 [INFO] k8s: jkube-service: Adding a default service 'eclipse-jkube-sample-spring-boot-jib' with ports [8080]
 [INFO] k8s: jkube-healthcheck-spring-boot: Adding readiness probe on port 8080, path='/health', scheme='HTTP', with initial delay 10 seconds

--- a/quickstarts/maven/xml-config/pom.xml
+++ b/quickstarts/maven/xml-config/pom.xml
@@ -174,7 +174,7 @@
               <!-- "alias" is used to correlate to the containers in the pod spec -->
               <alias>camel-service</alias>
               <build>
-                <from>quay.io/jkube/jkube-java-binary-s2i:0.0.7</from>
+                <from>quay.io/jkube/jkube-java-binary-s2i:0.0.9</from>
                 <assembly>
                   <targetDir>/deployments</targetDir>
                   <inline>


### PR DESCRIPTION
## Description
deps: Bump JKube base images to 0.0.9

Provides jkube-java-binary-s2i image with openjdk version "11.0.9.1" 2020-11-04 LTS

From:
```
openjdk version "11.0.8" 2020-07-14 LTS
OpenJDK Runtime Environment 18.9 (build 11.0.8+10-LTS)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.8+10-LTS, mixed mode, sharing)
```

To:
```
openjdk version "11.0.9.1" 2020-11-04 LTS
OpenJDK Runtime Environment 18.9 (build 11.0.9.1+1-LTS)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.9.1+1-LTS, mixed mode, sharing)
```

Relates to: https://github.com/jkubeio/jkube-images/pull/4

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] ~~I have implemented unit tests to cover my changes~~ 
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->