### PR TITLE
Fix for #537, Typo in WildFly bootable JAR healthCheck documentation

### DIFF
--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_healthcheck_wildfly_jar.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_healthcheck_wildfly_jar.adoc
@@ -17,7 +17,7 @@ The enricher will use the following settings by default:
 - readinessPath = `/health/ready`
 - livenessPath = `/health/live`
 - livenessInitialDelay = `60`
-- readinessIntialDelay = `10`
+- readinessInitialDelay = `10`
 - failureThreshold = `3`
 - successThreshold = `1`
 - enforceProbes = 'false'


### PR DESCRIPTION
Signed-off-by: JF Denise jdenise@redhat.com

## Description
Fix typo.

## Type of change

 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
