### PR TITLE
Fix #570: Change Behavior of `jkube.namespace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Usage:
 # ./scripts/changelog.sh semanticVersionNumber [linkLabelStartNumber]
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
+### 1.1.1-SNAPSHOT
+* Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag
+
 ### 1.1.0 (2021-01-28)
 * Fix #455: Use OpenShiftServer with JUnit rule instead of directly instantiating the OpenShiftMockServer
 * Fix #467: Upgrade assertj-core to 3.18.0

--- a/jkube-kit/build/api/pom.xml
+++ b/jkube-kit/build/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>jkube-kit-build-api</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1-SNAPSHOT</version>
 
   <name>JKube Kit :: Build :: API</name>
 

--- a/jkube-kit/build/service/docker/pom.xml
+++ b/jkube-kit/build/service/docker/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/build/service/jib/pom.xml
+++ b/jkube-kit/build/service/jib/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/common-maven/pom.xml
+++ b/jkube-kit/common-maven/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/common-test/pom.xml
+++ b/jkube-kit/common-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/common/pom.xml
+++ b/jkube-kit/common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
@@ -56,7 +57,6 @@ import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelectorRequirement;
 import io.fabric8.kubernetes.api.model.NamedContext;
-import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodCondition;
@@ -91,7 +91,6 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigSpec;
-import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.api.model.Template;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -110,6 +109,7 @@ public class KubernetesHelper {
     public static final Pattern PROFILES_PATTERN = Pattern.compile(PROFILES_PATTERN_REGEX, Pattern.CASE_INSENSITIVE);
     protected static final String[] POD_CONTROLLER_KINDS =
             { "ReplicationController", "ReplicaSet", "Deployment", "DeploymentConfig", "StatefulSet", "DaemonSet", "Job" };
+    public static final String JKUBE_NAMESPACE = "jkube.namespace";
 
 
     private KubernetesHelper() {}
@@ -952,13 +952,12 @@ public class KubernetesHelper {
         return null;
     }
 
-    public static String getNamespaceFromKubernetesList(Collection<HasMetadata> entities) {
-        for (HasMetadata h : entities) {
-            if (h instanceof Namespace || h instanceof Project) {
-                return h.getMetadata().getName();
-            }
+    public static String getConfiguredNamespace(Properties properties, String defaultNamespaceFromConfig) {
+        String jkubeNamespace = (String) properties.get(JKUBE_NAMESPACE);
+        if (StringUtils.isNotEmpty(jkubeNamespace)) {
+            return jkubeNamespace;
         }
-        return null;
+        return defaultNamespaceFromConfig;
     }
 
     public static boolean containsPort(List<ContainerPort> ports, String portValue) {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -19,14 +19,12 @@ import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.apps.DaemonSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import io.fabric8.kubernetes.api.model.Service;
@@ -48,6 +46,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -426,18 +425,29 @@ public class KubernetesHelperTest {
     }
 
     @Test
-    public void testGetNamespaceFromKubernetesList() {
+    public void testGetNamespaceFromKubernetesListReturnsValidNamespace() {
         // Given
-        List<HasMetadata> entities = new ArrayList<>();
-        entities.add(new NamespaceBuilder().withNewMetadata().withName("ns1").endMetadata().build());
-        entities.add(new DeploymentBuilder().withNewMetadata().withName("d1").endMetadata().build());
+        Properties properties = new Properties();
+        properties.put("jkube.namespace", "ns1");
 
         // When
-        String namespace = KubernetesHelper.getNamespaceFromKubernetesList(entities);
+        String namespace = KubernetesHelper.getConfiguredNamespace(properties, "default");
 
         // Then
         assertNotNull(namespace);
         assertEquals("ns1", namespace);
+    }
+
+    @Test
+    public void testGetNamespaceFromKubernetesListReturnsNull() {
+        // Given
+        Properties properties = new Properties();
+
+        // When
+        String namespace = KubernetesHelper.getConfiguredNamespace(properties, "default");
+
+        // Then
+        assertEquals("default", namespace);
     }
 
     private void assertLocalFragments(File[] fragments, int expectedSize) {

--- a/jkube-kit/config/image/pom.xml
+++ b/jkube-kit/config/image/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/config/resource/pom.xml
+++ b/jkube-kit/config/resource/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/config/service/pom.xml
+++ b/jkube-kit/config/service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>jkube-kit-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
@@ -58,7 +58,6 @@ import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
 import org.eclipse.jkube.kit.common.util.UserConfigurationCompare;
-import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil;
@@ -195,6 +194,11 @@ public class ApplyService {
             applyCustomResourceDefinition((CustomResourceDefinition) dto, sourceName);
         } else if (dto instanceof Job) {
             applyJob((Job) dto, sourceName);
+
+        } else if (dto instanceof Namespace) {
+            applyNamespace((Namespace) dto);
+        } else if (dto instanceof Project) {
+            applyProject((Project) dto);
         } else if (dto instanceof HasMetadata) {
             HasMetadata entity = (HasMetadata) dto;
             try {
@@ -1032,17 +1036,17 @@ public class ApplyService {
      */
     public boolean applyNamespace(Namespace entity) {
         String currentNamespace = getOrCreateMetadata(entity).getName();
-        log.info("Using currentNamespace: " + currentNamespace);
+        log.info("Creating currentNamespace: " + currentNamespace);
         String name = getName(entity);
         Objects.requireNonNull(name, "No name for " + entity );
         Namespace old = kubernetesClient.namespaces().withName(name).get();
         if (!isRunning(old)) {
             try {
                 Object answer = kubernetesClient.namespaces().create(entity);
-                logGeneratedEntity("Created currentNamespace: ", currentNamespace, entity, answer);
+                logGeneratedEntity("Created Namespace: ", currentNamespace, entity, answer);
                 return true;
             } catch (Exception e) {
-                onApplyError("Failed to create currentNamespace: " + name + " due " + e.getMessage(), e);
+                onApplyError("Failed to create Namespace: " + name + " due " + e.getMessage(), e);
             }
         }
         return false;
@@ -1068,7 +1072,7 @@ public class ApplyService {
             return false;
         }
         String currentNamespace = getOrCreateMetadata(entity).getName();
-        log.info("Using project: " + currentNamespace);
+        log.info("Creating project: " + currentNamespace);
         String name = getName(entity);
         Objects.requireNonNull(name, "No name for " + entity);
         OpenShiftClient openshiftClient = getOpenShiftClient();
@@ -1432,23 +1436,6 @@ public class ApplyService {
                 apply(entity, fileName);
             }
         }
-    }
-
-    /**
-     * Picks namespace for ApplyService, by default namespace specified in ClusterAccess is given
-     * preference. If there is namespace specified in provided Kubernetes resources, it would be
-     * given preference over ClusterAccess's namespace
-     *
-     * @param entities a list of Kubernetes resources to process
-     * @param clusterAccess {@link ClusterAccess} Kubernetes Cluster Access
-     * @return namespace for ApplyService
-     */
-    public static String getNamespaceForApplyService(Set<HasMetadata> entities, ClusterAccess clusterAccess) {
-        String namespaceInProvidedKubernetesList = KubernetesHelper.getNamespaceFromKubernetesList(entities);
-        if (namespaceInProvidedKubernetesList == null) {
-            return clusterAccess.getNamespace();
-        }
-        return namespaceInProvidedKubernetesList;
     }
 
     public static List<HasMetadata> getK8sListWithNamespaceFirst(Collection<HasMetadata> k8sList) {

--- a/jkube-kit/doc/pom.xml
+++ b/jkube-kit/doc/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <artifactId>jkube-kit-doc</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>JKube Kit :: Documentation</name>

--- a/jkube-kit/enricher/api/pom.xml
+++ b/jkube-kit/enricher/api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/enricher/generic/pom.xml
+++ b/jkube-kit/enricher/generic/pom.xml
@@ -19,7 +19,7 @@
     <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/enricher/specific/pom.xml
+++ b/jkube-kit/enricher/specific/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/generator/api/pom.xml
+++ b/jkube-kit/generator/api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/generator/java-exec/pom.xml
+++ b/jkube-kit/generator/java-exec/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/generator/karaf/pom.xml
+++ b/jkube-kit/generator/karaf/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/generator/webapp/pom.xml
+++ b/jkube-kit/generator/webapp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/generator/wildfly-swarm/pom.xml
+++ b/jkube-kit/generator/wildfly-swarm/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/jkube-kit-micronaut/pom.xml
+++ b/jkube-kit/jkube-kit-micronaut/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>jkube-kit-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jkube-kit/jkube-kit-openliberty/pom.xml
+++ b/jkube-kit/jkube-kit-openliberty/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jkube-kit-parent</artifactId>
         <groupId>org.eclipse.jkube</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jkube-kit/jkube-kit-quarkus/pom.xml
+++ b/jkube-kit/jkube-kit-quarkus/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jkube-kit-parent</artifactId>
         <groupId>org.eclipse.jkube</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jkube-kit/jkube-kit-spring-boot/pom.xml
+++ b/jkube-kit/jkube-kit-spring-boot/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jkube-kit-parent</artifactId>
         <groupId>org.eclipse.jkube</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jkube-kit/jkube-kit-thorntail-v2/pom.xml
+++ b/jkube-kit/jkube-kit-thorntail-v2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>jkube-kit-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jkube-kit/jkube-kit-vertx/pom.xml
+++ b/jkube-kit/jkube-kit-vertx/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jkube-kit-parent</artifactId>
         <groupId>org.eclipse.jkube</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jkube-kit/jkube-kit-wildfly-jar/pom.xml
+++ b/jkube-kit/jkube-kit-wildfly-jar/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>jkube-kit-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/pom.xml
+++ b/jkube-kit/pom.xml
@@ -18,13 +18,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>jkube-kit-build</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/profile/pom.xml
+++ b/jkube-kit/profile/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jkube-kit-parent</artifactId>
         <groupId>org.eclipse.jkube</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jkube-kit/resource/helm/pom.xml
+++ b/jkube-kit/resource/helm/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/resource/service/pom.xml
+++ b/jkube-kit/resource/service/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/watcher/api/pom.xml
+++ b/jkube-kit/watcher/api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/jkube-kit/watcher/standard/pom.xml
+++ b/jkube-kit/watcher/standard/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube-kit-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 

--- a/kubernetes-maven-plugin/doc/pom.xml
+++ b/kubernetes-maven-plugin/doc/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>kubernetes-maven-plugin-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -72,6 +72,9 @@ This plugin comes with a set of default enrichers. In addition custom enrichers 
 | <<jkube-name>>
 | Add a default name to every object which misses a name.
 
+| <<jkube-namespace>>
+| Add specified _Namespace_ to Kubernetes resources metadata or create a new Namespace
+
 | <<jkube-pod-annotation>>
 | Copy over annotations from a `Deployment` to a `Pod`
 
@@ -120,6 +123,9 @@ include::enricher/_jkube_service.adoc[]
 
 [[jkube-name]]
 ==== jkube-name
+
+[[jkube-namespace]]
+include::enricher/_jkube_namespace.adoc[]
 
 [[jkube-portname]]
 ==== jkube-portname

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_namespace.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_namespace.adoc
@@ -1,0 +1,23 @@
+[[jkube-namespace]]
+==== jkube-namespace
+
+This enricher adds `Namespace`/`Project` to Kubernetes Resources list or append an already existing `Namespace`/`Project` to all Kubernetes resources' in `.metadata` which are present during the enrichment phase.
+
+The following configuration parameters can be used to influence the behaviour of this enricher:
+
+[[enricher-jkube-namespace]]
+.Default namespace enricher
+[cols="1,6,1"]
+|===
+| Element | Description | Property
+
+| *namespace*
+| Namespace as string which we want to create. A new `Namespace` object would be created and added to the list of Kubernetes resources generated during the enrichment phase.
+| `jkube.enricher.jkube-namespace.namespace`
+
+| *type*
+| Whether we want to generate a `Namespace` or an OpenShift specific `Project` resource. One of: _Namespace_, _Project_.
+
+  Defaults to `Namespace`.
+| `jkube.enricher.jkube-namespace.type`
+|===

--- a/kubernetes-maven-plugin/it/pom.xml
+++ b/kubernetes-maven-plugin/it/pom.xml
@@ -26,7 +26,7 @@ for running a single test.
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>kubernetes-maven-plugin-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kubernetes-maven-plugin/it/src/it/namespace/expected/create-and-set-different-namespace/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/namespace/expected/create-and-set-different-namespace/kubernetes.yml
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      labels:
+        app: namespace
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace-to-create-name
+    status:
+      phase: Active
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: namespace
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+      namespace: namespace-to-operate
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: namespace
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: namespace
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+      namespace: namespace-to-operate
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: namespace
+          provider: jkube
+          group: org.eclipse.jkube
+      template:
+        metadata:
+          annotations:
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: namespace
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: "@matches('jkube/namespace:.*$')@"
+              imagePullPolicy: IfNotPresent
+              name: spring-boot
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              securityContext:
+                privileged: false

--- a/kubernetes-maven-plugin/it/src/it/namespace/expected/create-and-set-namespace/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/namespace/expected/create-and-set-namespace/kubernetes.yml
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      labels:
+        app: namespace
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace-to-create-and-operate
+    status:
+      phase: Active
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: namespace
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+      namespace: namespace-to-create-and-operate
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: namespace
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: namespace
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+      namespace: namespace-to-create-and-operate
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: namespace
+          provider: jkube
+          group: org.eclipse.jkube
+      template:
+        metadata:
+          annotations:
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: namespace
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: "@matches('jkube/namespace:.*$')@"
+              imagePullPolicy: IfNotPresent
+              name: spring-boot
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              securityContext:
+                privileged: false

--- a/kubernetes-maven-plugin/it/src/it/namespace/expected/create-namespace/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/namespace/expected/create-namespace/kubernetes.yml
@@ -1,0 +1,109 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      labels:
+        app: namespace
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace-to-create-name
+    status:
+      phase: Active
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: namespace
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: namespace
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: namespace
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: namespace
+          provider: jkube
+          group: org.eclipse.jkube
+      template:
+        metadata:
+          annotations:
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: namespace
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: "@matches('jkube/namespace:.*$')@"
+              imagePullPolicy: IfNotPresent
+              name: spring-boot
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              securityContext:
+                privileged: false

--- a/kubernetes-maven-plugin/it/src/it/namespace/expected/default/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/namespace/expected/default/kubernetes.yml
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: namespace
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: namespace
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: namespace
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: namespace
+          provider: jkube
+          group: org.eclipse.jkube
+      template:
+        metadata:
+          annotations:
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: namespace
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: "@matches('jkube/namespace:.*$')@"
+              imagePullPolicy: IfNotPresent
+              name: spring-boot
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              securityContext:
+                privileged: false

--- a/kubernetes-maven-plugin/it/src/it/namespace/expected/set-namespace/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/namespace/expected/set-namespace/kubernetes.yml
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: namespace
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+      namespace: namespace-to-operate
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: namespace
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: namespace
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: namespace
+      namespace: namespace-to-operate
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: namespace
+          provider: jkube
+          group: org.eclipse.jkube
+      template:
+        metadata:
+          annotations:
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: namespace
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: "@matches('jkube/namespace:.*$')@"
+              imagePullPolicy: IfNotPresent
+              name: spring-boot
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              securityContext:
+                privileged: false

--- a/kubernetes-maven-plugin/it/src/it/namespace/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/namespace/invoker.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+invoker.goals.1=clean k8s:resource -Pdefault
+invoker.goals.2=clean k8s:resource -Pcreate-namespace
+invoker.goals.3=clean k8s:resource -Pset-namespace
+invoker.goals.4=clean k8s:resource -Pcreate-and-set-namespace
+invoker.goals.5=clean k8s:resource -Pcreate-and-set-different-namespace

--- a/kubernetes-maven-plugin/it/src/it/namespace/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/namespace/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>namespace</artifactId>
+  <groupId>org.eclipse.jkube</groupId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.3.3.RELEASE</version>
+  </parent>
+
+  <properties>
+    <target>targets</target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <directory>${project.basedir}/${target}</directory>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+        <version>@jkube.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>default</id>
+      <properties>
+        <target>default</target>
+      </properties>
+    </profile>
+    <profile>
+      <id>create-namespace</id>
+      <properties>
+        <jkube.enricher.jkube-namespace.namespace>namespace-to-create-name</jkube.enricher.jkube-namespace.namespace>
+        <target>create-namespace</target>
+      </properties>
+    </profile>
+    <profile>
+      <id>set-namespace</id>
+      <properties>
+        <jkube.namespace>namespace-to-operate</jkube.namespace>
+        <target>set-namespace</target>
+      </properties>
+    </profile>
+    <profile>
+      <id>create-and-set-namespace</id>
+      <properties>
+        <jkube.enricher.jkube-namespace.namespace>namespace-to-create-and-operate</jkube.enricher.jkube-namespace.namespace>
+        <jkube.namespace>namespace-to-create-and-operate</jkube.namespace>
+        <target>create-and-set-namespace</target>
+      </properties>
+    </profile>
+    <profile>
+      <id>create-and-set-different-namespace</id>
+      <properties>
+        <jkube.enricher.jkube-namespace.namespace>namespace-to-create-name</jkube.enricher.jkube-namespace.namespace>
+        <jkube.namespace>namespace-to-operate</jkube.namespace>
+        <target>create-and-set-different-namespace</target>
+      </properties>
+    </profile>
+  </profiles>
+
+</project>

--- a/kubernetes-maven-plugin/it/src/it/namespace/src/main/java/zero/Application.java
+++ b/kubernetes-maven-plugin/it/src/it/namespace/src/main/java/zero/Application.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package zero;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+
+}

--- a/kubernetes-maven-plugin/it/src/it/namespace/verify.groovy
+++ b/kubernetes-maven-plugin/it/src/it/namespace/verify.groovy
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+import org.eclipse.jkube.maven.it.Verify
+
+[
+  "default", "create-namespace", "set-namespace", "create-and-set-namespace", "create-and-set-different-namespace"
+].each {
+  Verify.verifyResourceDescriptors(
+    new File(basedir, sprintf("/%s/classes/META-INF/jkube/kubernetes.yml", it)),
+    new File(basedir, sprintf("/expected/%s/kubernetes.yml", it)))
+}
+
+true

--- a/kubernetes-maven-plugin/plugin/pom.xml
+++ b/kubernetes-maven-plugin/plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.eclipse.jkube</groupId>
       <artifactId>kubernetes-maven-plugin-parent</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
@@ -35,7 +35,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.Set;
 
-import static org.eclipse.jkube.kit.config.service.ApplyService.getNamespaceForApplyService;
+import static org.eclipse.jkube.kit.common.util.KubernetesHelper.getConfiguredNamespace;
 
 /**
  * Base class for goals which deploy the generated artifacts into the Kubernetes cluster
@@ -179,10 +179,10 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
             Set<HasMetadata> entities = KubernetesResourceUtil.loadResources(manifest);
             log.info("Using %s at %s in namespace %s with manifest %s ", clusterKind, masterUrl, clusterAccess.getNamespace(), manifest);
 
-            configureApplyService(kubernetes, entities);
+            configureApplyService(kubernetes);
 
             // Apply rest of the entities present in manifest
-            applyEntities(kubernetes, getNamespaceForApplyService(entities, clusterAccess), manifest.getName(), entities);
+            applyEntities(kubernetes, getConfiguredNamespace(project.getProperties(), clusterAccess.getNamespace()), manifest.getName(), entities);
             log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up", clusterAccess.isOpenShift() ? "oc" : "kubectl");
         } catch (KubernetesClientException e) {
             KubernetesResourceUtil.handleKubernetesClientException(e, this.log);
@@ -221,7 +221,7 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
         applyService.setProcessTemplatesLocally(true);
     }
 
-    private void configureApplyService(KubernetesClient kubernetes, Set<HasMetadata> entities) {
+    private void configureApplyService(KubernetesClient kubernetes) {
         applyService.setAllowCreate(createNewResources);
         applyService.setServicesOnlyMode(servicesOnly);
         applyService.setIgnoreServiceMode(ignoreServices);
@@ -233,7 +233,7 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
         applyService.setRollingUpgrade(rollingUpgrades);
         applyService.setRollingUpgradePreserveScale(isRollingUpgradePreserveScale());
         applyService.setRecreateMode(recreate);
-        applyService.setNamespace(getNamespaceForApplyService(entities, clusterAccess));
+        applyService.setNamespace(getConfiguredNamespace(project.getProperties(), clusterAccess.getNamespace()));
 
         boolean openShift = OpenshiftHelper.isOpenShift(kubernetes);
         if (openShift) {

--- a/kubernetes-maven-plugin/pom.xml
+++ b/kubernetes-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/openshift-maven-plugin/it/pom.xml
+++ b/openshift-maven-plugin/it/pom.xml
@@ -26,7 +26,7 @@ for running a single test.
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>openshift-maven-plugin-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/openshift-maven-plugin/it/src/it/project/expected/create-project-and-set-different-namespace/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/create-project-and-set-different-namespace/openshift.yml
@@ -1,0 +1,144 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: project.openshift.io/v1
+    kind: Project
+    metadata:
+      labels:
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project-to-create-name
+    status:
+      phase: Active
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+      namespace: namespace-to-operate
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: project
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+      namespace: namespace-to-operate
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+      strategy:
+        rollingParams:
+          timeoutSeconds: 3600
+        type: Rolling
+      template:
+        metadata:
+          annotations:
+            app.openshift.io/vcs-ref: "@ignore@"
+            app.openshift.io/vcs-uri: "@ignore@"
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: project
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: "@matches('project:.*$')@"
+              imagePullPolicy: IfNotPresent
+              name: spring-boot
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              securityContext:
+                privileged: false
+      triggers:
+        - type: ConfigChange
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - spring-boot
+            from:
+              kind: ImageStreamTag
+              name: project:latest
+          type: ImageChange
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      annotations:
+        app.openshift.io/vcs-ref: "@ignore@"
+        app.openshift.io/vcs-uri: "@ignore@"
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+      namespace: namespace-to-operate
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Service
+        name: project

--- a/openshift-maven-plugin/it/src/it/project/expected/create-project-and-set-namespace/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/create-project-and-set-namespace/openshift.yml
@@ -1,0 +1,144 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: project.openshift.io/v1
+    kind: Project
+    metadata:
+      labels:
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project-to-create-and-operate
+    status:
+      phase: Active
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+      namespace: project-to-create-and-operate
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: project
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+      namespace: project-to-create-and-operate
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+      strategy:
+        rollingParams:
+          timeoutSeconds: 3600
+        type: Rolling
+      template:
+        metadata:
+          annotations:
+            app.openshift.io/vcs-ref: "@ignore@"
+            app.openshift.io/vcs-uri: "@ignore@"
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: project
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: "@matches('project:.*$')@"
+              imagePullPolicy: IfNotPresent
+              name: spring-boot
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              securityContext:
+                privileged: false
+      triggers:
+        - type: ConfigChange
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - spring-boot
+            from:
+              kind: ImageStreamTag
+              name: project:latest
+          type: ImageChange
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      annotations:
+        app.openshift.io/vcs-ref: "@ignore@"
+        app.openshift.io/vcs-uri: "@ignore@"
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+      namespace: project-to-create-and-operate
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Service
+        name: project

--- a/openshift-maven-plugin/it/src/it/project/expected/create-project/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/create-project/openshift.yml
@@ -1,0 +1,141 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: project.openshift.io/v1
+    kind: Project
+    metadata:
+      labels:
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project-to-create-name
+    status:
+      phase: Active
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: project
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+      strategy:
+        rollingParams:
+          timeoutSeconds: 3600
+        type: Rolling
+      template:
+        metadata:
+          annotations:
+            app.openshift.io/vcs-ref: "@ignore@"
+            app.openshift.io/vcs-uri: "@ignore@"
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: project
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: "@matches('project:.*$')@"
+              imagePullPolicy: IfNotPresent
+              name: spring-boot
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              securityContext:
+                privileged: false
+      triggers:
+        - type: ConfigChange
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - spring-boot
+            from:
+              kind: ImageStreamTag
+              name: project:latest
+          type: ImageChange
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      annotations:
+        app.openshift.io/vcs-ref: "@ignore@"
+        app.openshift.io/vcs-uri: "@ignore@"
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Service
+        name: project

--- a/openshift-maven-plugin/it/src/it/project/expected/default/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/default/openshift.yml
@@ -1,0 +1,130 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: project
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+      strategy:
+        rollingParams:
+          timeoutSeconds: 3600
+        type: Rolling
+      template:
+        metadata:
+          annotations:
+            app.openshift.io/vcs-ref: "@ignore@"
+            app.openshift.io/vcs-uri: "@ignore@"
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: project
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+          - env:
+              - name: KUBERNETES_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            image: "@matches('project:.*$')@"
+            imagePullPolicy: IfNotPresent
+            name: spring-boot
+            ports:
+              - containerPort: 8080
+                name: http
+                protocol: TCP
+              - containerPort: 9779
+                name: prometheus
+                protocol: TCP
+              - containerPort: 8778
+                name: jolokia
+                protocol: TCP
+            securityContext:
+              privileged: false
+      triggers:
+      - type: ConfigChange
+      - imageChangeParams:
+          automatic: true
+          containerNames:
+          - spring-boot
+          from:
+            kind: ImageStreamTag
+            name: project:latest
+        type: ImageChange
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      annotations:
+        app.openshift.io/vcs-ref: "@ignore@"
+        app.openshift.io/vcs-uri: "@ignore@"
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Service
+        name: project

--- a/openshift-maven-plugin/it/src/it/project/expected/set-namespace/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/set-namespace/openshift.yml
@@ -1,0 +1,133 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.io/git-branch: "@ignore@"
+        prometheus.io/port: "9779"
+      labels:
+        expose: "true"
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+      namespace: namespace-to-operate
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        provider: jkube
+        app: project
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+      namespace: namespace-to-operate
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        app: project
+        provider: jkube
+        group: org.eclipse.jkube
+      strategy:
+        rollingParams:
+          timeoutSeconds: 3600
+        type: Rolling
+      template:
+        metadata:
+          annotations:
+            app.openshift.io/vcs-ref: "@ignore@"
+            app.openshift.io/vcs-uri: "@ignore@"
+            jkube.io/git-commit: "@ignore@"
+            jkube.io/git-branch: "@ignore@"
+          labels:
+            provider: jkube
+            app: project
+            version: "@ignore@"
+            group: org.eclipse.jkube
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: "@matches('project:.*$')@"
+              imagePullPolicy: IfNotPresent
+              name: spring-boot
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              securityContext:
+                privileged: false
+      triggers:
+        - type: ConfigChange
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - spring-boot
+            from:
+              kind: ImageStreamTag
+              name: project:latest
+          type: ImageChange
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      annotations:
+        app.openshift.io/vcs-ref: "@ignore@"
+        app.openshift.io/vcs-uri: "@ignore@"
+        jkube.io/git-commit: "@ignore@"
+        jkube.io/git-branch: "@ignore@"
+      labels:
+        app: project
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube
+      name: project
+      namespace: namespace-to-operate
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Service
+        name: project

--- a/openshift-maven-plugin/it/src/it/project/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/project/invoker.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+invoker.goals.1=clean oc:resource -Pdefault
+invoker.goals.2=clean oc:resource -Pcreate-project
+invoker.goals.3=clean oc:resource -Pset-namespace
+invoker.goals.4=clean oc:resource -Pcreate-project-and-set-namespace
+invoker.goals.5=clean oc:resource -Pcreate-project-and-set-different-namespace

--- a/openshift-maven-plugin/it/src/it/project/pom.xml
+++ b/openshift-maven-plugin/it/src/it/project/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>project</artifactId>
+  <groupId>org.eclipse.jkube</groupId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.3.3.RELEASE</version>
+  </parent>
+
+  <properties>
+    <target>targets</target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <directory>${project.basedir}/${target}</directory>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>openshift-maven-plugin</artifactId>
+        <version>@jkube.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>default</id>
+      <properties>
+        <target>default</target>
+      </properties>
+    </profile>
+    <profile>
+      <id>create-project</id>
+      <properties>
+        <jkube.enricher.jkube-namespace.namespace>project-to-create-name</jkube.enricher.jkube-namespace.namespace>
+        <target>create-project</target>
+      </properties>
+    </profile>
+    <profile>
+      <id>set-namespace</id>
+      <properties>
+        <jkube.namespace>namespace-to-operate</jkube.namespace>
+        <target>set-namespace</target>
+      </properties>
+    </profile>
+    <profile>
+      <id>create-project-and-set-namespace</id>
+      <properties>
+        <jkube.enricher.jkube-namespace.namespace>project-to-create-and-operate</jkube.enricher.jkube-namespace.namespace>
+        <jkube.namespace>project-to-create-and-operate</jkube.namespace>
+        <target>create-project-and-set-namespace</target>
+      </properties>
+    </profile>
+    <profile>
+      <id>create-project-and-set-different-namespace</id>
+      <properties>
+        <jkube.enricher.jkube-namespace.namespace>project-to-create-name</jkube.enricher.jkube-namespace.namespace>
+        <jkube.namespace>namespace-to-operate</jkube.namespace>
+        <target>create-project-and-set-different-namespace</target>
+      </properties>
+    </profile>
+  </profiles>
+
+</project>

--- a/openshift-maven-plugin/it/src/it/project/src/main/java/zero/Application.java
+++ b/openshift-maven-plugin/it/src/it/project/src/main/java/zero/Application.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package zero;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+
+}

--- a/openshift-maven-plugin/it/src/it/project/verify.groovy
+++ b/openshift-maven-plugin/it/src/it/project/verify.groovy
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+import org.eclipse.jkube.maven.it.Verify
+
+[
+  "default", "create-project", "set-namespace", "create-project-and-set-namespace", "create-project-and-set-different-namespace"
+].each {
+  Verify.verifyResourceDescriptors(
+    new File(basedir, sprintf("/%s/classes/META-INF/jkube/openshift.yml", it)),
+    new File(basedir, sprintf("/expected/%s/openshift.yml", it)))
+}
+
+true

--- a/openshift-maven-plugin/plugin/pom.xml
+++ b/openshift-maven-plugin/plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.eclipse.jkube</groupId>
       <artifactId>openshift-maven-plugin-parent</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/openshift-maven-plugin/pom.xml
+++ b/openshift-maven-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.eclipse.jkube</groupId>
     <artifactId>jkube</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>org.eclipse.jkube</groupId>
   <artifactId>jkube</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Eclipse JKube</description>
   <name>Eclipse JKube</name>


### PR DESCRIPTION
Now `jkube.namespace` would only append namespace in Kubernetes
resources metadata. Earlier we were creating a new namespace too when
this property was configured.

For creating a new namespace this property should be used:
`jkube.enricher.jkube-namespace.namespace`


## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->