### PR TITLE
Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.2.0-SNAPSHOT
+* Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported
 * Fix #558: Update CircleCI sonar jobs to run using JDK 11 environment.
 * Fix #546: Use `java.util.function.Function` instead of Guava's `com.google.common.base.Function`
 * Fix #545: Replace Boolean.valueOf with Boolean.parseBoolean for string to boolean conversion

--- a/jkube-kit/build/api/pom.xml
+++ b/jkube-kit/build/api/pom.xml
@@ -54,5 +54,10 @@
       <artifactId>junit</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManagerCreateDockerTarArchiveTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManagerCreateDockerTarArchiveTest.java
@@ -1,0 +1,376 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.api.assembly;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import org.eclipse.jkube.kit.common.Assembly;
+import org.eclipse.jkube.kit.common.AssemblyConfiguration;
+import org.eclipse.jkube.kit.common.AssemblyFile;
+import org.eclipse.jkube.kit.common.AssemblyFileEntry;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.PrefixedLogger;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.eclipse.jkube.kit.config.image.build.JKubeConfiguration;
+
+import mockit.Mocked;
+import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.AbstractFileAssert;
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class AssemblyManagerCreateDockerTarArchiveTest {
+
+  private static final String DOCKERFILE_DEFAULT_FALLBACK_CONTENT = "FROM busybox\nCOPY /maven /maven/\nVOLUME [\"/maven\"]";
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Mocked
+  private PrefixedLogger prefixedLogger;
+
+  private AssemblyManager assemblyManager;
+  private File baseDirectory;
+  private File targetDirectory;
+
+  @Before
+  public void setUp() throws Exception {
+    assemblyManager = AssemblyManager.getInstance();
+    baseDirectory = temporaryFolder.getRoot();
+    targetDirectory = temporaryFolder.newFolder("target");
+  }
+
+  @Test
+  public void createChangedFilesArchive() throws IOException {
+    // Given
+    final JKubeConfiguration jKubeConfiguration = createJKubeConfiguration();
+    final List<AssemblyFileEntry> entries = new ArrayList<>();
+    final File assemblyDirectory = temporaryFolder.getRoot().toPath().resolve("target").resolve("docker").toFile();
+    entries.add(AssemblyFileEntry.builder()
+        .source(temporaryFolder.getRoot().toPath().resolve("target").resolve("test-0.1.0.jar").toFile())
+        .dest(temporaryFolder.getRoot().toPath().resolve("target").resolve("docker").resolve("test-0.1.0.jar").toFile())
+        .fileMode("0655")
+        .build());
+    // When
+    final File result = assemblyManager.createChangedFilesArchive(
+        entries, assemblyDirectory, "image-name", jKubeConfiguration);
+    // Then
+    assertThat(result)
+        .exists()
+        .isFile()
+        .hasName("changed-files.tar")
+        .hasSize(1536);
+  }
+
+  @Test
+  public void withoutDockerfile() throws IOException {
+    // Given
+    final JKubeConfiguration jKubeConfiguration = createJKubeConfiguration();
+    final BuildConfiguration buildConfiguration = BuildConfiguration.builder().build();
+
+    // When
+    File dockerArchiveFile = assemblyManager.createDockerTarArchive(
+        "test-image", jKubeConfiguration, buildConfiguration, prefixedLogger, null);
+
+    // Then
+    assertTargetHasDockerDirectories("test-image");
+    assertThat(dockerArchiveFile).isFile().hasName("docker-build.tar").hasSize(3072);
+    assertDockerFile("test-image").hasContent(DOCKERFILE_DEFAULT_FALLBACK_CONTENT);
+    assertBuildDirectoryFileTree("test-image").containsExactlyInAnyOrder(
+        "Dockerfile",
+        "maven",
+        "maven/test-0.1.0.jar");
+  }
+
+  @Test
+  public void withoutDockerfileAndFinalCustomizer() throws IOException {
+    // Given
+    final JKubeConfiguration jKubeConfiguration = createJKubeConfiguration();
+    final BuildConfiguration buildConfiguration = BuildConfiguration.builder().build();
+    final AtomicBoolean customized = new AtomicBoolean(false);
+    final ArchiverCustomizer finalCustomizer = ac -> {
+      customized.set(true);
+      return ac;
+    };
+
+    // When
+    File dockerArchiveFile = assemblyManager.createDockerTarArchive(
+        "no-docker-file-and-customizer", jKubeConfiguration, buildConfiguration, prefixedLogger, finalCustomizer);
+
+    // Then
+    assertTargetHasDockerDirectories("no-docker-file-and-customizer");
+    assertThat(dockerArchiveFile).isFile().hasName("docker-build.tar").hasSize(3072);
+    assertDockerFile("no-docker-file-and-customizer").hasContent(DOCKERFILE_DEFAULT_FALLBACK_CONTENT);
+    assertBuildDirectoryFileTree("no-docker-file-and-customizer").containsExactlyInAnyOrder(
+        "Dockerfile",
+        "maven",
+        "maven/test-0.1.0.jar");
+    assertThat(customized).isTrue();
+  }
+
+  @Test
+  public void withoutDockerfileAndAlreadyExistingFileInAssemblyGetsOverwritten() throws IOException {
+    final JKubeConfiguration jKubeConfiguration = createJKubeConfiguration();
+    final BuildConfiguration buildConfiguration = BuildConfiguration.builder().build();
+    File dockerArchiveFile;
+
+    // When
+    assemblyManager.createDockerTarArchive(
+        "modified-image", jKubeConfiguration, buildConfiguration, prefixedLogger, null);
+    // Modify file contents
+    writeLineToFile(jKubeConfiguration.getProject().getArtifact(), "Modified content");
+    dockerArchiveFile = assemblyManager.createDockerTarArchive(
+        "modified-image", jKubeConfiguration, buildConfiguration, prefixedLogger, null);
+
+    // Then
+    assertTargetHasDockerDirectories("modified-image");
+    assertThat(dockerArchiveFile).isFile().hasName("docker-build.tar").hasSize(4608);
+    assertDockerFile("modified-image").hasContent(DOCKERFILE_DEFAULT_FALLBACK_CONTENT);
+    assertBuildDirectoryFileTree("modified-image").containsExactlyInAnyOrder(
+        "Dockerfile",
+        "maven",
+        "maven/test-0.1.0.jar");
+    assertThat(resolveDockerBuild("modified-image").resolve("maven").resolve("test-0.1.0.jar"))
+        .exists().isRegularFile()
+        .hasContent("Modified content");
+  }
+
+  @Test
+  public void withDockerfileInBaseDirectory() throws IOException {
+    // Given
+    final File dockerFile = new File(baseDirectory, "Dockerfile");
+    writeLineToFile(dockerFile, "FROM openjdk:jre");
+    final JKubeConfiguration configuration = createJKubeConfiguration();
+    final BuildConfiguration jKubeBuildConfiguration = BuildConfiguration.builder()
+        .dockerFileFile(dockerFile).dockerFile(dockerFile.getPath()).build();
+
+    // When
+    File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+
+    // Then
+    assertTargetHasDockerDirectories("test-image");
+    assertThat(dockerArchiveFile).isFile().hasName("docker-build.tar").hasSize(5120);
+    assertDockerFile("test-image").hasContent("FROM openjdk:jre\n");
+    assertBuildDirectoryFileTree("test-image").containsExactlyInAnyOrder(
+        "Dockerfile",
+        "maven",
+        "maven/Dockerfile",
+        "maven/test-0.1.0.jar",
+        "maven/target",
+        "maven/target/test-0.1.0.jar");
+  }
+
+  @Test
+  public void withDockerfileInBaseDirectoryAndAssemblyFile() throws IOException {
+    // Given
+    final File dockerFile = new File(baseDirectory, "Dockerfile");
+    writeLineToFile(dockerFile, "FROM busybox");
+    final File assemblyFile = temporaryFolder.newFile("extra-file-1.txt");
+    writeLineToFile(assemblyFile, "HELLO");
+    AssemblyConfiguration assemblyConfig = AssemblyConfiguration.builder()
+        .inline(Assembly.builder()
+            .file(AssemblyFile.builder()
+                .source(assemblyFile)
+                .outputDirectory(new File("."))
+                .build())
+            .build())
+        .build();
+    final JKubeConfiguration configuration = createJKubeConfiguration();
+    final BuildConfiguration jKubeBuildConfiguration = BuildConfiguration.builder()
+        .dockerFileFile(dockerFile).dockerFile(dockerFile.getPath())
+        .assembly(assemblyConfig)
+        .build();
+
+    // When
+    final File dockerArchiveFile = assemblyManager.createDockerTarArchive(
+        "dockerfile-and-assembly-file", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+
+    // Then
+    assertTargetHasDockerDirectories("dockerfile-and-assembly-file");
+    assertThat(dockerArchiveFile).isFile().hasName("docker-build.tar").hasSize(6144);
+    assertDockerFile("dockerfile-and-assembly-file").hasContent("FROM busybox\n");
+    assertBuildDirectoryFileTree("dockerfile-and-assembly-file").containsExactlyInAnyOrder(
+        "Dockerfile",
+        "maven",
+        "maven/Dockerfile",
+        "maven/test-0.1.0.jar",
+        "maven/extra-file-1.txt",
+        "maven/target",
+        "maven/target/test-0.1.0.jar");
+  }
+
+  @Test
+  public void withDockerfileInBaseDirectoryAndDockerInclude() throws IOException {
+    // Given
+    final File dockerFile = new File(baseDirectory, "Dockerfile");
+    writeLineToFile(dockerFile, "FROM openjdk:jre");
+    writeLineToFile(new File(baseDirectory, ".jkube-dockerinclude"), "**/*.txt");
+    writeLineToFile(new File(targetDirectory, "ill-be-included.txt"), "Hello");
+    writeLineToFile(new File(targetDirectory, "ill-wont-be-included"), "Hello");
+    final JKubeConfiguration configuration = createJKubeConfiguration();
+    final BuildConfiguration jKubeBuildConfiguration = BuildConfiguration.builder()
+        .dockerFileFile(dockerFile).dockerFile(dockerFile.getPath()).build();
+
+    // When
+    final File dockerArchiveFile = assemblyManager.createDockerTarArchive(
+        "test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+
+    // Then
+    assertTargetHasDockerDirectories("test-image");
+    assertThat(dockerArchiveFile).isFile().hasName("docker-build.tar").hasSize(4608);
+    assertDockerFile("test-image").hasContent("FROM openjdk:jre\n");
+    assertBuildDirectoryFileTree("test-image").containsExactlyInAnyOrder(
+        "Dockerfile",
+        "maven",
+        "maven/test-0.1.0.jar",
+        "maven/target",
+        "maven/target/ill-be-included.txt");
+  }
+
+  @Test
+  public void withDockerfileInBaseDirectoryAndDockerExclude() throws IOException {
+    // Given
+    final File dockerFile = new File(baseDirectory, "Dockerfile");
+    writeLineToFile(dockerFile, "FROM openjdk:jre");
+    writeLineToFile(new File(baseDirectory, ".jkube-dockerexclude"), "**/*.txt");
+    writeLineToFile(new File(targetDirectory, "ill-wont-be-included.txt"), "Hello");
+    writeLineToFile(new File(targetDirectory, "ill-be-included"), "Hello");
+    final JKubeConfiguration configuration = createJKubeConfiguration();
+    final BuildConfiguration jKubeBuildConfiguration = BuildConfiguration.builder()
+        .dockerFileFile(dockerFile).dockerFile(dockerFile.getPath()).build();
+
+    // When
+    final File dockerArchiveFile = assemblyManager.createDockerTarArchive(
+        "test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+
+    // Then
+    assertTargetHasDockerDirectories("test-image");
+    assertThat(dockerArchiveFile).isFile().hasName("docker-build.tar").hasSize(6144);
+    assertDockerFile("test-image").hasContent("FROM openjdk:jre\n");
+    assertBuildDirectoryFileTree("test-image").containsExactlyInAnyOrder(
+        "Dockerfile",
+        "maven",
+        "maven/Dockerfile",
+        "maven/test-0.1.0.jar",
+        "maven/target",
+        "maven/target/test-0.1.0.jar",
+        "maven/target/ill-be-included");
+  }
+
+  @Test
+  public void withDockerfileInBaseDirectoryAndDockerIgnore() throws IOException {
+    // Given
+    final File dockerFile = new File(baseDirectory, "Dockerfile");
+    writeLineToFile(dockerFile, "FROM openjdk:jre");
+    writeLineToFile(new File(baseDirectory, ".jkube-dockerignore"), "**/*.txt\ntarget/ill-be-ignored-too");
+    writeLineToFile(new File(targetDirectory, "ill-be-ignored.txt"), "Hello");
+    writeLineToFile(new File(targetDirectory, "ill-be-ignored-too"), "Hello");
+    writeLineToFile(new File(targetDirectory, "i-wont-be-ignored"), "Hello");
+    final JKubeConfiguration configuration = createJKubeConfiguration();
+    final BuildConfiguration jKubeBuildConfiguration = BuildConfiguration.builder()
+        .dockerFileFile(dockerFile).dockerFile(dockerFile.getPath()).build();
+
+    // When
+    File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+
+    // Then
+    assertTargetHasDockerDirectories("test-image");
+    assertThat(dockerArchiveFile).isFile().hasName("docker-build.tar").hasSize(6144);
+    assertDockerFile("test-image").hasContent("FROM openjdk:jre\n");
+    assertBuildDirectoryFileTree("test-image").containsExactlyInAnyOrder(
+        "Dockerfile",
+        "maven",
+        "maven/Dockerfile",
+        "maven/test-0.1.0.jar",
+        "maven/target",
+        "maven/target/test-0.1.0.jar",
+        "maven/target/i-wont-be-ignored");
+  }
+
+  private void assertTargetHasDockerDirectories(String imageDirName) {
+    assertThat(targetDirectory.toPath().resolve("docker").resolve(imageDirName))
+        .isDirectory().exists()
+        .isDirectoryContaining(p -> p.toFile().isDirectory() && p.toFile().getName().equals("build"))
+        .isDirectoryContaining(p -> p.toFile().isDirectory() && p.toFile().getName().equals("work"))
+        .isDirectoryContaining(p -> p.toFile().isDirectory() && p.toFile().getName().equals("tmp"))
+        .extracting(p -> p.resolve("build").resolve("Dockerfile").toFile())
+        .satisfies(p -> assertThat(p).exists().isFile());
+  }
+
+  private Path resolveDockerBuild(String imageDirName) {
+    return targetDirectory.toPath().resolve("docker").resolve(imageDirName).resolve("build");
+  }
+
+  private AbstractFileAssert<?> assertDockerFile(String imageDirName) {
+    return assertThat(resolveDockerBuild(imageDirName).resolve("Dockerfile").toFile()).isFile().exists();
+  }
+
+  private AbstractListAssert<ListAssert<String>, List<? extends String>, String, ObjectAssert<String>> assertBuildDirectoryFileTree(
+      String imageDirName) throws IOException {
+    final Path buildPath = resolveDockerBuild(imageDirName);
+    return assertThat(Files.walk(buildPath)
+        .map(buildPath::relativize)
+        .map(Path::toString)
+        .filter(StringUtils::isNotBlank)
+        .collect(Collectors.toList()));
+  }
+
+  private static void writeLineToFile(File file, String line) throws IOException {
+    if (!file.exists()) {
+      assertTrue(file.createNewFile());
+    }
+    PrintWriter writer = new PrintWriter(file, StandardCharsets.UTF_8.name());
+    writer.println(line);
+    writer.close();
+  }
+
+  private JKubeConfiguration createJKubeConfiguration() throws IOException {
+    return JKubeConfiguration.builder()
+        .project(JavaProject.builder()
+            .groupId("org.eclipse.jkube")
+            .artifactId("test")
+            .packaging("jar")
+            .version("0.1.0")
+            .baseDirectory(baseDirectory)
+            .buildDirectory(targetDirectory)
+            .artifact(createEmptyArtifact())
+            .build())
+        .outputDirectory("target/docker")
+        .sourceDirectory("src/main/docker")
+        .build();
+  }
+
+  private File createEmptyArtifact() throws IOException {
+    File emptyArtifact = new File(targetDirectory, "test-0.1.0.jar");
+    assertTrue(emptyArtifact.createNewFile());
+    return emptyArtifact;
+  }
+}

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManagerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManagerTest.java
@@ -12,583 +12,186 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.jkube.kit.build.api.assembly;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.eclipse.jkube.kit.common.Assembly;
-import org.eclipse.jkube.kit.common.AssemblyFileEntry;
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
 import org.eclipse.jkube.kit.common.AssemblyConfiguration;
-import org.eclipse.jkube.kit.common.AssemblyFile;
-import org.eclipse.jkube.kit.config.image.ImageConfiguration;
-import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
-import org.eclipse.jkube.kit.common.PrefixedLogger;
-import org.eclipse.jkube.kit.config.image.build.DockerFileBuilder;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.eclipse.jkube.kit.config.image.build.JKubeConfiguration;
 
 import mockit.Expectations;
 import mockit.Injectable;
-import mockit.Mocked;
-import mockit.Tested;
 import mockit.Verifications;
-import org.eclipse.jkube.kit.config.image.build.JKubeConfiguration;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class AssemblyManagerTest {
 
-    @Tested
-    private AssemblyManager assemblyManager;
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private AssemblyManager assemblyManager;
+  private File targetDirectory;
+
+  @Before
+  public void setUp() throws Exception {
+    assemblyManager = AssemblyManager.getInstance();
+    targetDirectory = temporaryFolder.newFolder("target");
+  }
+
+  @Test
+  public void testGetInstanceShouldBeSingleton() {
+    // When
+    final AssemblyManager other = AssemblyManager.getInstance();
+    // Then
+    assertThat(assemblyManager).isSameAs(other);
+  }
+
+  @Test
+  public void testNoAssembly() {
+    // Given
+    final BuildConfiguration buildConfig = BuildConfiguration.builder().build();
+    final AssemblyConfiguration assemblyConfig = null;
+    // When
+    final String result = assemblyManager
+        .createDockerFileBuilder(buildConfig, assemblyConfig)
+        .content();
+    // Then
+    assertThat(result)
+        .doesNotContain("COPY", "VOLUME")
+        .isEqualTo("FROM busybox\n");
+  }
+
+  @Test
+  public void assemblyFiles(
+      @Injectable final JKubeConfiguration configuration, @Injectable final JavaProject project) throws Exception {
+    // Given
+    final File buildDirs = temporaryFolder.newFolder("buildDirs");
+    // @formatter:off
+      new Expectations() {{
+          configuration.getProject(); result = project;
+          project.getBaseDirectory(); result = buildDirs;
+      }};
+      // @formatter:on
+    ImageConfiguration imageConfiguration = ImageConfiguration.builder()
+        .name("testImage").build(createBuildConfig())
+        .build();
+    // When
+    AssemblyFiles assemblyFiles = assemblyManager.getAssemblyFiles(imageConfiguration, configuration);
+    // Then
+    assertThat(assemblyFiles)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("assemblyDirectory",
+            buildDirs.toPath().resolve("testImage").resolve("build").toFile())
+        .extracting(AssemblyFiles::getUpdatedEntriesAndRefresh)
+        .asList().isEmpty();
+  }
+
+
+  @Test
+  public void testCopyValidVerifyGivenDockerfile(@Injectable final KitLogger logger) throws IOException {
+    BuildConfiguration buildConfig = createBuildConfig();
+
+    assemblyManager.verifyGivenDockerfile(
+        new File(getClass().getResource("/docker/Dockerfile_assembly_verify_copy_valid.test").getPath()),
+        buildConfig, new Properties(),
+        logger);
+
+    // @formatter:off
+    new Verifications() {{
+      logger.warn(anyString, (Object []) any); times = 0;
+    }};
+    //@formatter:on
+  }
+
+  @Test
+  public void testCopyInvalidVerifyGivenDockerfile(@Injectable final KitLogger logger) throws IOException {
+    BuildConfiguration buildConfig = createBuildConfig();
+
+    assemblyManager.verifyGivenDockerfile(
+        new File(getClass().getResource("/docker/Dockerfile_assembly_verify_copy_invalid.test").getPath()),
+        buildConfig, new Properties(),
+        logger);
+
+    // @formatter:off
+    new Verifications() {{
+      logger.warn(anyString, (Object []) any); times = 1;
+    }};
+    //@formatter:on
+  }
+
+  @Test
+  public void testCopyChownValidVerifyGivenDockerfile(@Injectable final KitLogger logger) throws IOException {
+    BuildConfiguration buildConfig = createBuildConfig();
+
+    assemblyManager.verifyGivenDockerfile(
+        new File(getClass().getResource("/docker/Dockerfile_assembly_verify_copy_chown_valid.test").getPath()),
+        buildConfig,
+        new Properties(),
+        logger);
+
+    // @formatter:off
+    new Verifications() {{
+      logger.warn(anyString, (Object []) any); times = 0;
+    }};
+    //@formatter:on
+  }
+
+  private BuildConfiguration createBuildConfig() {
+    return BuildConfiguration.builder()
+        .assembly(AssemblyConfiguration.builder()
+            .name("maven")
+            .targetDir("/maven")
+            .build())
+        .build();
+  }
+
+  @Test
+  public void testEnsureThatArtifactFileIsSetWithProjectArtifactSet() throws IOException {
+    // Given
+    JavaProject project = JavaProject.builder()
+        .artifact(temporaryFolder.newFile("temp-project-0.0.1.jar"))
+        .build();
+    // When
+    final File artifactFile = assemblyManager.ensureThatArtifactFileIsSet(project);
+    // Then
+    assertThat(artifactFile).isFile().exists().hasName("temp-project-0.0.1.jar");
+  }
+
+  @Test
+  public void testEnsureThatArtifactFileIsSetWithNullProjectArtifact() throws IOException {
+    // Given
+    assertTrue(new File(targetDirectory, "foo-project-0.0.1.jar").createNewFile());
+    JavaProject project = JavaProject.builder()
+        .buildDirectory(targetDirectory)
+        .packaging("jar")
+        .buildFinalName("foo-project-0.0.1")
+        .build();
+    // When
+    final File artifactFile = assemblyManager.ensureThatArtifactFileIsSet(project);
+    // Then
+    assertThat(artifactFile).isFile().exists().hasName("foo-project-0.0.1.jar");
+  }
+
+  @Test
+  public void testEnsureThatArtifactFileIsSetWithEverythingNull() throws IOException {
+    // Given
+    JavaProject project = JavaProject.builder().build();
+    // When
+    final File artifactFile = assemblyManager.ensureThatArtifactFileIsSet(project);
+    // Then
+    assertThat(artifactFile).isNull();
+  }
 
-    @Mocked
-    private PrefixedLogger prefixedLogger;
-
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Test
-    public void testGetInstanceShouldBeSingleton() {
-        // When
-        final AssemblyManager dam1 = AssemblyManager.getInstance();
-        final AssemblyManager dam2 = AssemblyManager.getInstance();
-        // Then
-        assertSame(dam1, dam2);
-    }
-
-    @Test
-    public void testNoAssembly() {
-        BuildConfiguration buildConfig = BuildConfiguration.builder().build();
-        AssemblyConfiguration assemblyConfig = buildConfig.getAssembly();
-
-        DockerFileBuilder builder = assemblyManager.createDockerFileBuilder(buildConfig, assemblyConfig);
-        String content = builder.content();
-
-        assertFalse(content.contains("COPY"));
-        assertFalse(content.contains("VOLUME"));
-    }
-
-    @Test
-    public void assemblyFiles(@Injectable final JKubeConfiguration configuration, @Injectable final JavaProject project)
-        throws Exception {
-
-        // Given
-        final File baseDirectory = temporaryFolder.newFolder("buildDirs");
-        final File targetDir = new File(baseDirectory, "target");
-        assertTrue(targetDir.mkdirs());
-        new Expectations() {{
-            configuration.getProject();
-            result = project;
-
-            project.getBaseDirectory();
-            result = baseDirectory;
-        }};
-        ImageConfiguration imageConfiguration = ImageConfiguration.builder()
-            .name("testImage").build(createBuildConfig())
-            .build();
-        // When
-        AssemblyFiles assemblyFiles = assemblyManager.getAssemblyFiles(imageConfiguration, configuration);
-        // Then
-        assertNotNull(assemblyFiles);
-        assertEquals(baseDirectory.toPath().resolve("testImage").resolve("build").toFile(), assemblyFiles.getAssemblyDirectory());
-        assertTrue(assemblyFiles.getUpdatedEntriesAndRefresh().isEmpty());
-    }
-
-    @Test
-    public void testCreateChangedFilesArchive() throws IOException {
-        // Given
-        final List<AssemblyFileEntry> entries = new ArrayList<>();
-        final File assemblyDirectory = temporaryFolder.getRoot().toPath().resolve("target").resolve("docker").toFile();
-        final JKubeConfiguration jc = createNoDockerfileConfiguration();
-        entries.add(AssemblyFileEntry.builder()
-            .source(temporaryFolder.getRoot().toPath().resolve("target").resolve("test-0.1.0.jar").toFile())
-            .dest(temporaryFolder.getRoot().toPath().resolve("target").resolve("docker").resolve("test-0.1.0.jar").toFile())
-            .fileMode("0655")
-            .build());
-        // When
-        final File result = assemblyManager.createChangedFilesArchive(entries, assemblyDirectory, "image-name", jc);
-        // Then
-        assertNotNull(result);
-        assertTrue(result.exists());
-        assertTrue(result.isFile());
-        assertEquals("changed-files.tar", result.getName());
-        assertEquals(1536, result.length());
-    }
-
-    @Test
-    public void testCopyValidVerifyGivenDockerfile(@Injectable final KitLogger logger) throws IOException {
-        BuildConfiguration buildConfig = createBuildConfig();
-
-        assemblyManager.verifyGivenDockerfile(
-                new File(getClass().getResource("/docker/Dockerfile_assembly_verify_copy_valid.test").getPath()),
-                buildConfig, new Properties(),
-                logger);
-
-        new Verifications() {{
-            logger.warn(anyString, (Object []) any); times = 0;
-        }};
-
-    }
-
-    @Test
-    public void testCopyInvalidVerifyGivenDockerfile(@Injectable final KitLogger logger) throws IOException {
-        BuildConfiguration buildConfig = createBuildConfig();
-
-        assemblyManager.verifyGivenDockerfile(
-                new File(getClass().getResource("/docker/Dockerfile_assembly_verify_copy_invalid.test").getPath()),
-                buildConfig, new Properties(),
-                logger);
-
-        new Verifications() {{
-            logger.warn(anyString, (Object []) any); times = 1;
-        }};
-
-    }
-
-    @Test
-    public void testCopyChownValidVerifyGivenDockerfile(@Injectable final KitLogger logger) throws IOException {
-        BuildConfiguration buildConfig = createBuildConfig();
-
-        assemblyManager.verifyGivenDockerfile(
-                new File(getClass().getResource("/docker/Dockerfile_assembly_verify_copy_chown_valid.test").getPath()),
-                buildConfig,
-                new Properties(),
-                logger);
-
-        new Verifications() {{
-            logger.warn(anyString, (Object []) any); times = 0;
-        }};
-    }
-
-    private BuildConfiguration createBuildConfig() {
-        return BuildConfiguration.builder()
-                .assembly(AssemblyConfiguration.builder()
-                        .name("maven")
-                        .targetDir("/maven")
-                        .build())
-                .build();
-    }
-
-    @Test
-    public void testEnsureThatArtifactFileIsSetWithProjectArtifactSet() throws IOException {
-        // Given
-        JavaProject project = JavaProject.builder()
-                .artifact(temporaryFolder.newFile("temp-project-0.0.1.jar"))
-                .build();
-        // When
-        File artifactFile = assemblyManager.ensureThatArtifactFileIsSet(project);
-        // Then
-        assertNotNull(artifactFile);
-        assertEquals("temp-project-0.0.1.jar", artifactFile.getName());
-    }
-
-    @Test
-    public void testEnsureThatArtifactFileIsSetWithNullProjectArtifact() throws IOException {
-        // Given
-        File targetDirectory = temporaryFolder.newFolder("target");
-        File jarFile = new File(targetDirectory, "foo-project-0.0.1.jar");
-        assertTrue(jarFile.createNewFile());
-        JavaProject project = JavaProject.builder()
-                .buildDirectory(targetDirectory)
-                .packaging("jar")
-                .buildFinalName("foo-project-0.0.1")
-                .build();
-        // When
-        File artifactFile = assemblyManager.ensureThatArtifactFileIsSet(project);
-        // Then
-        assertNotNull(artifactFile);
-        assertTrue(artifactFile.exists());
-        assertEquals("foo-project-0.0.1.jar", artifactFile.getName());
-    }
-
-    @Test
-    public void testEnsureThatArtifactFileIsSetWithEverythingNull() throws IOException {
-        // Given
-        JavaProject project = JavaProject.builder().build();
-        // When
-        File artifactFile = assemblyManager.ensureThatArtifactFileIsSet(project);
-        // Then
-        assertNull(artifactFile);
-    }
-
-    @Test
-    public void testCreateDockerTarArchiveWithoutDockerfile() throws IOException {
-        // Given
-        final JKubeConfiguration jKubeBuildContext = createNoDockerfileConfiguration();
-        final BuildConfiguration jKubeBuildConfiguration = BuildConfiguration.builder().build();
-
-        // When
-        File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", jKubeBuildContext, jKubeBuildConfiguration, prefixedLogger, null);
-
-        // Then
-        assertNotNull(dockerArchiveFile);
-        assertTrue(dockerArchiveFile.exists());
-        assertEquals(3072, dockerArchiveFile.length());
-        final File outputDirectory = temporaryFolder.getRoot().toPath().resolve("target").resolve("docker").toFile();
-        assertTrue(outputDirectory.isDirectory() && outputDirectory.exists());
-        File buildOutputDir = new File(outputDirectory, "test-image");
-        assertTrue(buildOutputDir.isDirectory() && buildOutputDir.exists());
-        File buildDir = new File(buildOutputDir, "build");
-        File workDir = new File(buildOutputDir, "work");
-        File tmpDir = new File(buildOutputDir, "tmp");
-        assertTrue(buildDir.isDirectory() && buildDir.exists());
-        assertTrue(workDir.isDirectory() && workDir.exists());
-        assertTrue(tmpDir.isDirectory() && tmpDir.exists());
-        assertTrue(new File(buildDir, "Dockerfile").exists());
-        File assemblyNameDirInBuild = new File(buildDir, "maven");
-        assertTrue(assemblyNameDirInBuild.isDirectory() && assemblyNameDirInBuild.exists());
-        assertTrue(new File(assemblyNameDirInBuild, "test-0.1.0.jar").exists());
-    }
-
-    @Test
-    public void testCreateDockerTarArchiveWithoutDockerfileAndFinalCustomizer() throws IOException {
-        // Given
-        final JKubeConfiguration jKubeBuildContext = createNoDockerfileConfiguration();
-        final BuildConfiguration jKubeBuildConfiguration = BuildConfiguration.builder().build();
-        final AtomicBoolean customized = new AtomicBoolean(false);
-        final ArchiverCustomizer finalCustomizer = ac -> {
-            customized.set(true);
-            return ac;
-        };
-
-        // When
-        File dockerArchiveFile = assemblyManager.createDockerTarArchive(
-            "test-image", jKubeBuildContext, jKubeBuildConfiguration, prefixedLogger, finalCustomizer);
-
-        // Then
-        assertNotNull(dockerArchiveFile);
-        assertTrue(dockerArchiveFile.exists());
-        assertEquals(3072, dockerArchiveFile.length());
-        final File outputDirectory = temporaryFolder.getRoot().toPath().resolve("target").resolve("docker").toFile();
-        assertTrue(outputDirectory.isDirectory() && outputDirectory.exists());
-        File buildOutputDir = new File(outputDirectory, "test-image");
-        assertTrue(buildOutputDir.isDirectory() && buildOutputDir.exists());
-        File buildDir = new File(buildOutputDir, "build");
-        File workDir = new File(buildOutputDir, "work");
-        File tmpDir = new File(buildOutputDir, "tmp");
-        assertTrue(buildDir.isDirectory() && buildDir.exists());
-        assertTrue(workDir.isDirectory() && workDir.exists());
-        assertTrue(tmpDir.isDirectory() && tmpDir.exists());
-        assertTrue(new File(buildDir, "Dockerfile").exists());
-        File assemblyNameDirInBuild = new File(buildDir, "maven");
-        assertTrue(assemblyNameDirInBuild.isDirectory() && assemblyNameDirInBuild.exists());
-        assertTrue(new File(assemblyNameDirInBuild, "test-0.1.0.jar").exists());
-        assertTrue(customized.get());
-    }
-
-    @Test
-    public void testAlreadyExistingFileInAssemblyGetsOverwritten() throws IOException {
-        final JKubeConfiguration jKubeBuildContext = createNoDockerfileConfiguration();
-        final BuildConfiguration jKubeBuildConfiguration = BuildConfiguration.builder().build();
-        File finalArtifactFile = jKubeBuildContext.getProject().getArtifact();
-        File dockerArchiveFile = null;
-
-        // When
-        dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", jKubeBuildContext, jKubeBuildConfiguration, prefixedLogger, null);
-        // Modify file contents
-        FileWriter fileWriter = new FileWriter(finalArtifactFile);
-        fileWriter.write("Modified content");
-        fileWriter.close();
-        dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", jKubeBuildContext, jKubeBuildConfiguration, prefixedLogger, null);
-
-        // Then
-        assertNotNull(dockerArchiveFile);
-        assertTrue(dockerArchiveFile.exists());
-        File copiedFile = new File(temporaryFolder.getRoot().toPath().resolve("target/docker/test-image/build/maven/").toFile(), "test-0.1.0.jar");
-        assertTrue(copiedFile.exists());
-        assertEquals("Modified content", new String(Files.readAllBytes(copiedFile.toPath())));
-    }
-
-    private JKubeConfiguration createNoDockerfileConfiguration() throws IOException {
-        File targetFolder = temporaryFolder.newFolder("target");
-        File finalArtifactFile = new File(targetFolder, "test-0.1.0.jar");
-        assertTrue(finalArtifactFile.createNewFile());
-        File outputDirectory = new File(targetFolder, "docker");
-        return JKubeConfiguration.builder()
-            .project(JavaProject.builder()
-                .groupId("org.eclipse.jkube")
-                .artifactId("test")
-                .packaging("jar")
-                .version("0.1.0")
-                .buildDirectory(targetFolder)
-                .artifact(finalArtifactFile)
-                .build())
-            .outputDirectory(outputDirectory.getAbsolutePath())
-            .sourceDirectory(temporaryFolder.getRoot().getAbsolutePath() + "/src/main/docker")
-            .build();
-    }
-
-    @Test
-    public void testCreateDockerTarArchiveWithDockerfile() throws IOException {
-        // Given
-        File baseProjectDir = temporaryFolder.newFolder("test-workspace");
-        File dockerFile = new File(baseProjectDir, "Dockerfile");
-        assertTrue(dockerFile.createNewFile());
-        writeLineTofile(dockerFile, "FROM openjdk:jre");
-        File targetDirectory = new File(baseProjectDir, "target");
-        File outputDirectory = new File(targetDirectory, "classes");
-        assertTrue(outputDirectory.mkdirs());
-        File finalArtifactFile = new File(targetDirectory, "test-0.1.0.jar");
-        assertTrue(finalArtifactFile.createNewFile());
-        File dockerDirectory = new File(targetDirectory, "docker");
-
-        final JKubeConfiguration configuration = getBuildJKubeConfiguration(baseProjectDir, targetDirectory, outputDirectory, finalArtifactFile);
-        final BuildConfiguration jKubeBuildConfiguration = getBuildConfiguration(dockerFile, BuildConfiguration.builder());
-
-        // When
-        File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
-
-        // Then
-        assertNotNull(dockerArchiveFile);
-        assertTrue(dockerArchiveFile.exists());
-        assertTrue(dockerDirectory.isDirectory() && dockerDirectory.exists());
-        File buildOutputDir = new File(dockerDirectory, "test-image");
-        assertTrue(buildOutputDir.isDirectory() && buildOutputDir.exists());
-        File buildDir = new File(buildOutputDir, "build");
-        File workDir = new File(buildOutputDir, "work");
-        File tmpDir = new File(buildOutputDir, "tmp");
-        assertTrue(buildDir.isDirectory() && buildDir.exists());
-        assertTrue(workDir.isDirectory() && workDir.exists());
-        assertTrue(tmpDir.isDirectory() && tmpDir.exists());
-        assertTrue(new File(buildDir, "Dockerfile").exists());
-        File jarCopiedInBuildDirs = new File(buildDir, "maven/target/test-0.1.0.jar");
-        assertTrue(jarCopiedInBuildDirs.exists());
-    }
-
-    private void writeLineTofile(File dockerFile, String line) throws FileNotFoundException, UnsupportedEncodingException {
-        PrintWriter writer = new PrintWriter(dockerFile, "UTF-8");
-        writer.println(line);
-        writer.close();
-    }
-
-    @Test
-    public void testCreateDockerTarArchiveWithDockerfileAndAssembly() throws IOException {
-        // Given
-        File baseProjectDir = temporaryFolder.newFolder("test-workspace");
-        File dockerFile = new File(baseProjectDir, "Dockerfile");
-        boolean dockerFileCreated = dockerFile.createNewFile();
-        writeLineTofile(dockerFile, "FROM openjdk:jre");
-
-        File assemblyFolder = new File(baseProjectDir, "additional");
-        boolean assemblyDirCreated = assemblyFolder.mkdirs();
-        File extraFile = new File(assemblyFolder, "extraFile.txt");
-        assertTrue(extraFile.createNewFile());
-
-        File targetDirectory = new File(baseProjectDir, "target");
-        File outputDirectory = new File(targetDirectory, "classes");
-        boolean outputDirectoryCreated = outputDirectory.mkdirs();
-        File finalArtifactFile = new File(targetDirectory, "test-0.1.0.jar");
-        boolean finalArtifactFileCreated = finalArtifactFile.createNewFile();
-        File dockerDirectory = new File(targetDirectory, "docker");
-        File buildOutputDir = new File(dockerDirectory, "test-image");
-        File buildDir = new File(buildOutputDir, "build");
-        File workDir = new File(buildOutputDir, "work");
-        File tmpDir = new File(buildOutputDir, "tmp");
-        File mavenDir = new File(buildDir, "maven");
-        File jarCopiedInBuildDirs = new File(mavenDir, "target/test-0.1.0.jar");
-
-        final JKubeConfiguration configuration = getBuildJKubeConfiguration(baseProjectDir, targetDirectory, outputDirectory, finalArtifactFile);
-        AssemblyConfiguration assemblyConfig = AssemblyConfiguration.builder()
-                .inline(Assembly.builder()
-                        .file(AssemblyFile.builder()
-                              .source(extraFile)
-                              .outputDirectory(mavenDir)
-                              .build())
-                        .build())
-                .build();
-
-        final BuildConfiguration jKubeBuildConfiguration = getBuildConfiguration(dockerFile, BuildConfiguration.builder().assembly(assemblyConfig));
-
-        // When
-        File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
-
-        // Then
-        assertTrue(dockerFileCreated);
-        assertTrue(assemblyDirCreated);
-        assertTrue(outputDirectoryCreated);
-        assertTrue(finalArtifactFileCreated);
-        assertTargetDockerOutputDir(dockerArchiveFile, dockerDirectory, buildOutputDir, buildDir, workDir, tmpDir, mavenDir);
-        assertTrue(new File(mavenDir, extraFile.getName()).exists());
-        assertTrue(jarCopiedInBuildDirs.exists());
-    }
-
-    @Test
-    public void testCreateDockerTarArchiveWithDockerfileWithJKubeDockerExclude() throws IOException {
-        // Given
-        File baseProjectDir = temporaryFolder.newFolder("test-workspace");
-        File dockerFile = new File(baseProjectDir, "Dockerfile");
-        boolean dockerFileCreated = dockerFile.createNewFile();
-        writeLineTofile(dockerFile, "FROM openjdk:jre");
-        File jkubeDockerExclude = new File(baseProjectDir, ".jkube-dockerexclude");
-        boolean jkubeDockerExcludeFileCreated = jkubeDockerExclude.createNewFile();
-        writeLineTofile(jkubeDockerExclude, "i-should-be-excluded");
-        File ignoredFile = new File(baseProjectDir, "i-should-be-excluded");
-        boolean ignoredFileCreated = ignoredFile.createNewFile();
-
-        File targetDirectory = new File(baseProjectDir, "target");
-        File outputDirectory = new File(targetDirectory, "classes");
-        boolean outputDirectoryCreated = outputDirectory.mkdirs();
-        File finalArtifactFile = new File(targetDirectory, "test-0.1.0.jar");
-        boolean finalArtifactFileCreated = finalArtifactFile.createNewFile();
-        File dockerDirectory = new File(targetDirectory, "docker");
-        File buildOutputDir = new File(dockerDirectory, "test-image");
-        File buildDir = new File(buildOutputDir, "build");
-        File workDir = new File(buildOutputDir, "work");
-        File tmpDir = new File(buildOutputDir, "tmp");
-        File mavenDir = new File(buildDir, "maven");
-        File jarCopiedInBuildDirs = new File(mavenDir, "target/test-0.1.0.jar");
-        File excludedFileCopiedToBuildDirs = new File(mavenDir, "i-should-be-excluded");
-        final JKubeConfiguration configuration = getBuildJKubeConfiguration(baseProjectDir, targetDirectory, outputDirectory, finalArtifactFile);
-        final BuildConfiguration jKubeBuildConfiguration = getBuildConfiguration(dockerFile, BuildConfiguration.builder());
-
-        // When
-        File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
-
-        // Then
-        assertProjectSetup(dockerFileCreated, jkubeDockerExcludeFileCreated, ignoredFileCreated, outputDirectoryCreated, finalArtifactFileCreated);
-        assertTargetDockerOutputDir(dockerArchiveFile, dockerDirectory, buildOutputDir, buildDir, workDir, tmpDir, mavenDir);
-        assertTrue(jarCopiedInBuildDirs.exists());
-        assertFalse(excludedFileCopiedToBuildDirs.exists());
-    }
-
-    @Test
-    public void testCreateDockerTarArchiveWithDockerfileWithJKubeDockerIgnore() throws IOException {
-        // Given
-        File baseProjectDir = temporaryFolder.newFolder("test-workspace");
-        File dockerFile = new File(baseProjectDir, "Dockerfile");
-        boolean dockerFileCreated = dockerFile.createNewFile();
-        writeLineTofile(dockerFile, "FROM openjdk:jre");
-        File jkubeDockerExclude = new File(baseProjectDir, ".jkube-dockerignore");
-        boolean jkubeDockerExcludeFileCreated = jkubeDockerExclude.createNewFile();
-        writeLineTofile(jkubeDockerExclude, "i-should-be-ignored");
-        File ignoredFile = new File(baseProjectDir, "i-should-be-ignored");
-        boolean ignoredFileCreated = ignoredFile.createNewFile();
-
-        File targetDirectory = new File(baseProjectDir, "target");
-        File outputDirectory = new File(targetDirectory, "classes");
-        boolean outputDirectoryCreated = outputDirectory.mkdirs();
-        File finalArtifactFile = new File(targetDirectory, "test-0.1.0.jar");
-        boolean finalArtifactFileCreated = finalArtifactFile.createNewFile();
-        File dockerDirectory = new File(targetDirectory, "docker");
-        File buildOutputDir = new File(dockerDirectory, "test-image");
-        File buildDir = new File(buildOutputDir, "build");
-        File workDir = new File(buildOutputDir, "work");
-        File tmpDir = new File(buildOutputDir, "tmp");
-        File mavenDir = new File(buildDir, "maven");
-        File jarCopiedInBuildDirs = new File(mavenDir, "target/test-0.1.0.jar");
-        File ignoredFileCopiedToBuildDirs = new File(mavenDir, "i-should-be-ignored");
-        final JKubeConfiguration configuration = getBuildJKubeConfiguration(baseProjectDir, targetDirectory, outputDirectory, finalArtifactFile);
-        final BuildConfiguration jKubeBuildConfiguration = getBuildConfiguration(dockerFile, BuildConfiguration.builder());
-
-        // When
-        File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
-
-        // Then
-        assertProjectSetup(dockerFileCreated, jkubeDockerExcludeFileCreated, ignoredFileCreated, outputDirectoryCreated, finalArtifactFileCreated);
-        assertTargetDockerOutputDir(dockerArchiveFile, dockerDirectory, buildOutputDir, buildDir, workDir, tmpDir, mavenDir);
-        assertTrue(jarCopiedInBuildDirs.exists());
-        assertFalse(ignoredFileCopiedToBuildDirs.exists());
-    }
-
-    @Test
-    public void testCreateDockerTarArchiveWithDockerfileWithJKubeDockerInclude() throws IOException {
-        // Given
-        File baseProjectDir = temporaryFolder.newFolder("test-workspace");
-        File dockerFile = new File(baseProjectDir, "Dockerfile");
-        boolean dockerFileCreated = dockerFile.createNewFile();
-        writeLineTofile(dockerFile, "FROM openjdk:jre");
-        File jkubeDockerExclude = new File(baseProjectDir, ".jkube-dockerinclude");
-        boolean jkubeDockerExcludeFileCreated = jkubeDockerExclude.createNewFile();
-        writeLineTofile(jkubeDockerExclude, "i-should-be-included");
-        File includedFile = new File(baseProjectDir, "i-should-be-included");
-        boolean includedFileCreated = includedFile.createNewFile();
-
-        File targetDirectory = new File(baseProjectDir, "target");
-        File outputDirectory = new File(targetDirectory, "classes");
-        boolean outputDirectoryCreated = outputDirectory.mkdirs();
-        File finalArtifactFile = new File(targetDirectory, "test-0.1.0.jar");
-        boolean finalArtifactFileCreated = finalArtifactFile.createNewFile();
-        File dockerDirectory = new File(targetDirectory, "docker");
-        File buildOutputDir = new File(dockerDirectory, "test-image");
-        File buildDir = new File(buildOutputDir, "build");
-        File workDir = new File(buildOutputDir, "work");
-        File tmpDir = new File(buildOutputDir, "tmp");
-        File mavenDir = new File(buildDir, "maven");
-        File jarCopiedInBuildDirs = new File(mavenDir, "target/test-0.1.0.jar");
-        File includedFileCopiedToBuildDirs = new File(mavenDir, "i-should-be-included");
-
-        final JKubeConfiguration configuration = getBuildJKubeConfiguration(baseProjectDir, targetDirectory, outputDirectory, finalArtifactFile);
-        final BuildConfiguration jKubeBuildConfiguration = getBuildConfiguration(dockerFile, BuildConfiguration.builder());
-
-        // When
-        File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
-
-        // Then
-        assertProjectSetup(dockerFileCreated, jkubeDockerExcludeFileCreated, includedFileCreated, outputDirectoryCreated, finalArtifactFileCreated);
-        assertTargetDockerOutputDir(dockerArchiveFile, dockerDirectory, buildOutputDir, buildDir, workDir, tmpDir, mavenDir);
-        assertFalse(jarCopiedInBuildDirs.exists());
-        assertTrue(includedFileCopiedToBuildDirs.exists());
-    }
-
-    private BuildConfiguration getBuildConfiguration(File dockerFile, BuildConfiguration.BuildConfigurationBuilder builder) {
-        return builder
-                .dockerFile(dockerFile.getPath())
-                .dockerFileFile(dockerFile)
-                .build();
-    }
-
-    private JKubeConfiguration getBuildJKubeConfiguration(File baseProjectDir, File targetDirectory, File outputDirectory, File finalArtifactFile) {
-        return JKubeConfiguration.builder()
-                .project(JavaProject.builder()
-                        .groupId("org.eclipse.jkube")
-                        .artifactId("test")
-                        .packaging("jar")
-                        .version("0.1.0")
-                        .buildDirectory(targetDirectory)
-                        .baseDirectory(baseProjectDir)
-                        .outputDirectory(outputDirectory)
-                        .properties(new Properties())
-                        .artifact(finalArtifactFile)
-                        .build())
-                .outputDirectory("target/docker")
-                .sourceDirectory(baseProjectDir.getPath() + "/src/main/docker")
-                .build();
-    }
-
-    private void assertTargetDockerOutputDir(File dockerArchiveFile, File dockerDirectory, File buildOutputDir, File buildDir, File workDir, File tmpDir, File mavenDir) {
-        assertNotNull(dockerArchiveFile);
-        assertTrue(dockerArchiveFile.exists());
-        assertTrue(dockerDirectory.isDirectory() && dockerDirectory.exists());
-        assertTrue(buildOutputDir.isDirectory() && buildOutputDir.exists());
-        assertTrue(buildDir.isDirectory() && buildDir.exists());
-        assertTrue(workDir.isDirectory() && workDir.exists());
-        assertTrue(tmpDir.isDirectory() && tmpDir.exists());
-        assertTrue(new File(buildDir, "Dockerfile").exists());
-        assertTrue(mavenDir.isDirectory() && mavenDir.exists());
-    }
-
-    private void assertProjectSetup(boolean dockerFileCreated, boolean jkubeDockerExcludeFileCreated, boolean ignoreFileCreated, boolean outputDirectoryCreated, boolean finalArtifactFileCreated) {
-        assertTrue(dockerFileCreated);
-        assertTrue(jkubeDockerExcludeFileCreated);
-        assertTrue(outputDirectoryCreated);
-        assertTrue(finalArtifactFileCreated);
-        assertTrue(ignoreFileCreated);
-    }
 }
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/build/_assembly.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/build/_assembly.adoc
@@ -107,6 +107,9 @@ Each fileset has the following fields:
    FileSystem#getPathMatcher] `glob` syntax.
 * `excludes`: A set of files and directory to exclude.
 ** If none is present, then there are no exclusions.
+** Wildcards are also supported, patterns will be matched using
+https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)[
+FileSystem#getPathMatcher] `glob` syntax.
 * `fileMode`: Similar to a UNIX permission, sets the file mode of the files included.
 * `directoryMode`: Similar to a UNIX permission, sets the directory mode of the directories included.
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/build/_overview.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/build/_overview.adoc
@@ -32,7 +32,17 @@ COPY maven/ /my/target/directory
 
 so that the assembly files will end up in `/my/target/directory` within the container.
 
-If this directory contains a `.jkube-dockerignore` (or alternatively, a `.jkube-dockerexclude` file), then it is used for excluding files for the build. Each line in this file is treated as a http://ant.apache.org/manual/Types/fileset.html[FileSet exclude pattern] as used by the http://maven.apache.org/plugins/maven-assembly-plugin[maven-assembly-plugin]. It is similar to `.dockerignore` when using Docker but has a slightly different syntax (hence the different name).
+If this directory contains a `.jkube-dockerignore` (or alternatively, a `.jkube-dockerexclude` file), then it is used
+for excluding files for the build. If the file doesn't exist, or it's empty, then there are no exclusions.
+
+Each line in this file is treated as an entry in the `excludes` assembly `fileSet` <<build-assembly-inline, configuration >>.
+Files can be referenced by using their relative path name.
+Wildcards are also supported, patterns will be matched using
+https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)[
+FileSystem#getPathMatcher] `glob` syntax.
+
+It is similar to `.dockerignore` when using Docker but has a slightly different syntax (hence the different name).
+
 <<ex-build-dockerexclude>> is an  example which excludes all compiled Java classes.
 
 [[ex-build-dockerexclude]]
@@ -46,7 +56,16 @@ target/classes/**  # <1>
 ====
 
 
-If this directory contains a `.jkube-dockerinclude` file, then it is used for including only those files for the build. Each line in this file is also treated as a http://ant.apache.org/manual/Types/fileset.html[FileSet exclude pattern] as used by the http://maven.apache.org/plugins/maven-assembly-plugin[maven-assembly-plugin]. <<ex-build-dockerinclude>> shows how to include only jar file that have build to the Docker build context.
+If this directory contains a `.jkube-dockerinclude` file, then it is used for including only those files for the build.
+If the file doesn't exist or it's empty, then everything is included.
+
+Each line in this file is treated as an entry in the `includes` assembly `fileSet` <<build-assembly-inline, configuration >>.
+Files can be referenced by using their relative path name.
+Wildcards are also supported, patterns will be matched using
+https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)[
+FileSystem#getPathMatcher] `glob` syntax.
+
+<<ex-build-dockerinclude>> shows how to include only jar file that have build to the Docker build context.
 
 [[ex-build-dockerinclude]]
 .Example `.jkube-dockerinclude`

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/build/_overview.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/build/_overview.adoc
@@ -32,11 +32,11 @@ COPY maven/ /my/target/directory
 
 so that the assembly files will end up in `/my/target/directory` within the container.
 
-If this directory contains a `.maven-dockerignore` (or alternatively, a `.maven-dockerexclude` file), then it is used for excluding files for the build. Each line in this file is treated as a http://ant.apache.org/manual/Types/fileset.html[FileSet exclude pattern] as used by the http://maven.apache.org/plugins/maven-assembly-plugin[maven-assembly-plugin]. It is similar to `.dockerignore` when using Docker but has a slightly different syntax (hence the different name).
+If this directory contains a `.jkube-dockerignore` (or alternatively, a `.jkube-dockerexclude` file), then it is used for excluding files for the build. Each line in this file is treated as a http://ant.apache.org/manual/Types/fileset.html[FileSet exclude pattern] as used by the http://maven.apache.org/plugins/maven-assembly-plugin[maven-assembly-plugin]. It is similar to `.dockerignore` when using Docker but has a slightly different syntax (hence the different name).
 <<ex-build-dockerexclude>> is an  example which excludes all compiled Java classes.
 
 [[ex-build-dockerexclude]]
-.Example `.maven-dockerexclude` or `.maven-dockerignore`
+.Example `.jkube-dockerexclude` or `.jkube-dockerignore`
 ====
 [source]
 ----
@@ -46,10 +46,10 @@ target/classes/**  # <1>
 ====
 
 
-If this directory contains a `.maven-dockerinclude` file, then it is used for including only those files for the build. Each line in this file is also treated as a http://ant.apache.org/manual/Types/fileset.html[FileSet exclude pattern] as used by the http://maven.apache.org/plugins/maven-assembly-plugin[maven-assembly-plugin]. <<ex-build-dockerinclude>> shows how to include only jar file that have build to the Docker build context.
+If this directory contains a `.jkube-dockerinclude` file, then it is used for including only those files for the build. Each line in this file is also treated as a http://ant.apache.org/manual/Types/fileset.html[FileSet exclude pattern] as used by the http://maven.apache.org/plugins/maven-assembly-plugin[maven-assembly-plugin]. <<ex-build-dockerinclude>> shows how to include only jar file that have build to the Docker build context.
 
 [[ex-build-dockerinclude]]
-.Example `.maven-dockerinclude`
+.Example `.jkube-dockerinclude`
 ====
 [source]
 ----


### PR DESCRIPTION
Fix #529 

Added `.jkube-dockerignore`, `.jkube-dockerexclude` and `.jkube-dockerinclude` in AssemblyManager while creating Dockerfile assembly configuration

Ported methods for handling docker includes and docker excludes from https://github.com/fabric8io/docker-maven-plugin/blob/master/src/main/java/io/fabric8/maven/docker/assembly/DockerAssemblyManager.java#L325-L352

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->