### PR TITLE
Re-introduce jkube.replicas property

### DIFF
--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -445,4 +445,8 @@ endif::[]
 | Domain added to the Service ID when creating Kubernetes Ingresses or OpenShift routes.
 | `jkube.domain`
 
+| *replicas*
+| Number of replicas for the container.
+| `jkube.replicas`
+
 |===

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
@@ -196,6 +196,9 @@ public class ResourceMojo extends AbstractJKubeMojo {
     @Parameter(property="jkube.interpolateTemplateParameters", defaultValue = "true")
     private Boolean interpolateTemplateParameters;
 
+    @Parameter(property = "jkube.replicas")
+    private Integer replicas;
+
     @Component
     private MavenProjectHelper projectHelper;
 
@@ -251,6 +254,9 @@ public class ResourceMojo extends AbstractJKubeMojo {
         realResourceDir = ResourceUtil.getFinalResourceDir(resourceDir, environment);
         if (namespace != null && !namespace.isEmpty()) {
             resources = ResourceConfig.toBuilder(resources).namespace(namespace).build();
+        }
+        if (replicas != null) {
+            resources = ResourceConfig.toBuilder(resources).replicas(replicas).build();
         }
         final ResourceServiceConfig resourceServiceConfig = ResourceServiceConfig.builder()
             .project(javaProject)


### PR DESCRIPTION
**Enhancement**

Current state:
When user wants to specify replica count, he has to use either _-Djkube.enricher.jkube-controller.replicaCount_ or _-Djkube.enricher.jkube-controller-from-configuration.replicaCount_ based on if resource fragments are used or not. This can be very confusing for users.

Proposal:
Unify both approaches (DefaultControllerEnricher and ControllerViaPluginConfigurationEnricher) to use _-Djkube.replicaCount_ instead

Reference issue: https://issues.redhat.com/browse/ENTESB-16080