### PR TITLE
Replace usages of deprecated StrSubstitutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Usage:
 * Fix #594: Debug with suspend mode removes Liveness Probe
 * Fix #591: Helm linter no longer fails with generated charts
 * Fix #587: Helm tar.gz packaged chart can be deployed
+* Fix #571: Replace usages of deprecated `org.apache.commons.text.StrSubstitutor`
 
 ### 1.1.1 (2021-02-23)
 * Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/WaitService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/WaitService.java
@@ -25,7 +25,6 @@ import org.eclipse.jkube.kit.build.service.docker.access.DockerAccessException;
 import org.eclipse.jkube.kit.build.service.docker.access.log.DefaultLogCallback;
 import org.eclipse.jkube.kit.build.service.docker.access.log.LogDispatcher;
 import org.eclipse.jkube.kit.build.service.docker.access.log.LogOutputSpec;
-import org.eclipse.jkube.kit.config.image.WaitConfiguration;
 import org.eclipse.jkube.kit.build.service.docker.wait.ExitCodeChecker;
 import org.eclipse.jkube.kit.build.service.docker.wait.HealthCheckChecker;
 import org.eclipse.jkube.kit.build.service.docker.wait.HttpPingChecker;
@@ -36,8 +35,10 @@ import org.eclipse.jkube.kit.build.service.docker.wait.WaitChecker;
 import org.eclipse.jkube.kit.build.service.docker.wait.WaitTimeoutException;
 import org.eclipse.jkube.kit.build.service.docker.wait.WaitUtil;
 import org.eclipse.jkube.kit.common.KitLogger;
-import org.apache.commons.text.StrSubstitutor;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.WaitConfiguration;
+
+import org.apache.commons.text.StringSubstitutor;
 
 /**
  * @author roland
@@ -147,7 +148,7 @@ public class WaitService {
     private WaitChecker getUrlWaitChecker(String imageConfigDesc,
                                           Properties projectProperties,
                                           WaitConfiguration wait) {
-        String waitUrl = StrSubstitutor.replace(wait.getUrl(), projectProperties);
+        String waitUrl = StringSubstitutor.replace(wait.getUrl(), projectProperties);
         WaitConfiguration.HttpConfiguration httpConfig = wait.getHttp();
         HttpPingChecker checker;
         if (httpConfig != null) {

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/ContainerCreateConfig.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/ContainerCreateConfig.java
@@ -13,14 +13,6 @@
  */
 package org.eclipse.jkube.kit.build.service.docker.access;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-
-import org.eclipse.jkube.kit.common.JsonFactory;
-import org.eclipse.jkube.kit.common.util.EnvUtil;
-import org.eclipse.jkube.kit.config.image.build.Arguments;
-import org.apache.commons.text.StrSubstitutor;
-
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
@@ -29,6 +21,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+
+import org.eclipse.jkube.kit.common.JsonFactory;
+import org.eclipse.jkube.kit.common.util.EnvUtil;
+import org.eclipse.jkube.kit.config.image.build.Arguments;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.apache.commons.text.StringSubstitutor;
 
 
 public class ContainerCreateConfig {
@@ -87,7 +87,7 @@ public class ContainerCreateConfig {
                      */
                     value = value.substring(1, value.length());
                 }
-                envProps.put(entry.getKey(), StrSubstitutor.replace(value, mavenProps));
+                envProps.put(entry.getKey(), StringSubstitutor.replace(value, mavenProps));
             }
         }
         if (envPropsFile != null) {


### PR DESCRIPTION
## Description
Replace usages of deprecated `org.apache.commons.text.StrSubstitutor` with `org.apache.commons.text.StringSubstitutor`.
Fixes #571 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift