### PR TITLE
set jib image creation time

### DIFF
--- a/jkube-kit/build/service/jib/src/main/java/org/eclipse/jkube/kit/service/jib/JibServiceUtil.java
+++ b/jkube-kit/build/service/jib/src/main/java/org/eclipse/jkube/kit/service/jib/JibServiceUtil.java
@@ -221,7 +221,7 @@ public class JibServiceUtil {
     }
 
     private static void submitPushToJib(TarImage baseImage, RegistryImage targetImage, ExecutorService jibBuildExecutor, KitLogger logger) throws InterruptedException, ExecutionException, RegistryException, CacheDirectoryCreationException, IOException {
-        Jib.from(baseImage).containerize(Containerizer.to(targetImage)
+        Jib.from(baseImage).setCreationTime(Instant.now()).containerize(Containerizer.to(targetImage)
             .setAllowInsecureRegistries(true)
             .setExecutorService(jibBuildExecutor)
             .addEventHandler(LogEvent.class, log(logger))


### PR DESCRIPTION
## Description
Set time image creationTime on jib api

## Type of change
bug fix

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->