### PR TITLE
Update Kubernetes Client from 5.0.0 to 5.1.1 #592

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Usage:
 * Fix #515: Properties now get resolved in CustomResource fragments
 * Fix #586: Apply and Undeploy service use configured namespace
 * Fix #584: Improved Vert.x 4 support
+* Fix #592: Upgrade kubernetes client from 5.0.0 to 5.1.1
 
 ### 1.1.1 (2021-02-23)
 * Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/Base64Util.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/Base64Util.java
@@ -14,8 +14,7 @@
 package org.eclipse.jkube.kit.common.util;
 
 import java.nio.charset.StandardCharsets;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 /**
  * For java 7 or lower version, java.util doesn't provide a base64 encode/decode way
@@ -23,7 +22,7 @@ import javax.xml.bind.DatatypeConverter;
 public class Base64Util {
 
     public static String encodeToString(byte[] bytes) {
-        return DatatypeConverter.printBase64Binary(bytes);
+        return new String(Base64.getEncoder().encode(bytes));
     }
 
     public static byte[] encode(byte[] bytes) {
@@ -39,7 +38,7 @@ public class Base64Util {
     }
 
     public static byte[] decode(String raw) {
-        return DatatypeConverter.parseBase64Binary(raw);
+        return Base64.getDecoder().decode(raw);
     }
 
     public static byte[] decode(byte[] bytes) {

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -53,7 +53,7 @@
     <version.json-path-assert>2.2.0</version.json-path-assert>
     <version.jsr305>3.0.2</version.jsr305>
     <version.JUnitParams>1.1.1</version.JUnitParams>
-    <version.kubernetes-client>5.0.0</version.kubernetes-client>
+    <version.kubernetes-client>5.1.1</version.kubernetes-client>
     <version.lombok>1.18.12</version.lombok>
     <version.maven-archiver>3.5.0</version.maven-archiver>
     <version.maven-core>3.6.3</version.maven-core>

--- a/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmService.java
+++ b/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmService.java
@@ -167,7 +167,9 @@ public class HelmService {
 
   private static String interpolateTemplateWithHelmParameter(String template, HelmParameter parameter) {
     String name = parameter.getParameter().getName();
-    String from = "${" + name + "}";
+    final String from = "$" + name;
+    final String braceEnclosedFrom = "${" + name + "}";
+    final String quotedBraceEnclosedFrom = "\"" + braceEnclosedFrom + "\"";
     String answer = template;
     String defaultExpression = "";
     String required = "";
@@ -178,10 +180,11 @@ public class HelmService {
     if (Boolean.TRUE.equals(parameter.getParameter().getRequired())) {
       required = "required \"A valid .Values." + parameter.getHelmName() + " entry required!\" ";
     }
-    String to = "{{ " + required + ".Values." + parameter.getHelmName() + defaultExpression + " }}";
-    answer = answer.replace(from,to);
-    from = "$" + name;
-    return answer.replace(from, to);
+    final String to = "{{ " + required + ".Values." + parameter.getHelmName() + defaultExpression + " }}";
+    answer = answer.replace(quotedBraceEnclosedFrom, to);
+    answer = answer.replace(braceEnclosedFrom, to);
+    answer = answer.replace(from, to);
+    return answer;
   }
 
   private static void interpolateTemplateParameterExpressionsWithHelmExpressions(File file, List<HelmParameter> helmParameters) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.citrus-core>2.6.2</version.citrus-core>
     <version.hamcrest-library>1.3</version.hamcrest-library>
-    <version.jackson>2.10.0</version.jackson>
+    <version.jackson>2.11.2</version.jackson>
     <version.jacoco>0.8.6</version.jacoco>
     <version.jmockit>1.49</version.jmockit>
     <version.junit>4.13.1</version.junit>


### PR DESCRIPTION
and align (transitive) dependencies


## Description

upgrading to latest Kubernetes Client 5.1.1 #592

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->

First draft. Currently failing:

```
com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException: while parsing a block mapping
 in 'reader', line 6, column 5:
        app: test
        ^
expected <block end>, but found '<scalar>'
 in 'reader', line 9, column 34:
        helm-variable: "(( required "A valid .Values.global_template_ ... 
                                     ^

 at [Source: (StringReader); line: 9, column: 34]
	at com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException.from(MarkedYAMLException.java:27)
	at com.fasterxml.jackson.dataformat.yaml.YAMLParser.nextToken(YAMLParser.java:359)
	at com.fasterxml.jackson.core.JsonParser.nextFieldName(JsonParser.java:868)
	at com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer$Vanilla.mapObject(UntypedObjectDeserializer.java:894)
	at com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer$Vanilla.deserialize(UntypedObjectDeserializer.java:652)
	at com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer$Vanilla.mapObject(UntypedObjectDeserializer.java:869)
	at com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer$Vanilla.deserialize(UntypedObjectDeserializer.java:652)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:540)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:377)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:29)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4524)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3466)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3434)
	at org.eclipse.jkube.kit.resource.helm.HelmServiceIT.assertYamls(HelmServiceIT.java:87)
	at org.eclipse.jkube.kit.resource.helm.HelmServiceIT.generateHelmChartsTest(HelmServiceIT.java:76)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:542)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:770)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:464)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:210)
Caused by: while parsing a block mapping
 in 'reader', line 6, column 5:
        app: test
        ^
expected <block end>, but found '<scalar>'
 in 'reader', line 9, column 34:
        helm-variable: "(( required "A valid .Values.global_template_ ... 
                                     ^

	at org.yaml.snakeyaml.parser.ParserImpl$ParseBlockMappingKey.produce(ParserImpl.java:572)
	at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:158)
	at org.yaml.snakeyaml.parser.ParserImpl.getEvent(ParserImpl.java:168)
	at com.fasterxml.jackson.dataformat.yaml.YAMLParser.nextToken(YAMLParser.java:355)
	... 39 more
```
