### PR TITLE
Fix #624: Unable to override Image Name in Simple Dockerfile Mode with `jkube.generator.name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Usage:
 * Fix #450: Quarkus port is inferred from application.properties/yaml (considers profile too)
 * Fix #471: Remove the declaration of thrown runtime exceptions across javadoc
 * Fix #620: Added k8s support for NetworkPolicy
+* Fix #624: Unable to override Image Name in Simple Dockerfile Mode with `jkube.generator.name` 
 
 ### 1.1.1 (2021-02-23)
 * Fix #570: Disable namespace creation during k8s:resource with `jkube.namespace` flag

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
@@ -35,6 +35,7 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author roland

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/PropertiesUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/PropertiesUtil.java
@@ -13,6 +13,8 @@
  */
 package org.eclipse.jkube.kit.common.util;
 
+import io.fabric8.kubernetes.client.utils.Utils;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -38,5 +40,24 @@ public class PropertiesUtil {
       }
     }
     return ret;
+  }
+
+  /**
+   * Return first Non Null set property from a set of provided properties
+   *
+   * @param properties {@link Properties} in a given project
+   * @param keys an array of property key values to find
+   * @return a string which is first non null value found for the provided list
+   */
+  public static String getValueFromProperties(Properties properties, String... keys) {
+    for (String property : keys) {
+      if (properties.containsKey(property)) {
+        String value = properties.get(property).toString();
+        if (Utils.isNotNullOrEmpty(value)) {
+          return value;
+        }
+      }
+    }
+    return null;
   }
 }

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/PropertiesUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/PropertiesUtilTest.java
@@ -20,8 +20,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.eclipse.jkube.kit.common.util.PropertiesUtil.getPropertiesFromResource;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.eclipse.jkube.kit.common.util.PropertiesUtil.getValueFromProperties;
 
 public class PropertiesUtilTest {
 
@@ -46,5 +45,32 @@ public class PropertiesUtilTest {
     Properties result = getPropertiesFromResource(PropertiesUtilTest.class.getResource("/this-file-does-not-exist"));
     // Then
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void testGetValueFromProperties() {
+    // Given
+    Properties properties = new Properties();
+    String[] keys = new String[] {"property1", "property2"};
+
+    // When
+    String imageName = getValueFromProperties(properties, keys);
+
+    // Then
+    assertThat(imageName).isNull();
+  }
+
+  @Test
+  public void testGetValueFromPropertiesReturnsValidValue() {
+    // Given
+    Properties properties = new Properties();
+    properties.put("property1", "value1");
+    String[] keys = new String[] {"property1", "property2"};
+
+    // When
+    String imageName = getValueFromProperties(properties, keys);
+
+    // Then
+    assertThat(imageName).isNotNull().isEqualTo("value1");
   }
 }

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
@@ -25,7 +25,6 @@ import java.util.Properties;
 import javax.validation.ConstraintViolationException;
 
 import org.eclipse.jkube.generator.api.GeneratorContext;
-import org.eclipse.jkube.kit.build.api.helper.DockerFileUtil;
 import org.eclipse.jkube.kit.build.service.docker.config.handler.ImageConfigResolver;
 import org.eclipse.jkube.kit.build.service.docker.helper.ConfigHelper;
 import org.eclipse.jkube.kit.build.service.docker.helper.ImageNameFormatter;
@@ -67,7 +66,12 @@ import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 
+import static org.eclipse.jkube.kit.build.api.helper.DockerFileUtil.addSimpleDockerfileConfig;
+import static org.eclipse.jkube.kit.build.api.helper.DockerFileUtil.createSimpleDockerfileConfig;
+import static org.eclipse.jkube.kit.build.api.helper.DockerFileUtil.getTopLevelDockerfile;
+import static org.eclipse.jkube.kit.build.api.helper.DockerFileUtil.isSimpleDockerFileMode;
 import static org.eclipse.jkube.kit.common.ResourceFileType.yaml;
+import static org.eclipse.jkube.kit.common.util.PropertiesUtil.getValueFromProperties;
 import static org.eclipse.jkube.kit.common.util.ResourceMojoUtil.DEFAULT_RESOURCE_LOCATION;
 import static org.eclipse.jkube.kit.common.util.ResourceMojoUtil.useDekorate;
 import static org.eclipse.jkube.maven.plugin.mojo.build.BuildMojo.CONTEXT_KEY_BUILD_TIMESTAMP;
@@ -381,18 +385,21 @@ public class ResourceMojo extends AbstractJKubeMojo {
             });
 
         Date now = getBuildReferenceDate();
+        ImageNameFormatter imageNameFormatter = new ImageNameFormatter(MavenUtil.convertMavenProjectToJKubeProject(project, session), now);
         storeReferenceDateInPluginContext(now);
         // Check for simple Dockerfile mode
-        if (DockerFileUtil.isSimpleDockerFileMode(project.getBasedir())) {
-            File topDockerfile = DockerFileUtil.getTopLevelDockerfile(project.getBasedir());
+        if (isSimpleDockerFileMode(project.getBasedir())) {
+            File topDockerfile = getTopLevelDockerfile(project.getBasedir());
+            String defaultImageName = imageNameFormatter.format(getValueFromProperties(project.getProperties(),
+                    "jkube.image.name", "jkube.generator.name"));
             if (ret.isEmpty()) {
-                ret.add(DockerFileUtil.createSimpleDockerfileConfig(topDockerfile, MavenUtil.getPropertiesWithSystemOverrides(project).getProperty("jkube.image.name")));
+                ret.add(createSimpleDockerfileConfig(topDockerfile, defaultImageName));
             } else if (ret.size() == 1 && ret.get(0).getBuildConfiguration() == null) {
-                ret.set(0, DockerFileUtil.addSimpleDockerfileConfig(resolvedImages.get(0), topDockerfile));
+                ret.set(0, addSimpleDockerfileConfig(resolvedImages.get(0), topDockerfile));
             }
         }
         String minimalApiVersion = ConfigHelper.initAndValidate(ret, null /* no minimal api version */,
-            new ImageNameFormatter(MavenUtil.convertMavenProjectToJKubeProject(project, session), now));
+          imageNameFormatter);
         return ret;
     }
 


### PR DESCRIPTION
Fix #624 
Modify Mojos logic to consider image name configured from properties

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->