### PR TITLE
Replace deprecated JsonParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Usage:
 * Fix #632: Add support for Quarkus Fast Jar Packaging
 * Fix #578: NullPointerException in ContainerEnvJavaOptionsMergeEnricher on k8s:resource
 * Fix #682: Update CircleCI image to new version
+* Fix #666: Replace deprecated JsonParser
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/chunked/EntityStreamReaderUtil.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/chunked/EntityStreamReaderUtil.java
@@ -17,12 +17,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import com.google.gson.JsonElement;
+import org.eclipse.jkube.kit.build.service.docker.access.DockerAccessException;
+
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
-import org.eclipse.jkube.kit.build.service.docker.access.DockerAccessException;
 
 public class EntityStreamReaderUtil {
 
@@ -31,12 +31,10 @@ public class EntityStreamReaderUtil {
     public static void processJsonStream(JsonEntityResponseHandler handler, InputStream stream) throws IOException {
         handler.start();
         try(JsonReader json = new JsonReader(new InputStreamReader(stream))) {
-            JsonParser parser = new JsonParser();
-
             json.setLenient(true);
             while (json.peek() != JsonToken.END_DOCUMENT) {
-                JsonElement element = parser.parse(json);
-                handler.process(element.getAsJsonObject());
+            	JsonObject jsonObject = JsonParser.parseReader(json).getAsJsonObject();
+                handler.process(jsonObject);
             }
         } finally {
             handler.stop();


### PR DESCRIPTION
closes #666 

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->