### PR TITLE
fix: Helm linter no longer fails with generated charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Usage:
 * Fix #584: Improved Vert.x 4 support
 * Fix #592: Upgrade kubernetes client from 5.0.0 to 5.1.1
 * Fix #594: Debug with suspend mode removes Liveness Probe
+* Fix #591: Helm linter no longer fails with generated charts
 
 ### 1.1.1 (2021-02-23)
 * Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag

--- a/jkube-kit/resource/helm/pom.xml
+++ b/jkube-kit/resource/helm/pom.xml
@@ -40,8 +40,8 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jmockit</groupId>

--- a/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/Chart.java
+++ b/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/Chart.java
@@ -29,6 +29,8 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Chart {
   @JsonProperty
+  private String apiVersion;
+  @JsonProperty
   private String name;
   @JsonProperty
   private String home;
@@ -54,6 +56,14 @@ public class Chart {
       ", home='" + home + '\'' +
       ", version='" + version + '\'' +
       '}';
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
   }
 
   public String getName() {

--- a/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmService.java
+++ b/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmService.java
@@ -42,6 +42,7 @@ import static org.eclipse.jkube.kit.common.util.TemplateUtil.escapeYamlTemplate;
 public class HelmService {
 
   private static final String YAML_EXTENSION = ".yaml";
+  private static final String CHART_API_VERSION = "v1";
   private static final String CHART_FILENAME = "Chart" + YAML_EXTENSION;
   private static final String VALUES_FILENAME = "values" + YAML_EXTENSION;
 
@@ -145,6 +146,7 @@ public class HelmService {
 
   static void createChartYaml(HelmConfig helmConfig, File outputDir) throws IOException {
     final Chart chart = new Chart();
+    chart.setApiVersion(CHART_API_VERSION);
     chart.setName(helmConfig.getChart());
     chart.setVersion(helmConfig.getVersion());
     chart.setDescription(helmConfig.getDescription());

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/ChartTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/ChartTest.java
@@ -18,9 +18,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ChartTest {
 
@@ -48,9 +46,10 @@ public class ChartTest {
     // When
     final Chart result = objectMapper.readValue(serializedMaintainer, Chart.class);
     // Then
-    assertThat(result.getName(), is("chart"));
-    assertThat(result.getHome(), is("e.t."));
-    assertThat(result.getVersion(), is("1337"));
-    assertThat(result.getSources(), contains("source"));
+    assertThat(result)
+        .hasFieldOrPropertyWithValue("name", "chart")
+        .hasFieldOrPropertyWithValue("home", "e.t.")
+        .hasFieldOrPropertyWithValue("version", "1337")
+        .extracting("sources").asList().containsExactly("source");
   }
 }

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmConfigTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmConfigTest.java
@@ -17,9 +17,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public class HelmConfigTest {
@@ -29,7 +27,7 @@ public class HelmConfigTest {
     // When
     final List<HelmConfig.HelmType> result = HelmConfig.HelmType.parseString(null);
     // Then
-    assertThat(result.isEmpty(), is(true));
+    assertThat(result).isEmpty();
   }
 
   @Test
@@ -37,7 +35,7 @@ public class HelmConfigTest {
     // When
     final List<HelmConfig.HelmType> result = HelmConfig.HelmType.parseString(" ");
     // Then
-    assertThat(result.isEmpty(), is(true));
+    assertThat(result).isEmpty();
   }
 
   @Test
@@ -45,7 +43,7 @@ public class HelmConfigTest {
     // When
     final List<HelmConfig.HelmType> result = HelmConfig.HelmType.parseString(",,  ,   ,, ");
     // Then
-    assertThat(result.isEmpty(), is(true));
+    assertThat(result).isEmpty();
   }
 
   @Test
@@ -53,7 +51,8 @@ public class HelmConfigTest {
     // When
     final List<HelmConfig.HelmType> result = HelmConfig.HelmType.parseString("kuBerNetes");
     // Then
-    assertThat(result, hasItem(HelmConfig.HelmType.KUBERNETES));
+
+    assertThat(result).containsOnly(HelmConfig.HelmType.KUBERNETES);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceIT.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceIT.java
@@ -32,9 +32,7 @@ import io.fabric8.openshift.api.model.Template;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HelmServiceIT {
 
@@ -62,19 +60,19 @@ public class HelmServiceIT {
     // When
     HelmService.generateHelmCharts(logger, helmConfig);
     // Then
-    assertThat(new File("target/helm-it/kubernetes/Chart.yaml").exists(), is(true));
-    assertThat(new File("target/helm-it/kubernetes/values.yaml").exists(), is(true));
-    assertThat(new File("target/helm-it/kubernetes/additional-file.txt").exists(), is(true));
-    assertThat(new File("target/helm-it/kubernetes/templates/kubernetes.yaml").exists(), is(true));
-    assertThat(new File("target/helm-it/openshift/Chart.yaml").exists(), is(true));
-    assertThat(new File("target/helm-it/openshift/values.yaml").exists(), is(true));
-    assertThat(new File("target/helm-it/openshift/additional-file.txt").exists(), is(true));
-    assertThat(new File("target/helm-it/openshift/templates/test-pod.yaml").exists(), is(true));
-    assertThat(new File("target/helm-it/openshift/templates/openshift.yaml").exists(), is(true));
-    assertThat(new File("target/helm-it/ITChart-1337-helm.tar").exists(), is(true));
-    assertThat(new File("target/helm-it/ITChart-1337-helmshift.tar").exists(), is(true));
+    assertThat(new File("target/helm-it/kubernetes/Chart.yaml")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/kubernetes/values.yaml")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/kubernetes/additional-file.txt")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/kubernetes/templates/kubernetes.yaml")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/openshift/Chart.yaml")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/openshift/values.yaml")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/openshift/additional-file.txt")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/openshift/templates/test-pod.yaml")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/openshift/templates/openshift.yaml")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/ITChart-1337-helm.tar")).exists().isNotEmpty();
+    assertThat(new File("target/helm-it/ITChart-1337-helmshift.tar")).exists().isNotEmpty();
     assertYamls();
-    assertThat(generatedChartCount.get(), is(2));
+    assertThat(generatedChartCount).hasValue(2);
   }
 
   private static void assertYamls() throws Exception {
@@ -85,7 +83,7 @@ public class HelmServiceIT {
       final Map<String, ?> expectedContent = mapper.readValue(replacePlaceholders(expected), Map.class);
       final Map<String, ?> actualContent =
           mapper.readValue(replacePlaceholders(generatedYamls.resolve(expectations.relativize(expected))), Map.class);
-      assertThat(expectedContent, equalTo(actualContent));
+      assertThat(expectedContent).isEqualTo(actualContent);
     }
   }
 

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceTest.java
@@ -27,8 +27,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HelmServiceTest {
 
@@ -73,8 +72,10 @@ public class HelmServiceTest {
     new Verifications() {{
       Chart chart;
       ResourceUtil.save(withNotNull(), chart = withCapture(), ResourceFileType.yaml);
-      assertThat(chart.getName(), is("Chart Name"));
-      assertThat(chart.getVersion(), is("1337"));
+      assertThat(chart)
+          .hasFieldOrPropertyWithValue("apiVersion", "v1")
+          .hasFieldOrPropertyWithValue("name", "Chart Name")
+          .hasFieldOrPropertyWithValue("version", "1337");
     }};
   }
 }

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/MaintainerTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/MaintainerTest.java
@@ -18,9 +18,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MaintainerTest {
 
@@ -43,8 +41,9 @@ public class MaintainerTest {
     // When
     final Maintainer result = objectMapper.readValue(serializedMaintainer, Maintainer.class);
     // Then
-    assertThat(result.getName(), is("John"));
-    assertThat(result.getEmail(), is("john@example.com"));
-    assertThat(result, equalTo(new Maintainer("John", "john@example.com")));
+    assertThat(result)
+        .hasFieldOrPropertyWithValue("name", "John")
+        .hasFieldOrPropertyWithValue("email", "john@example.com")
+        .isEqualTo(new Maintainer("John", "john@example.com"));
   }
 }

--- a/jkube-kit/resource/helm/src/test/resources/it/expected/kubernetes/Chart.yaml
+++ b/jkube-kit/resource/helm/src/test/resources/it/expected/kubernetes/Chart.yaml
@@ -13,5 +13,6 @@
 #
 
 ---
+apiVersion: v1
 name: ITChart
 version: "1337"

--- a/jkube-kit/resource/helm/src/test/resources/it/expected/openshift/Chart.yaml
+++ b/jkube-kit/resource/helm/src/test/resources/it/expected/openshift/Chart.yaml
@@ -13,5 +13,6 @@
 #
 
 ---
+apiVersion: v1
 name: ITChart
 version: "1337"


### PR DESCRIPTION
## Description
fix #591: Helm linter no longer fails with generated charts

+ updated jkube-kit-resource-helm to use assertj instead of hamcrest

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->