### PR TITLE
Fix #570: Change Behavior of `jkube.namespace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Usage:
 * Fix #546: Use `java.util.function.Function` instead of Guava's `com.google.common.base.Function`
 * Fix #545: Replace Boolean.valueOf with Boolean.parseBoolean for string to boolean conversion
 * Fix #515: Properties now get resolved in CustomResource fragments
+* Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag
 
 ### 1.1.0 (2021-01-28)
 * Fix #455: Use OpenShiftServer with JUnit rule instead of directly instantiating the OpenShiftMockServer

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
@@ -55,7 +56,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelectorRequirement;
 import io.fabric8.kubernetes.api.model.NamedContext;
-import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodCondition;
@@ -92,7 +92,6 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigSpec;
-import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.api.model.Template;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -115,6 +114,7 @@ public class KubernetesHelper {
     public static final Pattern PROFILES_PATTERN = Pattern.compile(PROFILES_PATTERN_REGEX, Pattern.CASE_INSENSITIVE);
     protected static final String[] POD_CONTROLLER_KINDS =
             { "ReplicationController", "ReplicaSet", "Deployment", "DeploymentConfig", "StatefulSet", "DaemonSet", "Job" };
+    public static final String JKUBE_NAMESPACE = "jkube.namespace";
 
 
     private KubernetesHelper() {}
@@ -925,13 +925,12 @@ public class KubernetesHelper {
         return null;
     }
 
-    public static String getNamespaceFromKubernetesList(Collection<HasMetadata> entities) {
-        for (HasMetadata h : entities) {
-            if (h instanceof Namespace || h instanceof Project) {
-                return h.getMetadata().getName();
-            }
+    public static String getConfiguredNamespace(Properties properties, String defaultNamespaceFromConfig) {
+        String jkubeNamespace = (String) properties.get(JKUBE_NAMESPACE);
+        if (StringUtils.isNotEmpty(jkubeNamespace)) {
+            return jkubeNamespace;
         }
-        return null;
+        return defaultNamespaceFromConfig;
     }
 
     public static boolean containsPort(List<ContainerPort> ports, String portValue) {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Namespace;
-import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
@@ -58,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -414,18 +414,29 @@ public class KubernetesHelperTest {
     }
 
     @Test
-    public void testGetNamespaceFromKubernetesList() {
+    public void testGetNamespaceFromKubernetesListReturnsValidNamespace() {
         // Given
-        List<HasMetadata> entities = new ArrayList<>();
-        entities.add(new NamespaceBuilder().withNewMetadata().withName("ns1").endMetadata().build());
-        entities.add(new DeploymentBuilder().withNewMetadata().withName("d1").endMetadata().build());
+        Properties properties = new Properties();
+        properties.put("jkube.namespace", "ns1");
 
         // When
-        String namespace = KubernetesHelper.getNamespaceFromKubernetesList(entities);
+        String namespace = KubernetesHelper.getConfiguredNamespace(properties, "default");
 
         // Then
         assertNotNull(namespace);
         assertEquals("ns1", namespace);
+    }
+
+    @Test
+    public void testGetNamespaceFromKubernetesListReturnsNull() {
+        // Given
+        Properties properties = new Properties();
+
+        // When
+        String namespace = KubernetesHelper.getConfiguredNamespace(properties, "default");
+
+        // Then
+        assertEquals("default", namespace);
     }
 
     @Test

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
@@ -35,11 +35,10 @@ import org.eclipse.jkube.kit.config.service.UndeployService;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.fabric8.openshift.api.model.Project;
 
 import static org.eclipse.jkube.kit.common.util.KubernetesHelper.getCrdContext;
+import static org.eclipse.jkube.kit.common.util.KubernetesHelper.getConfiguredNamespace;
 import static org.eclipse.jkube.kit.common.util.KubernetesHelper.loadResources;
 import static org.eclipse.jkube.kit.config.service.ApplyService.getK8sListWithNamespaceFirst;
 
@@ -69,7 +68,8 @@ public class KubernetesUndeployService implements UndeployService {
     }
     List<HasMetadata> undeployEntities = getK8sListWithNamespaceFirst(entities);
     Collections.reverse(undeployEntities);
-    final String currentNamespace = currentNamespace(undeployEntities);
+    final String currentNamespace = getConfiguredNamespace(jKubeServiceHub.getConfiguration().getProperties(),
+            jKubeServiceHub.getClusterAccess().getNamespace());
     undeployCustomResources(currentNamespace, undeployEntities);
     undeployResources(currentNamespace, undeployEntities);
   }
@@ -100,16 +100,6 @@ public class KubernetesUndeployService implements UndeployService {
       CustomResourceDefinitionList crdList = jKubeServiceHub.getClient().apiextensions().v1beta1().customResourceDefinitions().list();
       deleteCustomResourceIfCustomResourceDefinitionContextPresent(genericCustomResource, namespace, getCrdContext(crdList, genericCustomResource));
     };
-  }
-
-  // Visible for testing
-  String currentNamespace(List<HasMetadata> entities) {
-    for (HasMetadata entity : entities) {
-      if (entity instanceof Namespace || entity instanceof Project) {
-        return entity.getMetadata().getName();
-      }
-    }
-    return jKubeServiceHub.getClusterAccess().getNamespace();
   }
 
   private void deleteCustomResourceIfCustomResourceDefinitionContextPresent(GenericCustomResource customResource, String namespace, CustomResourceDefinitionContext crdContext) {

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.kit.config.service.kubernetes;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Properties;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionListBuilder;
@@ -35,8 +36,6 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.fabric8.openshift.api.model.Project;
-import io.fabric8.openshift.api.model.ProjectBuilder;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Verifications;
@@ -44,8 +43,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings({"ResultOfMethodCallIgnored", "AccessStaticViaInstance", "unused"})
 public class KubernetesUndeployServiceTest {
@@ -91,6 +88,8 @@ public class KubernetesUndeployServiceTest {
       file.isFile(); result = true;
       kubernetesHelper.loadResources(file);
       result = new HashSet<>(Arrays.asList(namespace, pod, service));
+      kubernetesHelper.getConfiguredNamespace((Properties) any, anyString);
+      result = "default";
     }};
     // @formatter:on
     // When
@@ -105,7 +104,7 @@ public class KubernetesUndeployServiceTest {
       jKubeServiceHub.getClient().resource(service).inNamespace("default")
           .withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
       times = 1;
-      jKubeServiceHub.getClient().resource(namespace)
+      jKubeServiceHub.getClient().resource(namespace).inNamespace("default")
               .withPropagationPolicy(DeletionPropagation.BACKGROUND).delete();
       times = 1;
     }};
@@ -147,44 +146,6 @@ public class KubernetesUndeployServiceTest {
       times = 1;
     }};
     // @formatter:on
-  }
-
-  @Test
-  public void currentNamespaceWithNamespaceEntityShouldReturnFromNamespace() {
-    // Given
-    final Pod other = new PodBuilder().withNewMetadata().withName("MrPoddington").endMetadata().build();
-    final Namespace namespace = new NamespaceBuilder().withNewMetadata().withName("FromNamespace").endMetadata().build();
-    final Project project = new ProjectBuilder().withNewMetadata().withName("FromProject").endMetadata().build();
-    // When
-    final String result = kubernetesUndeployService.currentNamespace(Arrays.asList(other, namespace, project, null));
-    // Then
-    assertThat(result).isEqualTo("FromNamespace");
-  }
-
-  @Test
-  public void currentNamespaceWithNoNamespaceEntityShouldReturnFromProject() {
-    // Given
-    final Pod other = new PodBuilder().withNewMetadata().withName("MrPoddington").endMetadata().build();
-    final Project project = new ProjectBuilder().withNewMetadata().withName("FromProject").endMetadata().build();
-    // When
-    final String result = kubernetesUndeployService.currentNamespace(Arrays.asList(other, project, null));
-    // Then
-    assertThat(result).isEqualTo("FromProject");
-  }
-
-  @Test
-  public void currentNamespaceWithNoValidEntitiesShouldReturnFromConfig() {
-    // Given
-    final Pod other = new PodBuilder().withNewMetadata().withName("MrPoddington").endMetadata().build();
-    // @formatter:off
-    new Expectations() {{
-      jKubeServiceHub.getClusterAccess().getNamespace(); result = "the-default";
-    }};
-    // @formatter
-    // When
-    final String result = kubernetesUndeployService.currentNamespace(Arrays.asList(other, null));
-    // Then
-    assertThat(result).isEqualTo("the-default");
   }
 
 }

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -72,6 +72,9 @@ This plugin comes with a set of default enrichers. In addition custom enrichers 
 | <<jkube-name>>
 | Add a default name to every object which misses a name.
 
+| <<jkube-namespace>>
+| Add specified _Namespace_ to Kubernetes resources metadata or create a new Namespace
+
 | <<jkube-pod-annotation>>
 | Copy over annotations from a `Deployment` to a `Pod`
 
@@ -120,6 +123,9 @@ include::enricher/_jkube_service.adoc[]
 
 [[jkube-name]]
 ==== jkube-name
+
+[[jkube-namespace]]
+include::enricher/_jkube_namespace.adoc[]
 
 [[jkube-portname]]
 ==== jkube-portname

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_namespace.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_namespace.adoc
@@ -1,0 +1,23 @@
+[[jkube-namespace]]
+==== jkube-namespace
+
+This enricher adds `Namespace`/`Project` to Kubernetes Resources list or append an already existing `Namespace`/`Project` to all Kubernetes resources' in `.metadata` which are present during the enrichment phase.
+
+The following configuration parameters can be used to influence the behaviour of this enricher:
+
+[[enricher-jkube-namespace]]
+.Default namespace enricher
+[cols="1,6,1"]
+|===
+| Element | Description | Property
+
+| *namespace*
+| Namespace as string which we want to create. A new `Namespace` object would be created and added to the list of Kubernetes resources generated during the enrichment phase.
+| `jkube.enricher.jkube-namespace.namespace`
+
+| *type*
+| Whether we want to generate a `Namespace` or an OpenShift specific `Project` resource. One of: _Namespace_, _Project_.
+
+  Defaults to `Namespace`.
+| `jkube.enricher.jkube-namespace.type`
+|===


### PR DESCRIPTION
Fix #570 
Now `jkube.namespace` would only append namespace in Kubernetes
resources metadata. Earlier we were creating a new namespace too when
this property was configured.

For creating a new namespace this property should be used:
`jkube.enricher.jkube-namespace.namespace`

`jkube.namespace` | `jkube.enricher.jkube-namespace.namespace` | behavior
--------------------------|---------------------------------------------------------------|-------------
:heavy_check_mark: | :x: | Namespace gets configured in all resources' `.metadata.namespace`
:x: | :heavy_check_mark: | Namespace gets created and added in `kubernetes.yml`. This namespace created is different from configured namespace
:x: | :x: | No namespace gets created or configured. All resources get deployed to the namespace being picked from global configuration
:heavy_check_mark: | :heavy_check_mark: | Namespace gets configured in Kubernetes resource with first option and a new Namespace gets created

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->