### PR TITLE
Debugging with suspend mode doesn't prevent Kubernetes cluster to restart the pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Usage:
 * Fix #586: Apply and Undeploy service use configured namespace
 * Fix #584: Improved Vert.x 4 support
 * Fix #592: Upgrade kubernetes client from 5.0.0 to 5.1.1
+* Fix #594: Debug with suspend mode removes Liveness Probe
 
 ### 1.1.1 (2021-02-23)
 * Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/DebugService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/DebugService.java
@@ -297,6 +297,10 @@ public class DebugService {
                 log.info("Readiness probe will be disabled on " + KubernetesHelper.getKind(entity) + " " + getName(entity) + " to allow attaching a remote debugger during suspension");
                 container.setReadinessProbe(null);
             }
+            if (container.getLivenessProbe() != null) {
+                log.info("Liveness probe will be disabled on " + KubernetesHelper.getKind(entity) + " " + getName(entity) + " to allow attaching a remote debugger during suspension");
+                container.setLivenessProbe(null);
+            }
             return true;
         } else {
             if (KubernetesHelper.removeEnvVar(env, DebugConstants.ENV_VAR_JAVA_DEBUG_SESSION)) {


### PR DESCRIPTION
In debug mode with suspend mode enabled (`-Djkube.debug.suspend`), the Kubernetes cluster restarts the pod if the remote debug session is not started soon enough, or the application startup debug process takes longer than the livenessProbe periods.

Documentation states that when [Debugging with suspension](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#_debugging_with_suspension):

>The jkube.debug.suspend flag will disable readiness probes in the Kubernetes deployment in order to start port-forwarding during the early phases of application startup

JKube correctly disables the readiness probes, but not the liveness probe. This means that if the configured liveness probe depends on the application running and we're on the middle of a debug session, maybe the liveness probe won't pass and Kubernetes will restart the Pod.

It makes sense, that when using suspension, both liveness and readiness probes are disabled.

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift


Fixes #594