### PR TITLE
fix: Helm tar.gz packaged chart can be deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Usage:
 * Fix #592: Upgrade kubernetes client from 5.0.0 to 5.1.1
 * Fix #594: Debug with suspend mode removes Liveness Probe
 * Fix #591: Helm linter no longer fails with generated charts
+* Fix #587: Helm tar.gz packaged chart can be deployed
 
 ### 1.1.1 (2021-02-23)
 * Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag

--- a/jkube-kit/common-test/pom.xml
+++ b/jkube-kit/common-test/pom.xml
@@ -30,6 +30,16 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
       <scope>provided</scope>

--- a/jkube-kit/common-test/src/main/java/org/eclipse/jkube/kit/common/assertj/ArchiveAssertions.java
+++ b/jkube-kit/common-test/src/main/java/org/eclipse/jkube/kit/common/assertj/ArchiveAssertions.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.assertj;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.assertj.core.api.AbstractFileAssert;
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.error.ShouldBeEmpty;
+import org.assertj.core.internal.Failures;
+
+import static org.assertj.core.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
+
+public class ArchiveAssertions extends AbstractFileAssert<ArchiveAssertions> {
+
+  private final Failures failures = Failures.instance();
+
+  private ArchiveAssertions(File actual) {
+    super(actual, ArchiveAssertions.class);
+  }
+
+  public static ArchiveAssertions assertThat(File archive) {
+    return new ArchiveAssertions(archive);
+  }
+
+  private String detect() throws IOException, CompressorException {
+    try (
+        FileInputStream fis = new FileInputStream(actual);
+        BufferedInputStream bis = new BufferedInputStream(fis)
+    ) {
+      return CompressorStreamFactory.detect(bis);
+    }
+  }
+
+  private void assertCompression(String expected) throws IOException, CompressorException {
+    final String detected = detect();
+    if (expected.equals(detected)) {
+      return;
+    }
+    throw failures.failure(info, shouldBeEqual(detected, expected));
+  }
+
+  public ArchiveAssertions isUncompressed() throws IOException, CompressorException {
+    try {
+      final String detected = detect();
+      throw failures.failure(info, ShouldBeEmpty.shouldBeEmpty(detected));
+    } catch (CompressorException ex) {
+      if (ex.getMessage().equals("No Compressor found for the stream signature.")) {
+        return this;
+      }
+      throw ex;
+    }
+  }
+
+  public ArchiveAssertions isGZip() throws IOException, CompressorException {
+    assertCompression("gz");
+    return this;
+  }
+
+  public ArchiveAssertions isBzip2() throws IOException, CompressorException {
+    assertCompression("bzip2");
+    return this;
+  }
+
+  private TarArchiveInputStream inputStream(BufferedInputStream bis) {
+    try {
+      return new TarArchiveInputStream(new CompressorStreamFactory().createCompressorInputStream(bis));
+    } catch (CompressorException ex) {
+      return new TarArchiveInputStream(bis);
+    }
+  }
+
+  public AbstractListAssert<ListAssert<String>, List<? extends String>, String, ObjectAssert<String>> fileTree()
+      throws IOException {
+    final List<String> archiveFileTree = new ArrayList<>();
+
+    try (
+        FileInputStream fis = new FileInputStream(actual);
+        BufferedInputStream bis = new BufferedInputStream(fis);
+        TarArchiveInputStream tis = inputStream(bis)
+    ) {
+      TarArchiveEntry entry;
+      while ((entry = tis.getNextTarEntry()) != null) {
+        archiveFileTree.add(entry.getName());
+      }
+    }
+    return org.assertj.core.api.Assertions.assertThat(archiveFileTree);
+  }
+}

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiverTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiverTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.archive;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.function.Consumer;
+
+import org.eclipse.jkube.kit.common.assertj.ArchiveAssertions;
+import org.eclipse.jkube.kit.common.util.FileUtil;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class JKubeTarArchiverTest {
+
+  private static final String LONG_FILE_NAME = "0123456789012345678901234567890123456789012345678901234567890123456789"
+      + "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+      + "nested.file.long";
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private File toCompress;
+
+  @Before
+  public void prepareDirectory() throws IOException {
+    toCompress = temporaryFolder.newFolder("toCompress");
+    final File nestedDir = toCompress.toPath().resolve("nested").resolve("directory").toFile();
+    FileUtils.forceMkdir(nestedDir);
+    final File nestedFile = nestedDir.toPath().resolve(LONG_FILE_NAME).toFile();
+    FileUtils.write(nestedFile, "Nested file content", StandardCharsets.UTF_8);
+    final File file = toCompress.toPath().resolve("file.txt").toFile();
+    FileUtils.write(file, "File content", StandardCharsets.UTF_8);
+  }
+
+  @Test
+  public void createTarBallOfDirectory_defaultCompression_createsTar() throws Exception {
+    // Given
+    final File outputFile = temporaryFolder.newFile("target.noExtension");
+    // When
+    final File result = JKubeTarArchiver.createTarBallOfDirectory(outputFile, toCompress, ArchiveCompression.none);
+    // Then
+    ArchiveAssertions.assertThat(result)
+        .isSameAs(outputFile)
+        .isNotEmpty()
+        .isUncompressed()
+        .fileTree()
+        .containsExactlyInAnyOrder(
+            "file.txt",
+            "nested/",
+            "nested/directory/",
+            "nested/directory/" + LONG_FILE_NAME);
+  }
+
+  @Test
+  public void createTarBallOfDirectory_gzipCompression_createsTar() throws Exception {
+    // Given
+    final File outputFile = temporaryFolder.newFile("target.tar.gzip");
+    // When
+    final File result = JKubeTarArchiver.createTarBallOfDirectory(outputFile, toCompress, ArchiveCompression.gzip);
+    // Then
+    ArchiveAssertions.assertThat(result)
+        .isSameAs(outputFile)
+        .isNotEmpty()
+        .isGZip()
+        .fileTree()
+        .containsExactlyInAnyOrder(
+            "file.txt",
+            "nested/",
+            "nested/directory/",
+            "nested/directory/" + LONG_FILE_NAME);
+  }
+
+  @Test
+  public void createTarBallOfDirectory_bzip2Compression_createsTar() throws Exception {
+    // Given
+    final File outputFile = temporaryFolder.newFile("target.tar.bz2");
+    // When
+    final File result = JKubeTarArchiver.createTarBallOfDirectory(outputFile, toCompress, ArchiveCompression.bzip2);
+    // Then
+    ArchiveAssertions.assertThat(result)
+        .isSameAs(outputFile)
+        .isNotEmpty()
+        .isBzip2()
+        .fileTree()
+        .containsExactlyInAnyOrder(
+            "file.txt",
+            "nested/",
+            "nested/directory/",
+            "nested/directory/" + LONG_FILE_NAME);
+  }
+
+  @Test
+  public void createTarBallOfDirectory_defaultCompressionWithEntryCustomizer_createsCustomizedTar() throws Exception {
+    // Given
+    final File outputFile = temporaryFolder.newFile("target.tar");
+    final Consumer<TarArchiveEntry> prependDirectory = tae ->  tae.setName("directory/" + tae.getName());
+    // When
+    final File result = JKubeTarArchiver.createTarBall(outputFile, toCompress,
+        FileUtil.listFilesAndDirsRecursivelyInDirectory(toCompress), Collections.emptyMap(), ArchiveCompression.none,
+        null, prependDirectory);
+    // Then
+    ArchiveAssertions.assertThat(result)
+        .isSameAs(outputFile)
+        .isNotEmpty()
+        .isUncompressed()
+        .fileTree()
+        .containsExactlyInAnyOrder(
+            "directory/file.txt",
+            "directory/nested/",
+            "directory/nested/directory/",
+            "directory/nested/directory/" + LONG_FILE_NAME);
+  }
+
+  @Test
+  public void createTarBallOfDirectory_defaultCompressionWithTarCustomizer_createsCustomizedTar() throws Exception {
+    // Given
+    final File outputFile = temporaryFolder.newFile("target.tar");
+    final Consumer<TarArchiveOutputStream> truncateFilenames = tae ->  tae.setLongFileMode(TarArchiveOutputStream.LONGFILE_TRUNCATE);
+    // When
+    final File result = JKubeTarArchiver.createTarBall(outputFile, toCompress,
+        FileUtil.listFilesAndDirsRecursivelyInDirectory(toCompress), Collections.emptyMap(), ArchiveCompression.none,
+        truncateFilenames, null);
+    // Then
+    ArchiveAssertions.assertThat(result)
+        .isSameAs(outputFile)
+        .isNotEmpty()
+        .isUncompressed()
+        .fileTree()
+        .containsExactlyInAnyOrder(
+            "file.txt",
+            "nested/",
+            "nested/directory/",
+            "nested/directory/01234567890123456789012345678901234567890123456789012345678901234567890123456789012");
+  }
+
+}

--- a/jkube-kit/resource/helm/pom.xml
+++ b/jkube-kit/resource/helm/pom.xml
@@ -36,6 +36,10 @@
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.jkube</groupId>
+      <artifactId>jkube-kit-common-test</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceIT.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceIT.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.openshift.api.model.Template;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
+import org.eclipse.jkube.kit.common.assertj.ArchiveAssertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -69,8 +70,21 @@ public class HelmServiceIT {
     assertThat(new File("target/helm-it/openshift/additional-file.txt")).exists().isNotEmpty();
     assertThat(new File("target/helm-it/openshift/templates/test-pod.yaml")).exists().isNotEmpty();
     assertThat(new File("target/helm-it/openshift/templates/openshift.yaml")).exists().isNotEmpty();
-    assertThat(new File("target/helm-it/ITChart-1337-helm.tar")).exists().isNotEmpty();
-    assertThat(new File("target/helm-it/ITChart-1337-helmshift.tar")).exists().isNotEmpty();
+    ArchiveAssertions.assertThat(new File("target/helm-it/ITChart-1337-helm.tar"))
+        .exists().isNotEmpty().isUncompressed().fileTree().containsExactlyInAnyOrder(
+            "ITChart/additional-file.txt",
+            "ITChart/templates/",
+            "ITChart/templates/kubernetes.yaml",
+            "ITChart/Chart.yaml",
+            "ITChart/values.yaml");
+    ArchiveAssertions.assertThat(new File("target/helm-it/ITChart-1337-helmshift.tar"))
+        .exists().isNotEmpty().isUncompressed().fileTree().containsExactlyInAnyOrder(
+            "ITChart/additional-file.txt",
+            "ITChart/templates/",
+            "ITChart/templates/openshift.yaml",
+            "ITChart/templates/test-pod.yaml",
+            "ITChart/Chart.yaml",
+            "ITChart/values.yaml");
     assertYamls();
     assertThat(generatedChartCount).hasValue(2);
   }


### PR DESCRIPTION
## Description
fix #587: Helm tar.gz packaged chart can be deployed

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->