### PR TITLE
Fix #510: Update Compatibility matrix for OpenShift 4.5 and 4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Usage:
 * Fix #181: Refactor PortForwardService to use Kubernetes Client Port Forwarding instead of kubectl binary
 * Fix #535: Bump JKube base images to 0.0.9
 * Fix #509: Port of ServiceDiscoveryEnricher from FMP
+* Fix #510: Update Compatibility matrix for OpenShift 4.5 and 4.6
 * Fix #511: Namespace as resource fragment results in NullPointerException
 * Fix #521: NPE on Buildconfig#getContextDir if `<dockerFile>` references a file with no directory
 * Fix #513: openshift-maven-plugin: service.yml fragment with ports creates service with unnamed port mapping

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_compatibility.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_compatibility.adoc
@@ -31,14 +31,14 @@ ifeval::["{goal-prefix}" == "oc"]
 
 .OpenShift Compatibility
 |===
-|     OMP             | OpenShift 4.4 | OpenShift 4.2 | OpenShift 3.11
+|     OMP             | OpenShift 4.6 | OpenShift 4.5 | OpenShift 4.4 | OpenShift 4.2 | OpenShift 3.11
 
-| OMP 1.0.2           |        ✓      |        ✓      |        ✓
-| OMP 1.0.1           |        ✓      |        ✓      |        ✓
-| OMP 1.0.0           |        ✓      |        ✓      |        ✓
-| OMP 0.2.0           |        ✓      |        ✓      |        ✓
-| OMP 0.1.1           |        ✓      |        ✓      |        ✓
-| OMP 0.1.0           |        ✓      |        ✓      |        ✓
+| OMP 1.0.2           |        ✓      |        ✓      |        ✓      |        ✓      |        ✓
+| OMP 1.0.1           |        ✓      |        ✓      |        ✓      |        ✓      |        ✓
+| OMP 1.0.0           |        ✓      |        ✓      |        ✓      |        ✓      |        ✓
+| OMP 0.2.0           |        ✓      |        ✓      |        ✓      |        ✓      |        ✓
+| OMP 0.1.1           |        ✓      |        ✓      |        ✓      |        ✓      |        ✓
+| OMP 0.1.0           |        ✓      |        ✓      |        ✓      |        ✓      |        ✓
 
 |===
 


### PR DESCRIPTION
I've run integration tests on CRC with OpenShift versions 4.5.14 and
4.6.9 and plugin behavior seems to be consistent with older versions
of OpenShift.

Fix #510

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->