### PR TITLE
Fix #497: Assembly descriptor removed but still in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.3.0-SNAPSHOT
+* Fix #497: Assembly descriptor removed but still in documentation
 * Fix #576: Add support to publishing helm chart
 * Fix #634: Replace occurrences of keySet() with entrySet() when value are needed
 * Fix #659: Update Fabric8 Kubernetes Client to v5.3.0

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/build/_configuration.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/build/_configuration.adoc
@@ -163,7 +163,6 @@ remote API.
   <assembly>
     <mode>dir</mode>
     <targetDir>/opt/demo</targetDir>
-    <descriptor>assembly.xml</descriptor>
   </assembly>
 </build>
 ----


### PR DESCRIPTION
## Description
Fix #497 
Remove assembly `<descriptor>` field from documentation as it's no
longer supported


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->