### PR TITLE
Chore: Remove use of deprecated CustomResourceDefinition DSL in ApplyService

### DIFF
--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
@@ -435,7 +435,7 @@ public class ApplyService {
             } else {
                 if (isRecreateMode()) {
                     log.info("Deleting Custom Resource Definition: " + id);
-                    kubernetesClient.customResourceDefinitions().withName(id).delete();
+                    kubernetesClient.apiextensions().v1beta1().customResourceDefinitions().withName(id).delete();
                     doCreateCustomResourceDefinition(entity, sourceName);
                 } else {
                     doPatchEntity(old, entity, currentNamespace, sourceName);


### PR DESCRIPTION
Looks like I missed updating one entry of `client.customResourceDefinitions()`
in ApplyService while upgrading to fabric8 kubernetes client v5.0.0. We should be using client.apiextensions() DSL

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->