### PR TITLE
Replace Boolean.valueOf with Boolean.parseBoolean for string to boolean conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.2.0-SNAPSHOT
-* Fix [#558:](https://github.com/eclipse/jkube/issues/558) Update CircleCI sonar jobs to run using JDK 11 enviornment.
+* Fix #558: Update CircleCI sonar jobs to run using JDK 11 enviornment.
+* Fix #545: Replace Boolean.valueOf with Boolean.parseBoolean for string to boolean conversion
+
 
 ### 1.1.0 (2021-01-28)
 * Fix #455: Use OpenShiftServer with JUnit rule instead of directly instantiating the OpenShiftMockServer

--- a/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/auth/handler/OpenShiftRegistryAuthHandler.java
+++ b/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/auth/handler/OpenShiftRegistryAuthHandler.java
@@ -58,7 +58,7 @@ public class OpenShiftRegistryAuthHandler implements RegistryAuthHandler {
         String useOpenAuthMode = registryAuthConfig.extractFromProperties(props, kind, AUTH_USE_OPENSHIFT_AUTH);
         // Check for system property
         if (useOpenAuthMode != null) {
-            boolean useOpenShift = Boolean.valueOf(useOpenAuthMode);
+            boolean useOpenShift = Boolean.parseBoolean(useOpenAuthMode);
             if (!useOpenShift) {
                 return null;
             }

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/BuildService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/BuildService.java
@@ -295,7 +295,7 @@ public class BuildService {
     private boolean checkForNocache(ImageConfiguration imageConfig) {
         String nocache = System.getProperty("docker.nocache");
         if (nocache != null) {
-            return nocache.length() == 0 || Boolean.valueOf(nocache);
+            return nocache.length() == 0 || Boolean.parseBoolean(nocache);
         } else {
             BuildConfiguration buildConfig = imageConfig.getBuildConfiguration();
             return buildConfig.nocache();

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/compose/DockerComposeServiceWrapper.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/compose/DockerComposeServiceWrapper.java
@@ -398,7 +398,7 @@ class DockerComposeServiceWrapper {
     private Boolean asBoolean(String key) {
         Boolean value = null;
         if (configuration.containsKey(key)) {
-            value = Boolean.valueOf(configuration.get(key).toString());
+            value = Boolean.parseBoolean(configuration.get(key).toString());
         }
         return value;
     }

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/property/ValueProvider.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/property/ValueProvider.java
@@ -249,7 +249,7 @@ public class ValueProvider {
         @Override
         protected Boolean withPrefix(String prefix, ConfigKey key, Properties properties) {
             String prop = properties.getProperty(key.asPropertyKey(prefix));
-            return prop == null ? null : Boolean.valueOf(prop);
+            return prop == null ? null : Boolean.parseBoolean(prop);
         }
     }
 


### PR DESCRIPTION
## Description

Fixes SonarCloud Debt for replacing **`Boolean.valueOf`** with **`Boolean.parseBoolean`** for `string` to `boolean` conversion

Closing this PR should fix #545 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->