### PR TITLE
Fix #639: Configuring Quotas for OpenShift BuildConfig not working as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Usage:
 * Fix #679: Quarkus package detection improvements
 * Fix #622: Corrected documentation for `jkube-healthcheck-karaf`
 * Fix #630: DeploymentConfigEnricher and DefaultControllerEnricher refactored and aligned
+* Fix #639: Quotas for OpenShift BuildConfig not working
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -57,11 +57,20 @@ This plugin comes with a set of default enrichers. In addition custom enrichers 
 | <<jkube-dependency>>
 | Examine build dependencies for `kubernetes.yml` and add the objects found therein.
 
+| <<jkube-docker-registry-secret>>
+| Add a `Secret` for your Docker registry credentials.
+
 | <<jkube-git>>
 | Check local `.git` directory and add build information as annotations.
 
 | <<jkube-image>>
 | Add the image name into a `PodSpec` of replication controller, replication sets and deployments, if missing.
+
+| <<jkube-ingress>>
+| Create a default Ingress if missing or configured from XML configuration
+
+| <<jkube-metadata>>
+| Add labels/annotations to generated Kubernetes resources
 
 | <<jkube-maven-issue-mgmt-enricher>>
 | Add Maven Issue Management information as annotations to the kubernetes/openshift resources
@@ -116,16 +125,40 @@ include::enricher/_jkube_container_env_java_options.adoc[]
 
 include::enricher/_jkube_controller.adoc[]
 
-include::enricher/_jkube_service.adoc[]
+[[jkube-dependency]]
+==== jkube-dependency
+
+[[jkube-docker-registry-secret]]
+==== jkube-docker-registry-secret
+
+This enricher enables {goal-prefix}:resource Secret generation feature. You can read more about it <<resource-secrets, Secrets>>.
+
+include::enricher/_jkube_git.adoc[]
 
 [[jkube-image]]
 ==== jkube-image
 
+[[jkube-ingress]]
+==== jkube-ingress
+
+This enricher is responsible for generating Ingress resource during {goal-prefix}:resource goal. You can read more about it in <<ingress-generation, Ingress Generation>> section.
+
+[[jkube-metadata]]
+==== jkube-metadata
+This enricher is responsible for adding labels and annotations to your resources. It reads `<labels>` and `<annotations>` fields provided in `<resources>` and adds respective labels/annotations to Kubernetes resources.
+
+You can also configure whether you want to add these labels/annotations to some specific resource or all resources. You can see an example if it's usage in {goal-prefix}:resource <<resource-labels-annotations, Labels And Annotations>> section.
+
+include::enricher/_jkube_maven_scm_enricher.adoc[]
+
+include::enricher/_jkube_maven_issue_mgmt.adoc[]
+
 [[jkube-name]]
 ==== jkube-name
 
-[[jkube-namespace]]
 include::enricher/_jkube_namespace.adoc[]
+
+include::enricher/_jkube_openshift_autotls.adoc[]
 
 [[jkube-portname]]
 ==== jkube-portname
@@ -135,29 +168,22 @@ include::enricher/_jkube_namespace.adoc[]
 
 include::enricher/_jkube_project_label.adoc[]
 
-include::enricher/_jkube_git.adoc[]
-
-[[jkube-dependency]]
-==== jkube-dependency
-
-include::enricher/_jkube_volume_permission.adoc[]
-
-include::enricher/_jkube_openshift_autotls.adoc[]
-
 include::enricher/_jkube_prometheus.adoc[]
-
-include::enricher/_jkube_maven_scm_enricher.adoc[]
-
-include::enricher/_jkube_maven_issue_mgmt.adoc[]
 
 include::enricher/_jkube_revision_history.adoc[]
 
-include::enricher/_jkube_triggers_annotation.adoc[]
-
 include::enricher/_jkube_secret_file.adoc[]
+
+include::enricher/_jkube_service.adoc[]
 
 [[jkube-serviceaccount]]
 ==== jkube-serviceaccount
+
+This enricher is responsible for creating ServiceAccount resource. See <<serviceaccount-generation, ServiceAccount Generation>> for more details.
+
+include::enricher/_jkube_triggers_annotation.adoc[]
+
+include::enricher/_jkube_volume_permission.adoc[]
 
 [[enrichers-specific]]
 === Specific Enrichers

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
@@ -234,7 +234,7 @@ The plugin configuration can be roughly divided into the following sections:
 * `<images>` defines which Docker <<image-configuration,images>> are used and configured. This section is similar to the
    https://dmp.fabric8.io//#image-configuration[image configuration] of the `docker-maven-plugin`, except that `<run>`
    and `<external>` sub-elements are ignored)
-* `<resource>` defines the resource descriptors for deploying on an OpenShift or Kuberneres cluster.
+* `<resources>` defines the resource descriptors for deploying on an OpenShift or Kubernetes cluster.
 * `<generator>` configures <<generators,generators>> which are responsible for creating images. Generators are used as an alternative to a dedicated `<images>` section.
 * `<enricher>` configures various aspects of <<enrichers,enrichers>> for creating or enhancing resource descriptors.
 
@@ -284,11 +284,44 @@ An extract of the plugin configuration is shown below:
       </service>
     </services>
 
-    <serviceAccounts>
+    <serviceAccounts> <!--7-->
       <serviceAccount>
         <name>build-robot</name>
       </serviceAccount>
     </serviceAccounts>
+
+    <annotations> <!--8-->
+      <all>
+        <version>${project.version}</version>
+        <artifactId>${project.artifactId}</artifactId>
+      </all>
+      <deployment> <!--9-->
+        <my>deployment</my>
+      </deployment>
+    </annotations>
+
+    <configMap> <!--10-->
+      <name>test</name>
+      <entries>
+        <entry> <!--11-->
+          <name>key1</name>
+          <value>value1</value>
+        </entry>
+        <entry> <!--12-->
+          <name>key3</name>
+          <file>${project.basedir}/src/main/resources/META-INF/resources/index.html</file>
+        </entry>
+      </entries>
+    </configMap>
+
+    <liveness> <!--13-->
+      <getUrl>http://localhost:8080/q/health</getUrl>
+      <initialDelaySeconds>3</initialDelaySeconds>
+      <timeoutSeconds>3</timeoutSeconds>
+    </liveness>
+    <remotes> <!--14-->
+       <remote>https://gist.githubusercontent.com/lordofthejars/ac2823cec7831697d09444bbaa76cd50/raw/e4b43f1b6494766dfc635b5959af7730c1a58a93/deployment.yaml</remote>
+    </remotes>
   </resources>
 </configuration>
 ----
@@ -298,6 +331,14 @@ An extract of the plugin configuration is shown below:
 <4> Number of replicas desired
 <5> Name of controller created by plugin
 <6> One or more http://kubernetes.io/docs/user-guide/services/[Service] definitions.
+<7> ServiceAccount(s) to create
+<8> Annotations which should be applied either to all or to specific resources
+<9> Annotations applied to Deployment resources only
+<10> ConfigMap to be created
+<11> ConfigMap data entry as a string key value pair
+<12> ConfigMap data entry with value as file path, file's contents are loaded into ConfigMap as key value
+<13> Liveness Probe to be added in PodTemplateSpec of Controller resource
+<14> Remote files used as resource fragments.
 
 The XML resource configuration is based on plain Kubernetes resource objects. When targeting OpenShift, Kubernetes resource descriptors will be automatically converted to their OpenShift counterparts, e.g. a Kubernetes http://kubernetes.io/docs/user-guide/deployments/[Deployment] will be converted to an OpenShift https://docs.openshift.com/container-platform/4.1/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are[DeploymentConfig].
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_configmap_file.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_configmap_file.adoc
@@ -47,6 +47,41 @@ You can also use `file` tag to refer to the content of a file.
 This creates a ConfigMap with key `test-application.properties` and value the content of the `src/test/resources/test-application.properties` file.
 If you set `name` tag then this is used as key instead of the filename.
 
+[[configmap-xml-configuration]]
+===== ConfigMap XML Configuration
+Here are the supported options while providing `<configMap>` in XML configuration
+
+.XML configmap configuration`<configMap>`
+[cols="1,5"]
+|===
+| Element | Description
+
+| <<configmap-entry-xml-configuration, `entries`>>
+| data for ConfigMap
+
+| `name`
+| Name of the ConfigMap
+|===
+
+[[configmap-entry-xml-configuration]]
+===== ConfigMap Entry XML Configuration
+`<entries>` is a list of `<port>` configuration objects. Here are the supported options while providing `<entry>` in XML configuration
+
+.XML configmap entry configuration`<entry>`
+[cols="1,5"]
+|===
+| Element | Description
+
+| `value`
+| Entry value
+
+| `file`
+| path to a file or directory. If it's a single file then file contents would be read as value. If it's a directory then each file's content is stored as value with file name as key.
+
+| `name`
+| Entry name
+|===
+
 If you are defining a custom `ConfigMap` file, you can use an annotation to define a file name as key and its content as the value:
 
 [source, yaml]

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_namespace.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_namespace.adoc
@@ -21,3 +21,16 @@ The following configuration parameters can be used to influence the behaviour of
   Defaults to `Namespace`.
 | `jkube.enricher.jkube-namespace.type`
 |===
+
+This enricher also configures generated Namespace in `.metadata.namespace` field for Kubernetes resources as per provided XML configuration too. Here is an example:
+
+[source,xml]
+----
+<configuration>
+    <resources>
+        <namespace>mynamespace</namespace>
+    </resources>
+</configuration>
+----
+
+

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_service.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_service.adoc
@@ -158,3 +158,67 @@ This example shows also the mapping rules:
 Multiple ports are **only** mapped when _multiPort_ mode is enabled (which is switched off by default). If _multiPort_ mode is disabled, only the first port from the list of mapped ports calculated as above is taken.
 
 When you set `legacyPortMapping` to true than ports 8080 to 9090 are mapped to port 80 automatically if not explicitly mapped via `_port_`. I.e. when an image exposes port 8080 with a legacy mapping this mapped to a service port 80, not 8080. You _should not_ switch this on for any good reason. In fact it might be that this option can vanish anytime.
+
+This enricher is also used by `<resources>` XML configuration to generate Service configured via XML. Here are the fields supported in `<resources>` which work with this enricher:
+
+.Fields supported in `<resources>`
+[cols="1,5"]
+|===
+| Element | Description
+| <<service-xml-configuration, `services`>>
+| Configuration element for generating Service resource
+|===
+
+[[service-xml-configuration]]
+===== Service XML Configuration
+`<services>` is a list of `<service>` configuration objects. Here are the supported options while providing `<service>` in XML configuration
+
+.XML `<service>` configuration
+[cols="1,5"]
+|===
+| Element | Description
+
+| `name`
+| Service name
+
+| `port`
+| Port to expose
+
+| `headless`
+| Whether this is a headless service.
+
+| `type`
+| Service type
+
+| `normalizePort`
+| Whether to normalize service port numbering.
+
+| <<service-port-xml-configuration, `ports`>>
+| Ports to expose
+|===
+
+[[service-port-xml-configuration]]
+===== Service `<port>` Configuration
+`<ports>` is a list of `<port>` configuration objects. Here are the supported options while providing `<port>` in XML configuration
+
+.XML service port configuration
+[cols="1,5"]
+|===
+| Element | Description
+
+| `protocol`
+| Protocol to use. Can be either "tcp" or "udp".
+
+| `port`
+| Container port to expose.
+
+| `targetPort`
+| Target port to expose.
+
+| `nodePort`
+| Port to expose from the port.
+
+| `name`
+| Name of the port
+|===
+

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-build.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-build.adoc
@@ -72,6 +72,51 @@ The configuration consists of two parts:
 Many of the options below are relevant for the <<build-kubernetes, Kubernetes Workflow>> or the <<build-openshift, OpenShift Workflow>> with Docker builds as they influence how the Docker image is build.
 
 For an S2I binary build, on the other hand, the most relevant section is the <<build-assembly, Assembly>> one because the build depends on which buider/base image is used and how it interprets the content of the uploaded `docker.tar`.
+
+[[setting-quota-openshift-build]]
+==== Setting Quotas for OpenShift Build
+You can also limit resource use by specifying resource limits as part of the build configuration. You can do this by providing `<openshiftBuildConfig>` field in `<resource>` configuration. Below is an example on how to do this:
+
+.Example of OpenShift S2I Build resource/limit Configuration
+[source,xml]
+----
+<configuration>
+    <resources>
+         <openshiftBuildConfig>
+            <requests> <!--1-->
+              <cpu>500m</cpu> <!--2-->
+              <memory>512Mi</memory> <!--3-->
+            </requests>
+            <limits> <!--4-->
+              <cpu>1000m</cpu> <!--5-->
+              <memory>1Gi</memory> <!--6-->
+            </limits>
+         </openshiftBuildConfig>
+    </resources>
+</configuration>
+----
+
+<1> Request field which maps to created BuildConfig's `.spec.resources.requests`
+<2> Minimum CPU required by Build Pod
+<3> Minimum memory required by Build Pod
+<4> Limits field which maps to created BuildConfig's (`.spec.resources.limits`)
+<5> Maximum CPU required by Build Pod
+<6> Maximum memory required by Build Pod
+
+It's also possible to provide a `buildconfig.yml` BuildConfig resource fragment in `src/main/jkube` directory like this:
+
+.BuildConfig fragment Example(`buildconfig.yml`)
+[source,yaml]
+----
+spec:
+  resources:
+    limits:
+      cpu: "600m"
+      memory: "512Mi"
+    requests:
+      cpu: "500m"
+      memory: "300Mi"
+----
 endif::[]
 
 [[build-goal-configuration]]

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -25,13 +25,13 @@ Labels and annotations can be easily added to any resource object. This is best 
     <!-- ... -->
     <resources>
       <labels> <!--1-->
-        <all> <!--1-->
-          <property> <!--2-->
+        <all> <!--2-->
+          <property> <!--3-->
             <name>organisation</name>
             <value>unesco</value>
           </property>
         </all>
-        <service> <!--3-->
+        <service> <!--4-->
           <property>
             <name>database</name>
             <value>mysql</value>
@@ -41,23 +41,20 @@ Labels and annotations can be easily added to any resource object. This is best 
             <value>true</value>
           </property>
         </service>
-        <replicaSet> <!--4-->
+        <replicaSet> <!--5-->
           <!-- ... -->
         </replicaSet>
-        <pod> <!--5-->
+        <pod> <!--6-->
           <!-- ... -->
         </pod>
-        <deployment> <!--6-->
+        <deployment> <!--7-->
           <!-- ... -->
         </deployment>
       </labels>
 
-      <annotations> <!--7-->
+      <annotations> <!--8-->
          <!-- ... -->
       </annotations>
-      <remotes> <!--8-->
-        <remote>https://gist.githubusercontent.com/lordofthejars/ac2823cec7831697d09444bbaa76cd50/raw/e4b43f1b6494766dfc635b5959af7730c1a58a93/deployment.yaml</remote>
-      </remotes>
     </resource>
   </configuration>
 </plugin>
@@ -110,6 +107,280 @@ endif::[]
 | Labels and annotations applied to `ServiceAccount` objects.
 |===
 
+[[controller-resource-generation]]
+=== Controller Generation
+
+In JKube terminology, a Controller resource is a Kubernetes resource which manages Pods created for your application. These can be one of the following resources:
+
+* https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/[ReplicationController]
+* https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/[ReplicaSet]
+* https://kubernetes.io/docs/concepts/workloads/controllers/deployment/[Deployment]
+* https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/[StatefulSet]
+* https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/[DaemonSet]
+* https://kubernetes.io/docs/concepts/workloads/controllers/job/[Job]
+ifeval::["{goal-prefix}" == "oc"]
+* https://docs.openshift.com/container-platform/4.7/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are[DeploymentConfig]
+endif::[]
+
+By default Deployment is generated in Kubernetes mode. You can easily configure different aspects of generated Controller resource using XML configuration. Here is an example:
+
+.Example of Controller Resource Configuration
+[source,xml]
+----
+<configuration>
+    <resources>
+        <env> <!--1-->
+          <organization>Eclipse Foundation</organization>
+          <projectname>jkube</projectname>
+        </env>
+        <controllerName>my-deploymentname</controllerName> <!--2-->
+        <containerPrivileged>true</containerPrivileged> <!--3-->
+        <imagePullPolicy>Always</imagePullPolicy> <!--4-->
+        <replicas>3</replicas> <!--5-->
+        <liveness> <!--6-->
+            <getUrl>http://localhost:8080/q/health</getUrl>
+            <tcpPort>8080</tcpPort>
+            <initialDelaySeconds>3</initialDelaySeconds>
+            <timeoutSeconds>3</timeoutSeconds>
+        </liveness>
+        <volumes> <!--7-->
+          <volume>
+            <name>scratch</name>
+            <type>emptyDir</type>
+            <medium>Memory</medium>
+            <mounts>
+              <mount>/var/scratch</mount>
+            </mounts>
+          </volume>
+        </volumes>
+    </resources>
+</configuration>
+----
+
+<1> Environment variables added to all of your application Pods
+<2> Name of Controller(`metadata.name` set in generated Deployment, Job, ReplicaSet etc)
+<3> Setting https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod[Security Context] of all application Pods.
+<4> Configure how images would be updated. Can be one of `IfNotPresent`, `Always` or `Never`. Read https://kubernetes.io/docs/concepts/containers/images/#updating-images[Kubernetes Images docs] for more details.
+<5> Number of replicas of pods we want to have in our application
+<6> Define an HTTP liveness request, see https://kubernetes.io/docs/concepts/containers/images/#updating-images[Kubernetes Liveness/Readiness probes] for more details.
+<7> Mounting an EmptyDir Volume to your application pods
+
+Here are the fields available in `<resources>` XML configuration that would work with this enricher:
+
+.<resources> fields used by this enricher
+[cols="1,5"]
+|===
+| Element | Description
+
+| `env`
+| Environment variables which will be added to containers in Pod template spec.
+
+| <<volume-xml-configuration, `volumes`>>
+| Configuration element for adding volume mounts to containers in Pod template spec
+
+| `controllerName`
+| Name of the controller resource(i.e. `Deployment`, `ReplicaSet`, `StatefulSet` etc) generated
+
+| <<probe-xml-configuration, `liveness`>>
+| Configuration element for adding a liveness probe
+
+| <<probe-xml-configuration, `readiness`>>
+| Configuration element for adding readiness probe
+
+| `containerPrivileged`
+| Run container in privileged mode. Sets `privileged: true` in generated Controller's PodTemplateSpec
+
+| `imagePullPolicy`
+| How images should be pulled (maps to ImagePullPolicy).
+
+| `replicas`
+| Number of replicas to create
+
+| `serviceAccount`
+| ServiceAccount name which will be used by pods created by controller resources(e.g. `Deployment`, `ReplicaSet` etc)
+|===
+
+[[probe-xml-configuration]]
+==== Probe XML Configuration
+Probe configuration is used for configuring https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes[liveness and readiness probes] for containers. Both `<liveness>` and `<readiness>` probes the following options:
+
+.XML Probe configuration
+[cols="1,5"]
+|===
+| Element | Description
+
+| `initialDelaySeconds`
+| Initial delay in seconds before the probe is started.
+
+| `timeoutSeconds`
+| Timeout in seconds how long the probe might take.
+
+| `exec`
+| Command to execute for probing.
+
+| `getUrl`
+| Probe this URL.
+
+| `tcpPort`
+| TCP port to probe.
+
+| `failureThreshold`
+| When a probe fails, Kubernetes will try failureThreshold times before giving up
+
+| `successThreshold`
+|  Minimum consecutive successes for the probe to be considered successful after having failed.
+|===
+
+[[volume-xml-configuration]]
+==== Volume XML Configuration
+`<volumes>` field contains a list of `<volume>` configurations. Different configurations are supported in order to support different https://kubernetes.io/docs/concepts/storage/volumes/[Volumes in Kubernetes].
+
+Here are the options supported by a single `<volume>` :
+
+.XML `<volume>` configuration
+[cols="1,5"]
+|===
+| Element | Description
+
+| `type`
+| type of Volume
+
+| `name`
+| name of volume to be mounted
+
+| `mounts`
+| List of mount paths of this volume.
+
+| `path`
+| Path for volume
+
+| `medium`
+| medium ,applicable for Volume type `emptyDir`
+
+| `repository`
+| repository ,applicable for Volume type `gitRepo`
+
+| `revision`
+| revision ,applicable for Volume type `gitRepo`
+
+| `secretName`
+| Secret name ,applicable for Volume type `secret`
+
+| `server`
+| Server name, applicable for Volume type `nfsPath`
+
+| `readOnly`
+| Whether it's read only or not
+
+| `pdName`
+| pdName, applicable for Volume type `gcePdName`
+
+| `fsType`
+| File system type for Volume
+
+| `partition`
+| partition, applicable for Volume type `gcePdName`
+
+| `endpoints`
+| endpoints, applicable for Volume type `glusterFsPath`
+
+| `claimRef`
+| Claim Reference, applicable for Volume type `persistentVolumeClaim`
+
+| `volumeId`
+| volume id
+
+| `diskName`
+| disk name, applicable for Volume type `azureDisk`
+
+| `diskUri`
+| disk uri, applicable for Volume type `azureDisk`
+
+| `kind`
+| kind, applicable for Volume type `azureDisk`
+
+| `cachingMode`
+| caching mode, applicable for Volume type `azureDisk`
+
+| `hostPathType`
+| Host Path type
+
+| `shareName`
+| Share name,  applicable for Volume type `azureFile`
+
+| `user`
+| User name
+
+| `secretFile`
+| Secret File, applicable for Volume type `cephfs`
+
+| `secretRef`
+| Secret reference, applicable for Volume type `cephfs`
+
+| `lun`
+| LUN(Logical Unit Number)
+
+| `targetWwns`
+| target WWNs, applicable for Volume type `fc`
+
+| `datasetName`
+| data set name, applicable for Volume type `flocker`
+
+| `portals`
+| list of portals, applicable for Volume type `iscsi`
+
+| `targetPortal`
+| target portal, applicable for Volume type `iscsi`
+
+| `registry`
+| registry, applicable for Volume type `quobyte`
+
+| `volume`
+| volume, applicable for Volume type `quobyte`
+
+| `group`
+| group, applicable for Volume type `quobyte`
+
+| `iqn`
+| IQN, applicable for Volume type `iscsi`
+
+| `monitors`
+| list of monitors, applicable for Volume type `rbd`
+
+| `pool`
+| pool, applicable for Volume type `rbd`
+
+| `keyring`
+| keyring, applicable for Volume type `rbd`
+
+| `image`
+| image, applicable for Volume type `rbd`
+
+| `gateway`
+| gateway, applicable for Volume type `scaleIO`
+
+| `system`
+| system, applicable for Volume type `scaleIO`
+
+| `protectionDomain`
+| protection domain, applicable for Volume type `scaleIO`
+
+| `storagePool`
+| storage pool, applicable for Volume type `scaleIO`
+
+| `volumeName`
+| volume name, applicable for Volume type `scaleIO` and `storageOS`
+
+| `configMapName`
+| ConfigMap name, applicable for Volume type `configMap`
+
+| `configMapItems`
+| List of ConfigMap items, applicable for Volume type `configMap`
+
+| `items`
+| List of items, applicable for Volume type `downwardAPI`
+|===
+
 [[resource-secrets]]
 === Secrets
 
@@ -143,8 +414,7 @@ namespace, if provided
 
 This is best explained by an example.
 
-.Example for XML configuration
-
+.Example for Setting docker registry in properties
 [source,xml]
 ----
 <properties>
@@ -152,6 +422,7 @@ This is best explained by an example.
 </properties>
 ----
 
+.Example for specifying Secret Configuration to be created
 [source,xml]
 ----
 <configuration>
@@ -185,6 +456,247 @@ metadata:
   annotations:
     maven.jkube.io/dockerServerId: ${docker.registry}
 type: kubernetes.io/dockercfg
+----
+
+[[ingress-generation]]
+=== Ingress Generation
+
+Once you've enabled `jkube.createExternalUrls` property, you should be able to generate an opinionated ingress during {goal-prefix}:resource goal. You can also configure it as per your needs using XML configuration or by providing your own resource fragments.
+
+**XML Configuration**
+
+.Fields supported in `<resources>`
+[cols="1,5"]
+|===
+| Element | Description
+
+| <<ingress-xml-configuration, `ingress`>>
+| Configuration element for creating new Ingress
+
+| `routeDomain`
+| Set host for Ingress or OpenShift Route
+|===
+
+Here is an example of configuring Ingress using XML configuration:
+
+.Enable Ingress Generation by enabling createExternalUrl property
+[source,xml]
+----
+<properties>
+     <jkube.createExternalUrls>true</jkube.createExternalUrls>
+</properties>
+----
+
+.Example for Ingress Configuration
+[source,xml]
+----
+<configuration>
+    <resources>
+        <ingress>
+          <ingressTlsConfigs>
+            <ingressTlsConfig> <!--1-->
+               <hosts>
+                 <host>foo.bar.com</host>
+               </hosts>
+               <secretName>testsecret-tls</secretName>
+            </ingressTlsConfig>
+          </ingressTlsConfigs>
+          <ingressRules>
+            <ingressRule>
+              <host>foo.bar.com</host> <!--2-->
+              <paths>
+                <path>
+                  <pathType>Prefix</pathType> <!--3-->
+                  <path>/foo</path>  <!--4-->
+                  <serviceName>service1</serviceName> <!--5-->
+                  <servicePort>8080</servicePort> <!--6-->
+                </path>
+              </paths>
+            </ingressRule>
+          </ingressRules>
+        </ingress>
+    </resources>
+</configuration>
+----
+
+<1> https://kubernetes.io/docs/concepts/services-networking/ingress/#tls[Ingress TLS] Configuration to specify Secret that contains TLS private key and certificate
+<2> Host names, can be precise matches or a wildcard. See https://kubernetes.io/docs/concepts/services-networking/ingress/#hostname-wildcards[Kubernetes Ingress Hostname] documentation for more details
+<3> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types[Ingress Path Type], Can be one of `ImplementationSpecific`, `Exact` or `Prefix`
+<4> Ingress path corresponding to provided `service.name`
+<5> Service Name corresponding to path
+<6> Service Port corresponding to path
+
+All the supported parameters in Ingress XML configuration are listed below:
+
+[[ingress-xml-configuration]]
+==== Ingress XML Configuration
+Here are the supported options while providing `<ingress>` in XML configuration
+
+.`<ingress>` configuration
+[cols="1,5"]
+|===
+| Element | Description
+
+| <<ingress-rule-xml-configuration, `ingressRules`>>
+| IngressRule configuration
+
+| <<ingress-tls-configuration, `ingressTlsConfigs`>>
+| Ingress TLS configuration
+|===
+
+[[ingress-rule-xml-configuration]]
+==== IngressRule XML Configuration
+Here are the supported options while providing `<ingressRules>` in XML configuration
+
+.`<ingressRule>` configuration
+[cols="1,5"]
+|===
+| Element | Description
+
+| `host`
+| Host name
+
+| <<ingress-rule-path-configuration, `paths`>>
+| IngressRule path configuration
+|===
+
+[[ingress-rule-path-configuration]]
+==== IngressRule Path XML Configuration
+Here are the supported options while providing `<paths>` in XML configuration
+
+.IngressRule `<path>` XML configuration
+[cols="1,5"]
+|===
+| Element | Description
+
+| `pathType`
+| type of Path
+
+| `path`
+| path
+
+| `serviceName`
+| Service name
+
+| `servicePort`
+| Service port
+
+| <<ingress-rule-path-resource-xml-configuration,`resource`>>
+| Resource reference in Ingress backend
+|===
+
+[[ingress-rule-path-resource-xml-configuration]]
+==== IngressRule Path Resource XML Configuration
+Here are the supported options while providing `<resource>` in IngressRule's path XML configuration
+
+.IngressRule Path `<resource>` XML configuration
+[cols="1,5"]
+|===
+| Element | Description
+
+| `name`
+| Resource name
+
+| `kind`
+| Resource kind
+
+| `apiGroup`
+| Resource's apiGroup
+|===
+
+[[ingress-tls-configuration]]
+==== IngressRule Path Resource XML Configuration
+Here are the supported options while providing `<ingressTlsConfigs>` in IngressRule's path XML configuration
+
+.IngressTls `<ingressTlsConfig>` XML configuration
+[cols="1,5"]
+|===
+| Element | Description
+
+| `secretName`
+| Secret name
+
+| `hosts`
+| a list of string `<host>` objects
+|===
+
+**Ingress Yaml fragment**:
+
+You can create Ingress using yaml fragment also. You would need to place a fragment of yaml in `src/main/jkube` directory like this:
+
+.Ingress fragment Example
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tls-example-ingress
+spec:
+  tls:
+  - hosts:
+    - https-example.foo.com
+    secretName: testsecret-tls
+  rules:
+  - host: https-example.foo.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: service1
+            port:
+              number: 80
+----
+
+[[serviceaccount-generation]]
+=== ServiceAccount Generation
+
+You can configure `<resource>` configuration to generate a ServiceAccount or configure an already existing ServiceAccount into your generated Deployment.
+
+Here is an example of XML configuration to generate a ServiceAccount:
+
+.Example for Creating ServiceAccount via XML
+[source,xml]
+----
+<configuration>
+    <resources>
+      <serviceAccounts>
+        <serviceAccount>
+          <name>my-serviceaccount</name> <!--1-->
+          <deploymentRef>my-deployment-name</deploymentRef> <!--2-->
+        </serviceAccount>
+      </serviceAccounts>
+    </resources>
+</configuration>
+----
+<1> Name of ServiceAccount to be created
+<2> Deployment which will be using this ServiceAccount
+
+If you don't want to generate ServiceAccount but just use an existing ServiceAccount in your Deployment. You can configure it via `<serviceAccount>` field in resource configuration. Here is an example:
+
+.Example for Configuring already existing ServiceAccount into generated Deployment
+[source,xml]
+----
+<configuration>
+    <resources>
+      <serviceAccount>my-existing-serviceaccount</serviceAccount>
+    </resources>
+</configuration>
+----
+
+**Service Account Resource fragment**:
+
+If you don't want to use XML configuration, you can provide a resource fragment for ServiceAccount resource. Here is how it would look like:
+
+.ServiceAccount resource fragment
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-robot
 ----
 
 [[resource-validation]]

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -673,6 +673,8 @@ public abstract class AbstractDockerMojo extends AbstractMojo
                 .forcePull(forcePull)
                 .imagePullManager(getImagePullManager(imagePullPolicy, autoPull))
                 .buildDirectory(project.getBuild().getDirectory())
+                .resourceConfig(resources)
+                .resourceDir(resourceDir)
                 .attacher((classifier, destFile) -> {
                     if (destFile.exists()) {
                         projectHelper.attachArtifact(project, "yml", classifier, destFile);

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/BuildMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/BuildMojoTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.maven.plugin.mojo.build;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.jkube.kit.config.resource.OpenshiftBuildConfig;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
+import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BuildMojoTest {
+    @Mocked
+    private MavenProject mavenProject;
+
+    @Before
+    public void setUp() {
+        // @formatter:off
+        new Expectations(){{
+            mavenProject.getBuild().getDirectory(); result = "target";
+        }};
+        // @formatter:on
+    }
+
+    @Test
+    public void testBuildServiceConfigBuilderReturnsNonNullResourceConfigIfConfigured() {
+        // Given
+        BuildMojo buildMojo = new BuildMojo();
+        buildMojo.project = mavenProject;
+        buildMojo.resources = ResourceConfig.builder()
+                .openshiftBuildConfig(OpenshiftBuildConfig.builder()
+                        .limit("cpu", "200m")
+                        .request("memory", "1Gi")
+                        .build())
+                .build();
+        buildMojo.resourceDir = new File("src/main/jkube");
+
+        // When
+        BuildServiceConfig.BuildServiceConfigBuilder buildServiceConfigBuilder = buildMojo.buildServiceConfigBuilder();
+
+        // Then
+        assertThat(buildServiceConfigBuilder).isNotNull();
+        BuildServiceConfig buildServiceConfig = buildServiceConfigBuilder.build();
+        assertThat(buildServiceConfig).isNotNull();
+        assertThat(buildServiceConfig.getResourceConfig()).isNotNull();
+        assertThat(buildServiceConfig.getResourceConfig().getOpenshiftBuildConfig()).isNotNull();
+        assertThat(buildServiceConfig.getResourceConfig().getOpenshiftBuildConfig().getLimits()).containsEntry("cpu", "200m");
+        assertThat(buildServiceConfig.getResourceConfig().getOpenshiftBuildConfig().getRequests()).containsEntry("memory", "1Gi");
+        assertThat(buildServiceConfig.getResourceDir().getPath()).isEqualTo("src/main/jkube");
+    }
+}


### PR DESCRIPTION
## Description
Fix #639 

+ Fixed OpenShift BuildConfig not getting picked up bug
+ Add documentation for XML resource configuration options

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->