### PR TITLE
Fix #523: period in image username omits registry in Deployment manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Usage:
 * Fix #521: NPE on Buildconfig#getContextDir if `<dockerFile>` references a file with no directory
 * Fix #513: openshift-maven-plugin: service.yml fragment with ports creates service with unnamed port mapping
 * Fix #231: IngressEnricher ignores IngressRules defined in XML config
+* Fix #523: period in image username omits registry in Deployment manifest
 
 ### 1.0.2 (2020-10-30)
 * Fix #429: Added quickstart for Micronaut framework

--- a/jkube-kit/config/image/pom.xml
+++ b/jkube-kit/config/image/pom.xml
@@ -59,5 +59,10 @@
       <artifactId>hamcrest-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -142,8 +142,16 @@ public class ImageName {
         return builder.toString();
     }
 
-    private boolean isRegistry(String part) {
-        return part.contains(".") || part.contains(":");
+    private boolean containsPeriodOrColon(String part) {
+        return containsPeriod(part) || containsColon(part);
+    }
+
+    private boolean containsPeriod(String part) {
+        return part.contains(".");
+    }
+
+    private boolean containsColon(String part) {
+        return part.contains(":");
     }
 
     /**
@@ -275,14 +283,11 @@ public class ImageName {
             user = null;
             repository = parts[0];
         } else if (parts.length >= 2) {
-            if (isRegistry(parts[0])) {
-                registry = parts[0];
+            if (containsPeriodOrColon(parts[0])) {
                 if (parts.length > 2) {
-                    user = parts[1];
-                    repository = joinTail(parts);
+                    assignRegistryUserAndRepository(parts);
                 } else {
-                    user = null;
-                    repository = parts[1];
+                    checkWhetherFirstElementIsUserOrRegistryAndAssign(parts);
                 }
             } else {
                 registry = null;
@@ -290,6 +295,30 @@ public class ImageName {
                 repository = rest;
             }
         }
+    }
+
+    private void checkWhetherFirstElementIsUserOrRegistryAndAssign(String[] parts) {
+        if (containsColon(parts[0])) {
+            assignRegistryAndRepository(parts);
+        } else {
+            assignUserAndRepository(parts);
+        }
+    }
+
+    private void assignRegistryUserAndRepository(String[] parts) {
+        registry = parts[0];
+        user = parts[1];
+        repository = joinTail(parts);
+    }
+
+    private void assignUserAndRepository(String[] parts) {
+        user = parts[0];
+        repository = String.join("/", parts);
+    }
+
+    private void assignRegistryAndRepository(String[] parts) {
+        registry = parts[0];
+        repository = parts[1];
     }
 
     // ================================================================================================

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameFullNameParseTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameFullNameParseTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.image;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class ImageNameFullNameParseTest {
+
+  @Parameterized.Parameter
+  public String testName;
+
+  @Parameterized.Parameter(1)
+  public String providedFullName;
+
+  @Parameterized.Parameter(2)
+  public String expectedFullName;
+
+  @Parameterized.Parameter(3)
+  public String registry;
+
+  @Parameterized.Parameter(4)
+  public String user;
+
+  @Parameterized.Parameter(5)
+  public String repository;
+
+  @Parameterized.Parameter(6)
+  public String tag;
+
+  @Parameterized.Parameter(7)
+  public String digest;
+
+  @Parameterized.Parameters(name = "{index}: {0}")
+  public static Object[][] data() {
+    return new Object[][] {
+        {"Repo and Name", "eclipse/eclipse_jkube",
+            "eclipse/eclipse_jkube:latest", null, "eclipse", "eclipse/eclipse_jkube", "latest", null},
+        {"Repo and Name with special characters", "valid.name-with__separators/eclipse_jkube",
+            "valid.name-with__separators/eclipse_jkube:latest", null,
+            "valid.name-with__separators", "valid.name-with__separators/eclipse_jkube", "latest", null},
+        {"Repo, Name and Tag", "eclipse/eclipse_jkube:1.3.3.7",
+            "eclipse/eclipse_jkube:1.3.3.7", null, "eclipse", "eclipse/eclipse_jkube", "1.3.3.7", null},
+        {"Repo, Name and Tag with special characters", "valid.name-with__separators/eclipse_jkube:valid__tag-4.2",
+            "valid.name-with__separators/eclipse_jkube:valid__tag-4.2", null,
+            "valid.name-with__separators", "valid.name-with__separators/eclipse_jkube", "valid__tag-4.2", null},
+        {"Registry, Repo and Name", "docker.io/eclipse/eclipse_jkube",
+            "docker.io/eclipse/eclipse_jkube:latest", "docker.io", "eclipse", "eclipse/eclipse_jkube", "latest", null},
+        {"Registry, Repo and Name with special characters",
+            "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube",
+            "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:latest",
+            "long.registry.example.com:8080",
+            "valid.name--with__separators", "valid.name--with__separators/eclipse_jkube", "latest", null},
+        {"Registry, Repo, Name and Tag", "docker.io/eclipse/eclipse_jkube:1.33.7",
+            "docker.io/eclipse/eclipse_jkube:1.33.7", "docker.io", "eclipse", "eclipse/eclipse_jkube", "1.33.7", null},
+        {"Registry, Repo, Name and Tag with special characters",
+            "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A",
+            "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A",
+            "long.registry.example.com:8080",
+            "valid.name--with__separators", "valid.name--with__separators/eclipse_jkube", "very--special__tag.2.A", null},
+    };
+  }
+
+  @Test
+  public void fullNameParse() {
+    final ImageName result = new ImageName(providedFullName);
+    assertThat(result)
+        .extracting(
+            ImageName::getFullName,
+            ImageName::getRegistry,
+            ImageName::getUser,
+            ImageName::getRepository,
+            ImageName::getTag,
+            ImageName::getDigest
+        )
+        .containsExactly(expectedFullName, registry, user, repository, tag, digest);
+  }
+}

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
@@ -16,6 +16,8 @@ package org.eclipse.jkube.kit.config.image;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public class ImageNameTest {
@@ -174,6 +176,38 @@ public class ImageNameTest {
         for (String l : legal) {
             new ImageName(l);
         }
+    }
+
+    @Test
+    public void testImageNameWithUsernameHavingPeriods() {
+        // Given
+        String name = "roman.gordill/customer-service-cache:latest";
+
+        // When
+        ImageName imageName = new ImageName(name);
+
+        // Then
+        assertNotNull(imageName);
+        assertEquals("roman.gordill", imageName.getUser());
+        assertEquals("roman.gordill/customer-service-cache", imageName.getRepository());
+        assertEquals("latest", imageName.getTag());
+        assertNull(imageName.getRegistry());
+    }
+
+    @Test
+    public void testImageNameWithNameContainingRegistryAndName() {
+        // Given
+        String name = "foo.com:5000/customer-service-cache:latest";
+
+        // When
+        ImageName imageName = new ImageName(name);
+
+        // Then
+        assertNotNull(imageName);
+        assertNull(imageName.getUser());
+        assertEquals("foo.com:5000", imageName.getRegistry());
+        assertEquals("customer-service-cache", imageName.getRepository());
+        assertEquals("latest", imageName.getTag());
     }
 
     // =======================================================================================

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.kit.enricher.handler;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
+import org.eclipse.jkube.kit.common.AssemblyConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.JavaProject;
@@ -543,5 +544,31 @@ public class ContainerHandlerTest {
         assertEquals(3,hostIPCount);
         assertEquals(9,containerPortCount);
         assertEquals(4,hostPortCount);
+    }
+
+    @Test
+    public void testGetContainersWithUserAndImageAndTagWithPeriodInImageUser() {
+        // Given
+        ContainerHandler containerHandler = createContainerHandler(project);
+        List<ImageConfiguration> imageConfigurations = new ArrayList<>();
+        imageConfigurations.add(ImageConfiguration.builder()
+                .name("roman.gordill/customer-service-cache:latest")
+                .registry("quay.io")
+                .build(BuildConfiguration.builder()
+                        .from("quay.io/jkube/jkube-java-binary-s2i:0.0.8")
+                        .assembly(AssemblyConfiguration.builder()
+                                .targetDir("/deployments")
+                                .build())
+                        .build())
+                .build());
+
+        // When
+        List<Container> containers = containerHandler.getContainers(config, imageConfigurations);
+
+        // Then
+        assertNotNull(containers);
+        assertEquals(1, containers.size());
+        Container container = containers.get(0);
+        assertEquals("quay.io/roman.gordill/customer-service-cache:latest", container.getImage());
     }
 }


### PR DESCRIPTION
Fix #523 

Periods can be in username too apart from registries. Refactor ImageName to consider this scenario.

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->