### PR TITLE
Fix #602: Add documentation regarding automatic Route generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Usage:
 * Fix #576: Add support to publishing helm chart
 * Fix #634: Replace occurrences of keySet() with entrySet() when value are needed
 * Fix #659: Update Fabric8 Kubernetes Client to v5.3.0
+* Fix #602: Add documentation regarding automatic Route generation
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -215,6 +215,8 @@ https://docs.openshift.org/latest/architecture/networking/routes.html[Route] des
 generated along the service if an {cluster} cluster is targeted.
 If you do not want to generate a Route descriptor, you can set the `jkube.openshift.generateRoute` property to `false`.
 
+Note: For automatic Route generation, Service resources need to have `expose: true` or `jkube.io/exposeUrl: true` labels in their metadata. Services with recognized web ports(`80`, `443`, `8080`, `9080`, , `9090`, `9443`) are automatically exposed. If your application is using some other port than these standard ports, You might need to manually set the Service as exposed by configuring ServiceEnricher(either set `jkube.enricher.jkube-service.expose` to `true` or by using XML configuration).
+
 .Route Generation Configuration
 [cols="1,6,1"]
 |===


### PR DESCRIPTION
## Description
Fix #602 Add some documentation about service expose labels in Route generation
section for resource goal

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->