### PR TITLE
Fix #471: Remove the declaration of thrown runtime exceptions across javadoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Usage:
 * Fix #591: Helm linter no longer fails with generated charts
 * Fix #587: Helm tar.gz packaged chart can be deployed
 * Fix #571: Replace usages of deprecated `org.apache.commons.text.StrSubstitutor`
+* Fix #471: Remove the declaration of thrown runtime exceptions across javadoc
 
 ### 1.1.1 (2021-02-23)
 * Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/PortMapping.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/PortMapping.java
@@ -82,7 +82,6 @@ public class PortMapping {
      *            <code>host_ip:host_port:container_port</code>. If the <code>host-port</code> is non-numeric it is
      *            assumed to be a variable (which later might be filled in with the dynamically created port).
      * @param projProperties project properties
-     * @throws IllegalArgumentException if the format doesn't fit
      */
     public PortMapping(List<String> portMappings, Properties projProperties) {
         this.projProperties = projProperties;

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/ImageConfigResolver.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/ImageConfigResolver.java
@@ -66,7 +66,6 @@ public class ImageConfigResolver {
      * @param unresolvedConfig the configuration to resolve
      * @param project project used for resolving
      * @return list of resolved image configurations
-     * @throws IllegalArgumentException if no type is given when an external reference configuration is provided
      * or when the type is not known (i.e. no handler is registered for this type).
      */
     public List<ImageConfiguration> resolve(ImageConfiguration unresolvedConfig, JavaProject project) {

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/compose/ComposeUtils.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/compose/ComposeUtils.java
@@ -65,8 +65,6 @@ class ComposeUtils {
      * @param absolutePath absolute path of the Maven project used to resolve non-absolute path resources, may be {@code null} if
      *                {@code pathToResolve} is {@link File#isAbsolute() absolute}
      * @return an absolute {@code File} reference to {@code pathToResolve}; <em>not</em> guaranteed to exist
-     * @throws IllegalArgumentException if {@code pathToResolve} is relative, and {@code project} is {@code null} or
-     *                                  provides a relative project directory
      */
     static File resolveAbsolutely(String pathToResolve, String absolutePath) {
         // avoid an NPE if the Maven project is not needed by DockerPathUtil

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/property/PropertyMode.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/config/handler/property/PropertyMode.java
@@ -33,7 +33,6 @@ public enum PropertyMode {
      *
      * @param name null or a valid name
      * @return PropertyMode
-     * @throws IllegalArgumentException if empty or invalid names
      */
     static PropertyMode parse(String name) {
         if(name == null) {

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/helper/DockerPathUtil.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/helper/DockerPathUtil.java
@@ -40,7 +40,6 @@ public class DockerPathUtil {
      * @param pathToResolve represents a filesystem resource, which may be an absolute path
      * @param baseDir the absolute path used to resolve non-absolute path resources; <em>must</em> be absolute
      * @return an absolute {@code File} reference to {@code pathToResolve}; <em>not</em> guaranteed to exist
-     * @throws IllegalArgumentException if the supplied {@code baseDir} does not represent an absolute path
      */
     public static File resolveAbsolutely(String pathToResolve, String baseDir) {
         // TODO: handle the case where pathToResolve specifies a non-existent path, for example, a base directory equal to "/" and a relative path of "../../foo".

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/helper/VolumeBindingUtil.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/helper/VolumeBindingUtil.java
@@ -155,7 +155,6 @@ public class VolumeBindingUtil {
      *                {@code ~}) present in the {@code bindingString}; <em>must</em> be absolute
      * @param bindingString the volume string from the docker-compose file
      * @return the volume string, with any relative paths resolved as absolute paths
-     * @throws IllegalArgumentException if the supplied {@code baseDir} is not absolute
      */
     public static String resolveRelativeVolumeBinding(File baseDir, String bindingString) {
 
@@ -217,7 +216,6 @@ public class VolumeBindingUtil {
      * @param baseDir the base directory used to resolve relative paths (e.g. beginning with {@code ./}, {@code ../},
      *                {@code ~}) present in the binding string; <em>must</em> be absolute
      * @param volumeConfiguration the volume configuration that may contain volume binding specifications
-     * @throws IllegalArgumentException if the supplied {@code baseDir} is not absolute
      */
     public static void resolveRelativeVolumeBindings(File baseDir, RunVolumeConfiguration volumeConfiguration) {
         List<String> bindings = volumeConfiguration.getBind();

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -237,7 +237,6 @@ public class ImageName {
      * Check whether the given name validates against the Docker rules for names
      *
      * @param image image name to validate
-     * d@throws IllegalArgumentException if the name doesnt validate
      */
     public static void validate(String image) {
         // Validation will be triggered during construction

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/DockerFileBuilder.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/DockerFileBuilder.java
@@ -106,7 +106,6 @@ public class DockerFileBuilder {
      * <a href="http://docs.docker.io/reference/builder/#usage">Docker reference manual</a>
      *
      * @return the dockerfile create
-     * @throws IllegalArgumentException if no src/dest entries have been added
      */
     public String content() {
 

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ProcessorConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ProcessorConfig.java
@@ -117,7 +117,6 @@ public class ProcessorConfig {
      * @param type a description used in an error message (like 'generator' or 'enricher')
      * @param <T> the concrete type
      * @return the ordered list according to the algorithm described above
-     * @throws IllegalArgumentException if the includes reference an non existing element
      */
     public <T extends Named> List<T> prepareProcessors(List<T> namedList, String type) {
         List<T> ret = new ArrayList<>();


### PR DESCRIPTION
Fix  #471 

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->