### PR TITLE
Fix #630: Add documentation for switchToDeployment flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Usage:
 * Fix #634: Replace occurrences of keySet() with entrySet() when value are needed
 * Fix #659: Update Fabric8 Kubernetes Client to v5.3.0
 * Fix #602: Add documentation regarding automatic Route generation
+* Fix #630: Document usage for `jkube.build.switchToDeployment` flag
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -355,6 +355,12 @@ ifeval::["{goal-prefix}" == "oc"]
 
   Defaults to `false`.
 | `jkube.openshift.enrichAllWithImageChangeTrigger`
+
+| *switchToDeployment*
+| Generate `Deployment` instead of `DeploymentConfig` during resource generation phase.
+
+  Defaults to `false`
+| `jkube.build.switchToDeployment`
 endif::[]
 
 | *profile*


### PR DESCRIPTION
## Description
Relates to #630 
+ Added documentation for `jkube.build.switchToDeployment` flag


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->