### PR TITLE
feat: Apply and Undeploy service use configured namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Usage:
 * Fix #546: Use `java.util.function.Function` instead of Guava's `com.google.common.base.Function`
 * Fix #545: Replace Boolean.valueOf with Boolean.parseBoolean for string to boolean conversion
 * Fix #515: Properties now get resolved in CustomResource fragments
+* Fix #586: Apply and Undeploy service use configured namespace
 
 ### 1.1.1 (2021-02-23)
 * Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
@@ -114,8 +113,6 @@ public class KubernetesHelper {
     public static final Pattern PROFILES_PATTERN = Pattern.compile(PROFILES_PATTERN_REGEX, Pattern.CASE_INSENSITIVE);
     protected static final String[] POD_CONTROLLER_KINDS =
             { "ReplicationController", "ReplicaSet", "Deployment", "DeploymentConfig", "StatefulSet", "DaemonSet", "Job" };
-    public static final String JKUBE_NAMESPACE = "jkube.namespace";
-
 
     private KubernetesHelper() {}
 
@@ -923,14 +920,6 @@ public class KubernetesHelper {
             return getOrCreateAnnotations(item).get(annotationKey);
         }
         return null;
-    }
-
-    public static String getConfiguredNamespace(Properties properties, String defaultNamespaceFromConfig) {
-        String jkubeNamespace = (String) properties.get(JKUBE_NAMESPACE);
-        if (StringUtils.isNotEmpty(jkubeNamespace)) {
-            return jkubeNamespace;
-        }
-        return defaultNamespaceFromConfig;
     }
 
     public static boolean containsPort(List<ContainerPort> ports, String portValue) {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -415,32 +415,6 @@ public class KubernetesHelperTest {
     }
 
     @Test
-    public void testGetNamespaceFromKubernetesListReturnsValidNamespace() {
-        // Given
-        Properties properties = new Properties();
-        properties.put("jkube.namespace", "ns1");
-
-        // When
-        String namespace = KubernetesHelper.getConfiguredNamespace(properties, "default");
-
-        // Then
-        assertNotNull(namespace);
-        assertEquals("ns1", namespace);
-    }
-
-    @Test
-    public void testGetNamespaceFromKubernetesListReturnsNull() {
-        // Given
-        Properties properties = new Properties();
-
-        // When
-        String namespace = KubernetesHelper.getConfiguredNamespace(properties, "default");
-
-        // Then
-        assertEquals("default", namespace);
-    }
-
-    @Test
     public void loadResourcesWithNestedTemplateAndDuplicateResources() throws IOException {
         // Given
         final File manifest = new File(KubernetesHelperTest.class.getResource(

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
@@ -38,7 +38,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 
 import static org.eclipse.jkube.kit.common.util.KubernetesHelper.getCrdContext;
-import static org.eclipse.jkube.kit.common.util.KubernetesHelper.getConfiguredNamespace;
 import static org.eclipse.jkube.kit.common.util.KubernetesHelper.loadResources;
 import static org.eclipse.jkube.kit.config.service.ApplyService.getK8sListWithNamespaceFirst;
 
@@ -68,10 +67,8 @@ public class KubernetesUndeployService implements UndeployService {
     }
     List<HasMetadata> undeployEntities = getK8sListWithNamespaceFirst(entities);
     Collections.reverse(undeployEntities);
-    final String currentNamespace = getConfiguredNamespace(jKubeServiceHub.getConfiguration().getProperties(),
-        jKubeServiceHub.getClusterAccess().getNamespace());
-    undeployCustomResources(currentNamespace, undeployEntities);
-    undeployResources(currentNamespace, undeployEntities);
+    undeployCustomResources(resourceConfig.getNamespace(), undeployEntities);
+    undeployResources(resourceConfig.getNamespace(), undeployEntities);
   }
 
   private void undeployCustomResources(String currentNamespace, List<HasMetadata> entities) {

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
@@ -16,7 +16,6 @@ package org.eclipse.jkube.kit.config.service.kubernetes;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Properties;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionListBuilder;
@@ -67,7 +66,7 @@ public class KubernetesUndeployServiceTest {
     // Given
     final File nonexistent = new File("I don't exist");
     // When
-    kubernetesUndeployService.undeploy(null, null, nonexistent, null);
+    kubernetesUndeployService.undeploy(null, ResourceConfig.builder().build(), nonexistent, null);
     // Then
     // @formatter:off
     new Verifications() {{
@@ -79,6 +78,7 @@ public class KubernetesUndeployServiceTest {
   @Test
   public void undeployWithManifestShouldDeleteAllEntities(@Mocked File file) throws Exception {
     // Given
+    final ResourceConfig resourceConfig = ResourceConfig.builder().namespace("default").build();
     final Namespace namespace = new NamespaceBuilder().withNewMetadata().withName("default").endMetadata().build();
     final Pod pod = new PodBuilder().withNewMetadata().withName("MrPoddington").endMetadata().build();
     final Service service = new Service();
@@ -88,12 +88,10 @@ public class KubernetesUndeployServiceTest {
       file.isFile(); result = true;
       kubernetesHelper.loadResources(file);
       result = new HashSet<>(Arrays.asList(namespace, pod, service));
-      kubernetesHelper.getConfiguredNamespace((Properties) any, anyString);
-      result = "default";
     }};
     // @formatter:on
     // When
-    kubernetesUndeployService.undeploy(null, null, file);
+    kubernetesUndeployService.undeploy(null, resourceConfig, file);
     // Then
     // @formatter:off
     new Verifications() {{

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftUndeployServiceTest.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
@@ -130,7 +131,7 @@ public class OpenshiftUndeployServiceTest {
     }};
     // @formatter:on
     // When
-    openshiftUndeployService.undeploy(null, null, temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null, ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(1);
     assertDeleted(entity);
@@ -142,7 +143,7 @@ public class OpenshiftUndeployServiceTest {
     final Pod entity = new Pod();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null, temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(1);
     assertDeleted(entity);
@@ -157,7 +158,7 @@ public class OpenshiftUndeployServiceTest {
         .build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null, temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(1);
     assertDeleted(entity);
@@ -179,7 +180,7 @@ public class OpenshiftUndeployServiceTest {
         .build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null, temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(3);
     assertDeleted(entity);
@@ -213,7 +214,7 @@ public class OpenshiftUndeployServiceTest {
         .endSpec().build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null, temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(3);
     assertDeleted(entity);
@@ -248,7 +249,7 @@ public class OpenshiftUndeployServiceTest {
         .endSpec().build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null, temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(1);
     assertDeleted(entity);
@@ -283,7 +284,7 @@ public class OpenshiftUndeployServiceTest {
         .endSpec().build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null, temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(2);
     assertDeleted(entity);

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -36,7 +36,6 @@
 
     <version.asciidoctor-maven-plugin>1.5.5</version.asciidoctor-maven-plugin>
     <version.asciidoctorj>1.5.4</version.asciidoctorj>
-    <version.assertj-core>3.18.0</version.assertj-core>
     <version.bouncycastle.bcpkix>1.61</version.bouncycastle.bcpkix>
     <version.commons-codec>1.15</version.commons-codec>
     <version.commons-compress>1.19</version.commons-compress>

--- a/kubernetes-maven-plugin/plugin/pom.xml
+++ b/kubernetes-maven-plugin/plugin/pom.xml
@@ -166,6 +166,10 @@
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/DebugMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/DebugMojo.java
@@ -15,7 +15,6 @@ package org.eclipse.jkube.maven.plugin.mojo.develop;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.eclipse.jkube.maven.plugin.mojo.build.ApplyMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -31,21 +30,17 @@ import java.util.Set;
 @Mojo(name = "debug", requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.PACKAGE)
 public class DebugMojo extends ApplyMojo {
 
-    @Parameter(property = "jkube.debug.port", defaultValue = "5005")
-    private String localDebugPort;
+  @Parameter(property = "jkube.debug.port", defaultValue = "5005")
+  private String localDebugPort;
 
-    @Parameter(property = "jkube.debug.suspend", defaultValue = "false")
-    private boolean debugSuspend;
+  @Parameter(property = "jkube.debug.suspend", defaultValue = "false")
+  private boolean debugSuspend;
 
-    @Override
-    protected void applyEntities(KubernetesClient kubernetes, String namespace, String fileName, Set<HasMetadata> entities) throws Exception {
-        try {
-            jkubeServiceHub.getDebugService().debug(namespace, fileName, entities, localDebugPort, debugSuspend, createLogger("[[Y]][W][[Y]] [[s]]"));
-        } catch (Exception exp) {
-            throw new MojoExecutionException(exp.getMessage());
-        }
-    }
+  @Override
+  protected void applyEntities(KubernetesClient kubernetes, String fileName, Set<HasMetadata> entities) {
+    jkubeServiceHub.getDebugService().debug(
+        applyService.getNamespace(), fileName, entities, localDebugPort, debugSuspend, createLogger("[[Y]][W][[Y]] [[s]]"));
+  }
 
 }
-
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/LogMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/LogMojo.java
@@ -26,32 +26,39 @@ import java.util.Set;
 
 /**
  * This goal tails the log of the most recent pod for the app that was deployed via <code>k8s:deploy</code>
- * <p>
- * To terminate the log hit
+ * <p> To terminate the log hit
  * <code>Ctrl+C</code>
  */
 @Mojo(name = "log", requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.VALIDATE)
 public class LogMojo extends ApplyMojo {
 
-    @Parameter(property = "jkube.log.follow", defaultValue = "true")
-    private boolean followLog;
-    @Parameter(property = "jkube.log.container")
-    private String logContainerName;
-    @Parameter(property = "jkube.log.pod")
-    private String podName;
+  @Parameter(property = "jkube.log.follow", defaultValue = "true")
+  private boolean followLog;
+  @Parameter(property = "jkube.log.container")
+  private String logContainerName;
+  @Parameter(property = "jkube.log.pod")
+  private String podName;
 
-    @Override
-    protected void applyEntities(final KubernetesClient kubernetes, final String namespace, String fileName, final Set<HasMetadata> entities) throws Exception {
-        new PodLogService(podLogServiceContextBuilder().build())
-            .tailAppPodsLogs(kubernetes, namespace, entities, false, null, followLog, null, true);
-    }
+  @Override
+  protected void applyEntities(final KubernetesClient kubernetes, String fileName, final Set<HasMetadata> entities) {
+    new PodLogService(podLogServiceContextBuilder().build()).tailAppPodsLogs(
+        kubernetes,
+        applyService.getNamespace(),
+        entities,
+        false,
+        null,
+        followLog,
+        null,
+        true
+    );
+  }
 
-    protected PodLogService.PodLogServiceContext.PodLogServiceContextBuilder podLogServiceContextBuilder() {
-        return PodLogService.PodLogServiceContext.builder()
-                .log(log)
-                .logContainerName(logContainerName)
-                .podName(podName)
-                .newPodLog(createLogger("[[C]][NEW][[C]] "))
-                .oldPodLog(createLogger("[[R]][OLD][[R]] "));
-    }
+  protected PodLogService.PodLogServiceContext.PodLogServiceContextBuilder podLogServiceContextBuilder() {
+    return PodLogService.PodLogServiceContext.builder()
+        .log(log)
+        .logContainerName(logContainerName)
+        .podName(podName)
+        .newPodLog(createLogger("[[C]][NEW][[C]] "))
+        .oldPodLog(createLogger("[[R]][OLD][[R]] "));
+  }
 }

--- a/kubernetes-maven-plugin/pom.xml
+++ b/kubernetes-maven-plugin/pom.xml
@@ -50,6 +50,12 @@
           <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${version.assertj-core}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
           <groupId>org.jmockit</groupId>
           <artifactId>jmockit</artifactId>
           <version>${version.jmockit}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
     <version.jacoco>0.8.6</version.jacoco>
     <version.jmockit>1.49</version.jmockit>
     <version.junit>4.13.1</version.junit>
+    <version.assertj-core>3.18.0</version.assertj-core>
     <version.lombok-maven-plugin>1.18.12.0</version.lombok-maven-plugin>
     <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
     <version.maven-enforcer-plugin>1.4.1</version.maven-enforcer-plugin>

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -106,7 +106,7 @@ function emailTemplate() {
   lines+="We are pleased to announce Eclipse JKube $1 was just released! You can find the release at Maven Central [1].\n\n"
   lines+="Eclipse JKube is a collection of plugins and libraries that are used for building container images using Docker, JIB or S2I build strategies.\nEclipse JKube generates and deploys Kubernetes/OpenShift manifests at compile time too.\n\n"
   lines+="JKube is the successor to the deprecated Fabric8 Maven Plugin, please check our migration guide [2] if you come from FMP.\n\n"
-  lines+="Using this release:\n\n<plugin>\n  <groupId>org.eclipse.jkube</groupId>\n  <artifactId>kubernetes-maven-plugin</artifactId>\n  <version>$1</version\n</plugin>\n\n(Check Maven Central [1] for the rest of artifacts)\n\n"
+  lines+="Using this release:\n\n<plugin>\n  <groupId>org.eclipse.jkube</groupId>\n  <artifactId>kubernetes-maven-plugin</artifactId>\n  <version>$1</version>\n</plugin>\n\n(Check Maven Central [1] for the rest of artifacts)\n\n"
   lines+="These are the features and fixes included in $1:\n"
   lines+="$numberedChangelog\n\n"
   lines+="Your feedback is highly appreciated, you can provide it replying to the mailing list or through the usual channels. $githubLinkId $gitterLinkId\n\n"


### PR DESCRIPTION
## Description
feat: Apply and Undeploy service use configured Namespace

As opposed to using a property that was read from Maven and passed on
as a System property.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] ~~I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly~~
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->