### PR TITLE
feat: Quarkus port is inferred from application.properties/yaml (cons…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,12 @@ Usage:
 * Fix #586: Apply and Undeploy service use configured namespace
 * Fix #584: Improved Vert.x 4 support
 * Fix #592: Upgrade kubernetes client from 5.0.0 to 5.1.1
-* Update Fabric8 Kubernetes Client from v5.1.1 to v5.2.1
+* Fix #615: Update Fabric8 Kubernetes Client from v5.1.1 to v5.2.1
 * Fix #594: Debug with suspend mode removes Liveness Probe
 * Fix #591: Helm linter no longer fails with generated charts
 * Fix #587: Helm tar.gz packaged chart can be deployed
 * Fix #571: Replace usages of deprecated `org.apache.commons.text.StrSubstitutor`
+* Fix #450: Quarkus port is inferred from application.properties/yaml (considers profile too)
 
 ### 1.1.1 (2021-02-23)
 * Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.quarkus;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jkube.kit.common.JavaProject;
+
+import java.net.URLClassLoader;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+import static org.eclipse.jkube.kit.common.util.PropertiesUtil.getPropertiesFromResource;
+import static org.eclipse.jkube.kit.common.util.YamlUtil.getPropertiesFromYamlResource;
+
+public class QuarkusUtils {
+
+  private static final String QUARKUS_HTTP_PORT = "quarkus.http.port";
+
+  private QuarkusUtils() {}
+
+  public static String extractPort(JavaProject javaProject, Properties properties, String defaultValue) {
+    final Optional<String> activeProfile = getActiveProfile(javaProject);
+    if (activeProfile.isPresent()) {
+      final String profilePort = properties.getProperty(String.format("%%%s.%s", activeProfile.get(), QUARKUS_HTTP_PORT));
+      if (StringUtils.isNotBlank(profilePort)) {
+        return profilePort;
+      }
+    }
+    return properties.getProperty(QUARKUS_HTTP_PORT, defaultValue);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static Properties getQuarkusConfiguration(URLClassLoader urlClassLoader) {
+    final Supplier<Properties>[] sources = new Supplier[]{
+        () -> getPropertiesFromResource(urlClassLoader.findResource("application.properties")),
+        () -> getPropertiesFromYamlResource(urlClassLoader.findResource("application.yml"))
+    };
+    for (Supplier<Properties> source : sources) {
+      final Properties props = source.get();
+      if (!props.isEmpty()) {
+        return props;
+      }
+    }
+    return new Properties();
+  }
+
+  private static Optional<String> getActiveProfile(JavaProject project) {
+    return Optional.ofNullable(project)
+        .map(JavaProject::getProperties)
+        .map(properties -> properties.get("quarkus.profile"))
+        .map(Object::toString);
+  }
+}

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusGenerator.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusGenerator.java
@@ -37,6 +37,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
+import static org.eclipse.jkube.kit.common.util.JKubeProjectUtil.getClassLoader;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.extractPort;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusConfiguration;
+
 public class QuarkusGenerator extends JavaExecGenerator {
 
   public QuarkusGenerator(GeneratorContext context) {
@@ -63,13 +67,17 @@ public class QuarkusGenerator extends JavaExecGenerator {
 
   @Override
   protected List<String> extractPorts() {
-    // TODO: Check application.properties for a port
-    if (isNativeImage()) {
-      return new ArrayList<>(Collections.singletonList(
-          getConfig(JavaExecGenerator.Config.WEB_PORT)
-      ));
+    final List<String> ports = new ArrayList<>();
+    final String quarkusPort = extractPort(
+        getProject(),
+        getQuarkusConfiguration(getClassLoader(getProject())),
+        null);
+    addPortIfValid(ports, getConfig(JavaExecGenerator.Config.WEB_PORT,quarkusPort));
+    if (!isNativeImage()) {
+      addPortIfValid(ports, getConfig(JavaExecGenerator.Config.JOLOKIA_PORT));
+      addPortIfValid(ports, getConfig(JavaExecGenerator.Config.PROMETHEUS_PORT));
     }
-    return super.extractPorts();
+    return ports;
   }
 
   @Override

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/QuarkusUtilsTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/QuarkusUtilsTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.quarkus;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Properties;
+
+import org.eclipse.jkube.kit.common.JavaProject;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.extractPort;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusConfiguration;
+
+public class QuarkusUtilsTest {
+
+  private JavaProject javaProject;
+
+  @Before
+  public void setUp() {
+    javaProject = JavaProject.builder().properties(new Properties()).build();
+  }
+
+  @Test
+  public void extractPort_noProfileAndNoPort_shouldReturnDefault() {
+    // When
+    final String result = extractPort(javaProject, new Properties(), "80");
+    // Then
+    assertThat(result).isEqualTo("80");
+  }
+
+  @Test
+  public void extractPort_noProfileAndPort_shouldReturnPort() {
+    // Given
+    final Properties properties = new Properties();
+    properties.put("quarkus.http.port", "1337");
+    // When
+    final String result = extractPort(javaProject, properties, "80");
+    // Then
+    assertThat(result).isEqualTo("1337");
+  }
+
+  @Test
+  public void extractPort_inactiveProfileAndPort_shouldReturnPort() {
+    // Given
+    final Properties properties = new Properties();
+    properties.put("quarkus.http.port", "1337");
+    properties.put("%dev.quarkus.http.port", "31337");
+    // When
+    final String result = extractPort(javaProject, properties, "80");
+    // Then
+    assertThat(result).isEqualTo("1337");
+  }
+
+  @Test
+  public void extractPort_activeProfileAndPort_shouldReturnProfilePort() {
+    // Given
+    final Properties properties = new Properties();
+    properties.put("quarkus.http.port", "1337");
+    properties.put("%dev.quarkus.http.port", "31337");
+    javaProject.getProperties().put("quarkus.profile", "dev");
+    // When
+    final String result = extractPort(javaProject, properties, "80");
+    // Then
+    assertThat(result).isEqualTo("31337");
+  }
+
+  @Test
+  public void getQuarkusConfiguration_propertiesAndYaml_shouldUseProperties() {
+    // Given
+    final URLClassLoader ucl = URLClassLoader.newInstance(new URL[] {
+        QuarkusUtilsTest.class.getResource("/utils-test/config/yaml/"),
+        QuarkusUtilsTest.class.getResource("/utils-test/config/properties/")
+    });
+    // When
+    final Properties props = getQuarkusConfiguration(ucl);
+    // Then
+    assertThat(props).containsOnly(
+        entry("quarkus.http.port", "1337"),
+        entry("%dev.quarkus.http.port", "8082"));
+  }
+
+  @Test
+  public void getQuarkusConfiguration_yamlOnly_shouldUseYaml() {
+    // Given
+    final URLClassLoader ucl = URLClassLoader.newInstance(new URL[] {
+        QuarkusUtilsTest.class.getResource("/utils-test/config/yaml/")
+    });
+    // When
+    final Properties props = getQuarkusConfiguration(ucl);
+    // Then
+    assertThat(props).containsOnly(
+        entry("quarkus.http.port", "31337"),
+        entry("%dev.quarkus.http.port", "13373"));
+  }
+
+  @Test
+  public void getQuarkusConfiguration_noConfigFiles_shouldReturnEmpty() {
+    // Given
+    final URLClassLoader ucl = URLClassLoader.newInstance(new URL[] {
+        QuarkusUtilsTest.class.getResource("/")
+    });
+    // When
+    final Properties props = getQuarkusConfiguration(ucl);
+    // Then
+    assertThat(props).isEmpty();
+  }
+}

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorExtractPortsTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorExtractPortsTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.quarkus.generator;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.eclipse.jkube.generator.api.GeneratorContext;
+import org.eclipse.jkube.kit.common.JavaProject;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QuarkusGeneratorExtractPortsTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Mocked
+  private GeneratorContext ctx;
+
+  @Mocked
+  private JavaProject project;
+
+  private File target;
+  private List<String> compileClassPathElements;
+  private Properties projectProperties;
+
+  @Before
+  public void setUp() throws IOException {
+    target = temporaryFolder.newFolder("target");
+    compileClassPathElements = new ArrayList<>();
+    projectProperties = new Properties();
+    // @formatter:off
+    new Expectations() {{
+      ctx.getProject(); result = project;
+      project.getCompileClassPathElements(); result = compileClassPathElements;
+      project.getOutputDirectory(); result = target;
+      project.getProperties(); result = projectProperties;
+    }};
+    // @formatter:on
+  }
+
+  @Test
+  public void extractPorts_withDefaults_shouldAddDefaults() {
+    // When
+    final List<String> result = new QuarkusGenerator(ctx).extractPorts();
+    // Then
+    assertThat(result).containsExactly("8080", "8778", "9779");
+  }
+
+  @Test
+  public void extractPorts_withDefaultsInNative_shouldAddDefaultsForNative() {
+    // Given
+    projectProperties.put("jkube.generator.quarkus.nativeImage", "true");
+    // When
+    final List<String> result = new QuarkusGenerator(ctx).extractPorts();
+    // Then
+    assertThat(result).containsExactly("8080");
+  }
+
+  @Test
+  public void extractPorts_withApplicationProperties_shouldAddConfigured() {
+    // Given
+    compileClassPathElements.add(
+        QuarkusGeneratorExtractPortsTest.class.getResource("/generator-extract-ports").getPath());
+    // When
+    final List<String> result = new QuarkusGenerator(ctx).extractPorts();
+    // Then
+    assertThat(result).containsExactly("1337", "8778", "9779");
+  }
+
+  @Test
+  public void extractPorts_withApplicationPropertiesAndProfile_shouldAddConfiguredProfile() {
+    // Given
+    projectProperties.put("quarkus.profile", "dev");
+    compileClassPathElements.add(
+        QuarkusGeneratorExtractPortsTest.class.getResource("/generator-extract-ports").getPath());
+    // When
+    final List<String> result = new QuarkusGenerator(ctx).extractPorts();
+    // Then
+    assertThat(result).containsExactly("31337", "8778", "9779");
+  }
+}

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
@@ -78,6 +78,8 @@ public class QuarkusGeneratorTest {
       project.getBaseDirectory(); result = baseDir; minTimes = 0;
       project.getBuildDirectory(); result = baseDir.getAbsolutePath();
       project.getProperties(); result = projectProps;
+      project.getCompileClassPathElements(); result = Collections.emptyList(); minTimes = 0;
+      project.getOutputDirectory(); result = baseDir;
       ctx.getProject(); result = project;
       ctx.getConfig(); result = config;
       ctx.getStrategy(); result = JKubeBuildStrategy.s2i; minTimes = 0;
@@ -88,7 +90,7 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void testCustomizeReturnsDefaultFromInOpenShift() {
+  public void customize_inOpenShift_shouldReturnS2iFrom() {
     // Given
     in(RuntimeMode.OPENSHIFT);
     // When
@@ -98,7 +100,7 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void testCustomizeReturnsDefaultFromInKubernetes() {
+  public void customize_inKubernetes_shouldReturnDockerFrom() {
     // Given
     in(RuntimeMode.KUBERNETES);
     // When
@@ -108,7 +110,7 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void testCustomizeReturnsDefaultFromWhenNativeInOpenShift() throws IOException {
+  public void customize_inOpenShift_shouldReturnNativeS2iFrom() throws IOException {
     // Given
     in(RuntimeMode.OPENSHIFT);
     setNativeConfig();
@@ -119,18 +121,18 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void testCustomizeReturnsDefaultFromWhenNativeInKubernetes() throws IOException {
+  public void customize_inKubernetes_shouldReturnNativeUbiFrom() throws IOException {
     // Given
     in(RuntimeMode.KUBERNETES);
     setNativeConfig();
     // When
     final List<ImageConfiguration> resultImages = new QuarkusGenerator(ctx).customize(new ArrayList<>(), true);
     // Then
-    assertBuildFrom(resultImages, "registry.access.redhat.com/ubi8/ubi-minimal:8.1");;
+    assertBuildFrom(resultImages, "registry.access.redhat.com/ubi8/ubi-minimal:8.1");
   }
 
   @Test
-  public void testCustomizeReturnsConfiguredFrom () {
+  public void customize_withConfiguredImage_shouldReturnConfigured() {
     config.getConfig().put("quarkus", Collections.singletonMap("from", BASE_JAVA_IMAGE));
     QuarkusGenerator generator = new QuarkusGenerator(ctx);
     List<ImageConfiguration> existingImages = new ArrayList<>();
@@ -141,7 +143,7 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void testCustomizeReturnsConfiguredFromWhenNative () throws IOException {
+  public void customize_withConfiguredNativeImage_shouldReturnConfiguredNative() throws IOException {
     setNativeConfig();
     config.getConfig().put("quarkus", Collections.singletonMap("from", BASE_NATIVE_IMAGE));
 
@@ -154,21 +156,20 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void testCustomizeReturnsPropertiesFrom () {
+  public void customize_withConfiguredInProperties_shouldReturnConfigured() {
     projectProps.put("jkube.generator.quarkus.from", BASE_JAVA_IMAGE);
 
     QuarkusGenerator generator = new QuarkusGenerator(ctx);
-    List<ImageConfiguration> resultImages = null;
     List<ImageConfiguration> existingImages = new ArrayList<>();
 
-    resultImages = generator.customize(existingImages, true);
+    List<ImageConfiguration> resultImages = generator.customize(existingImages, true);
 
     assertBuildFrom(resultImages, BASE_JAVA_IMAGE);
   }
 
 
   @Test
-  public void testCustomizeReturnsPropertiesFromWhenNative () throws IOException {
+  public void customize_withConfiguredNativeInProperties_shouldReturnConfiguredNative() throws IOException {
     setNativeConfig();
     projectProps.put("jkube.generator.quarkus.from", BASE_NATIVE_IMAGE);
 
@@ -181,7 +182,7 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void testAssembly() throws IOException {
+  public void assembly_withDefaults_shouldReturnDefaultAssemblyInImage() {
     // When
     final List<ImageConfiguration> resultImages = new QuarkusGenerator(ctx)
         .customize(new ArrayList<>(), false);
@@ -202,7 +203,7 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void testAssemblyWhenNative() throws IOException {
+  public void assembly_withDefaultsInNative_shouldReturnDefaultNativeAssemblyInImage() throws IOException {
     // Given
     setNativeConfig();
     // When
@@ -225,7 +226,7 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void testIsFatJarShouldBeFalse() {
+  public void isFatJar_withDefaults_shouldBeFalse() {
     // When
     final boolean result = new QuarkusGenerator(ctx).isFatJar();
     // Then

--- a/jkube-kit/jkube-kit-quarkus/src/test/resources/generator-extract-ports/application.properties
+++ b/jkube-kit/jkube-kit-quarkus/src/test/resources/generator-extract-ports/application.properties
@@ -1,0 +1,2 @@
+quarkus.http.port=1337
+%dev.quarkus.http.port=31337

--- a/jkube-kit/jkube-kit-quarkus/src/test/resources/utils-test/config/properties/application.properties
+++ b/jkube-kit/jkube-kit-quarkus/src/test/resources/utils-test/config/properties/application.properties
@@ -1,0 +1,2 @@
+quarkus.http.port=1337
+%dev.quarkus.http.port=8082

--- a/jkube-kit/jkube-kit-quarkus/src/test/resources/utils-test/config/yaml/application.yml
+++ b/jkube-kit/jkube-kit-quarkus/src/test/resources/utils-test/config/yaml/application.yml
@@ -1,0 +1,7 @@
+quarkus:
+  http:
+    port: 31337
+"%dev":
+  quarkus:
+    http:
+      port: 13373

--- a/quickstarts/maven/quarkus/pom.xml
+++ b/quickstarts/maven/quarkus/pom.xml
@@ -89,6 +89,12 @@
   </build>
   <profiles>
     <profile>
+      <id>dev</id>
+      <properties>
+        <quarkus.profile>dev</quarkus.profile>
+      </properties>
+    </profile>
+    <profile>
       <id>native-docker</id>
       <activation>
         <property>

--- a/quickstarts/maven/quarkus/src/main/resources/application.properties
+++ b/quickstarts/maven/quarkus/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+%dev.quarkus.http.port=9080


### PR DESCRIPTION
## Description
feat: Quarkus port is inferred from application.properties/yaml (considers profile too)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->