### PR TITLE
refactor: QuarkusGenerator packaging configurable from everywhere*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Usage:
 * Fix #677: KarafGenerator includes Jolokia port (8778)
 * Fix #682: Update CircleCI image to new version
 * Fix #666: Replace deprecated JsonParser
+* Fix #679: Quarkus package detection improvements
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtil.java
@@ -109,7 +109,8 @@ public class JKubeProjectUtil {
   }
 
     public static Properties getPropertiesWithSystemOverrides(JavaProject project) {
-        Properties properties = new Properties(project.getProperties());
+        final Properties properties = new Properties();
+        properties.putAll(project.getProperties());
         properties.putAll(System.getProperties());
         return properties;
     }

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusMode.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusMode.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.quarkus;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.quarkus.generator.QuarkusAssemblies;
+
+import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusConfiguration;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.runnerSuffix;
+
+public enum QuarkusMode {
+
+  NATIVE("native", false, QuarkusAssemblies.NATIVE),
+  FAST_JAR("fast-jar", false, QuarkusAssemblies.FAST_JAR),
+  LEGACY_JAR("legacy-jar", false, QuarkusAssemblies.LEGACY_JAR),
+  UBER_JAR("uber-jar", true, QuarkusAssemblies.UBER_JAR);
+
+  private final String packageType;
+  private final boolean isFatJar;
+  private final QuarkusAssemblies.QuarkusAssembly assembly;
+
+  QuarkusMode(String packageType, boolean isFatJar, QuarkusAssemblies.QuarkusAssembly assembly) {
+    this.packageType = packageType;
+    this.isFatJar = isFatJar;
+    this.assembly = assembly;
+  }
+
+  public boolean isFatJar() {
+    return isFatJar;
+  }
+
+  public QuarkusAssemblies.QuarkusAssembly getAssembly() {
+    return assembly;
+  }
+
+  public static QuarkusMode from(JavaProject project) {
+    final Properties quarkusConfiguration = getQuarkusConfiguration(project);
+    return from(quarkusConfiguration).orElseGet(() -> fromFiles(project, quarkusConfiguration));
+  }
+
+  private static Optional<QuarkusMode> from(Properties properties) {
+    return Optional.ofNullable(properties.getProperty("quarkus.package.type"))
+        .flatMap(packageType -> Arrays.stream(QuarkusMode.values())
+            .filter(qm -> qm.packageType.equalsIgnoreCase(packageType))
+            .findFirst());
+  }
+
+  private static QuarkusMode fromFiles(JavaProject project, Properties properties) {
+    final String runnerSuffix = runnerSuffix(properties);
+    if (hasFileThatEndsWith(project, runnerSuffix + ".jar") && new File(project.getBuildDirectory(), "lib").exists()) {
+      return QuarkusMode.LEGACY_JAR;
+    } else if(hasFileThatEndsWith(project, runnerSuffix + ".jar")) {
+      return QuarkusMode.UBER_JAR;
+    } else if(hasFileThatEndsWith(project, runnerSuffix)) {
+      return QuarkusMode.NATIVE;
+    }
+    return QuarkusMode.FAST_JAR;
+  }
+
+  private static boolean hasFileThatEndsWith(JavaProject project, String suffix) {
+    File buildDir = project.getBuildDirectory();
+    String[] file = buildDir.list((dir, name) -> name.endsWith(suffix));
+    return file != null && file.length > 0;
+  }
+}

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
@@ -16,17 +16,21 @@ package org.eclipse.jkube.quarkus;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.common.JavaProject;
 
+import java.io.File;
 import java.net.URLClassLoader;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
 
+import static org.eclipse.jkube.kit.common.util.JKubeProjectUtil.getClassLoader;
 import static org.eclipse.jkube.kit.common.util.PropertiesUtil.getPropertiesFromResource;
+import static org.eclipse.jkube.kit.common.util.PropertiesUtil.toMap;
 import static org.eclipse.jkube.kit.common.util.YamlUtil.getPropertiesFromYamlResource;
 
 public class QuarkusUtils {
 
   private static final String QUARKUS_HTTP_PORT = "quarkus.http.port";
+  private static final String QUARKUS_PACKAGE_RUNNER_SUFFIX = "quarkus.package.runner-suffix";
 
   private QuarkusUtils() {}
 
@@ -41,19 +45,48 @@ public class QuarkusUtils {
     return properties.getProperty(QUARKUS_HTTP_PORT, defaultValue);
   }
 
+  public static String runnerSuffix(Properties properties) {
+    return properties.getProperty(QUARKUS_PACKAGE_RUNNER_SUFFIX, "-runner");
+  }
+
+  public static String findSingleFileThatEndsWith(JavaProject project, String suffix) {
+    final File buildDir = project.getBuildDirectory();
+    String[] file = buildDir.list((dir, name) -> name.endsWith(suffix));
+    if (file == null || file.length != 1) {
+      throw new IllegalStateException("Can't find single file with suffix '" + suffix +
+          "' in " + buildDir + " (zero or more than one files found ending with '" +
+          suffix + "')");
+    }
+    return file[0];
+  }
+
+  /**
+   * Returns the applicable Quarkus configuration properties.
+   *
+   * <p> It takes into account properties provided either via application.properties, or application.yaml files.
+   *
+   * <p> Any property overridden in the project's properties (e.g. Maven properties) will take precedence over the ones
+   * defined in the static configuration files.
+   *
+   * @param project from which to read the configuration
+   * @return the applicable Quarkus configuration properties
+   */
   @SuppressWarnings("unchecked")
-  public static Properties getQuarkusConfiguration(URLClassLoader urlClassLoader) {
+  public static Properties getQuarkusConfiguration(JavaProject project) {
+    final URLClassLoader urlClassLoader = getClassLoader(project);
     final Supplier<Properties>[] sources = new Supplier[]{
         () -> getPropertiesFromResource(urlClassLoader.findResource("application.properties")),
+        () -> getPropertiesFromYamlResource(urlClassLoader.findResource("application.yaml")),
         () -> getPropertiesFromYamlResource(urlClassLoader.findResource("application.yml"))
     };
     for (Supplier<Properties> source : sources) {
       final Properties props = source.get();
       if (!props.isEmpty()) {
+        props.putAll(toMap(project.getProperties()));
         return props;
       }
     }
-    return new Properties();
+    return project.getProperties();
   }
 
   private static Optional<String> getActiveProfile(JavaProject project) {

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusAssemblies.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusAssemblies.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.quarkus.generator;
+
+import org.eclipse.jkube.kit.common.Assembly;
+import org.eclipse.jkube.kit.common.AssemblyConfiguration;
+import org.eclipse.jkube.kit.common.AssemblyFileSet;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.util.FileUtil;
+import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.eclipse.jkube.quarkus.QuarkusUtils.findSingleFileThatEndsWith;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusConfiguration;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.runnerSuffix;
+
+public class QuarkusAssemblies {
+
+  public static final QuarkusAssembly NATIVE = quarkusGenerator -> {
+    final JavaProject project = quarkusGenerator.getContext().getProject();
+    final Properties quarkusConfiguration = getQuarkusConfiguration(project);
+    final List<String> relativePaths = new ArrayList<>();
+    relativePaths.add(findSingleFileThatEndsWith(project, runnerSuffix(quarkusConfiguration)));
+    final AssemblyFileSet fileSet = AssemblyFileSet.builder()
+        .directory(FileUtil.getRelativePath(project.getBaseDirectory(), project.getBuildDirectory()))
+        .includes(relativePaths)
+        .fileMode("0755")
+        .build();
+    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir(), fileSet);
+  };
+
+  public static final QuarkusAssembly FAST_JAR = quarkusGenerator -> {
+    final JavaProject project = quarkusGenerator.getContext().getProject();
+    final File quarkusAppDirectory = new File(project.getBuildDirectory(), "quarkus-app");
+    if (!quarkusAppDirectory.exists()) {
+      throw new IllegalStateException("The quarkus-app directory required in Quarkus Fast Jar mode was not found");
+    }
+    AssemblyFileSet.AssemblyFileSetBuilder fileSetBuilder = AssemblyFileSet.builder()
+        .directory(FileUtil.getRelativePath(project.getBaseDirectory(), quarkusAppDirectory))
+        .include("quarkus-run.jar")
+        .include("*")
+        .include("**/*")
+        .fileMode("0640");
+    addDefaultArtifactExclude(project, fileSetBuilder);
+    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir(), fileSetBuilder.build());
+  };
+
+  public static final QuarkusAssembly LEGACY_JAR = quarkusGenerator -> {
+    final JavaProject project = quarkusGenerator.getContext().getProject();
+    AssemblyFileSet.AssemblyFileSetBuilder fileSetBuilder = AssemblyFileSet.builder()
+        .directory(FileUtil.getRelativePath(project.getBaseDirectory(), project.getBuildDirectory()))
+        .include(findSingleFileThatEndsWith(project, runnerSuffix(getQuarkusConfiguration(project)) + ".jar"))
+        .include("lib")
+        .fileMode("0640");
+    addDefaultArtifactExclude(project, fileSetBuilder);
+    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir(), fileSetBuilder.build());
+  };
+
+  public static final QuarkusAssembly UBER_JAR = quarkusGenerator -> {
+    final JavaProject project = quarkusGenerator.getContext().getProject();
+    AssemblyFileSet.AssemblyFileSetBuilder fileSetBuilder = AssemblyFileSet.builder()
+        .directory(FileUtil.getRelativePath(project.getBaseDirectory(), project.getBuildDirectory()))
+        .include(findSingleFileThatEndsWith(project, runnerSuffix(getQuarkusConfiguration(project)) + ".jar"))
+        .fileMode("0640");
+    addDefaultArtifactExclude(project, fileSetBuilder);
+    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir(), fileSetBuilder.build());
+  };
+
+  private static void addDefaultArtifactExclude(JavaProject project, AssemblyFileSet.AssemblyFileSetBuilder fileSetBuilder) {
+    // We also need to exclude default jar file
+    File defaultJarFile = JKubeProjectUtil.getFinalOutputArtifact(project);
+    if (defaultJarFile != null) {
+      fileSetBuilder.exclude(defaultJarFile.getName());
+    }
+  }
+
+  private static AssemblyConfiguration createAssemblyConfiguration(String targetDir, AssemblyFileSet jKubeAssemblyFileSet) {
+    jKubeAssemblyFileSet.setOutputDirectory(".");
+    return AssemblyConfiguration.builder()
+        .targetDir(targetDir)
+        .excludeFinalOutputArtifact(true)
+        .inline(Assembly.builder().fileSet(jKubeAssemblyFileSet).build())
+        .build();
+  }
+
+  @FunctionalInterface
+  public interface QuarkusAssembly {
+    AssemblyConfiguration createAssemblyConfiguration(QuarkusGenerator quarkusGenerator);
+  }
+}

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/QuarkusModeTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/QuarkusModeTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.quarkus;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.eclipse.jkube.kit.common.JavaProject;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("ResultOfMethodCallIgnored")
+public class QuarkusModeTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Mocked
+  private JavaProject project;
+
+  private File target;
+  private List<String> compileClassPathElements;
+  private Properties projectProperties;
+
+  @Before
+  public void setUp() throws IOException {
+    target = temporaryFolder.newFolder("target");
+    compileClassPathElements = new ArrayList<>();
+    projectProperties = new Properties();
+    // @formatter:off
+    new Expectations() {{
+      project.getCompileClassPathElements(); result = compileClassPathElements;
+      project.getOutputDirectory(); result = target;
+      project.getBuildDirectory(); result = target; minTimes = 0;
+      project.getProperties(); result = projectProperties;
+    }};
+    // @formatter:on
+  }
+
+  @Test
+  public void from_withNoSettingsAndNoFiles_shouldReturnFastJar() {
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result).isEqualTo(QuarkusMode.FAST_JAR);
+  }
+
+  @Test
+  public void from_withNoSettingsAndNativeBinary_shouldReturnNative() throws IOException {
+    // Given
+    new File(target, "-runner").createNewFile();
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result).isEqualTo(QuarkusMode.NATIVE);
+  }
+
+  @Test
+  public void from_withCustomSuffixAndNativeBinary_shouldReturnNative() throws IOException {
+    // Given
+    projectProperties.put("quarkus.package.runner-suffix", "-coyote");
+    new File(target, "-coyote").createNewFile();
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result).isEqualTo(QuarkusMode.NATIVE);
+  }
+
+  @Test
+  public void from_withNoSettingsAndRunnerJar_shouldReturnUberJar() throws IOException {
+    // Given
+    new File(target, "-runner.jar").createNewFile();
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result).isEqualTo(QuarkusMode.UBER_JAR);
+  }
+
+  @Test
+  public void from_withCustomSuffixAndRunnerJar_shouldReturnUberJar() throws IOException {
+    // Given
+    projectProperties.put("quarkus.package.runner-suffix", "-coyote");
+    new File(target, "-coyote.jar").createNewFile();
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result).isEqualTo(QuarkusMode.UBER_JAR);
+  }
+
+  @Test
+  public void from_withNoSettingsAndRunnerJarAndLib_shouldReturnLegacyJar() throws IOException {
+    // Given
+    new File(target, "-runner.jar").createNewFile();
+    FileUtils.forceMkdir(new File(target, "lib"));
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result).isEqualTo(QuarkusMode.LEGACY_JAR);
+  }
+
+  @Test
+  public void from_withNativePackaging_shouldReturnNative() {
+    // Given
+    projectProperties.put("quarkus.package.type", "native");
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result)
+        .isEqualTo(QuarkusMode.NATIVE)
+        .hasFieldOrPropertyWithValue("fatJar", false);
+  }
+
+  @Test
+  public void from_withLegacyJarPackaging_shouldReturnLegacyJar() {
+    // Given
+    projectProperties.put("quarkus.package.type", "legacy-jar");
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result)
+        .isEqualTo(QuarkusMode.LEGACY_JAR)
+        .hasFieldOrPropertyWithValue("fatJar", false);
+  }
+
+  @Test
+  public void from_withFastJarPackaging_shouldReturnFastJar() {
+    // Given
+    projectProperties.put("quarkus.package.type", "fast-jar");
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result)
+        .isEqualTo(QuarkusMode.FAST_JAR)
+        .hasFieldOrPropertyWithValue("fatJar", false);
+  }
+
+  @Test
+  public void from_withUberJarPackaging_shouldReturnUberJar() {
+    // Given
+    projectProperties.put("quarkus.package.type", "uber-jar");
+    // When
+    final QuarkusMode result = QuarkusMode.from(project);
+    // Then
+    assertThat(result)
+        .isEqualTo(QuarkusMode.UBER_JAR)
+        .hasFieldOrPropertyWithValue("fatJar", true);
+  }
+}

--- a/quickstarts/maven/quarkus/pom.xml
+++ b/quickstarts/maven/quarkus/pom.xml
@@ -32,9 +32,22 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <jkube.version>${project.version}</jkube.version>
-    <version.quarkus>1.7.0.Final</version.quarkus>
+    <version.quarkus>1.13.1.Final</version.quarkus>
+    <quarkus.package.type>legacy-jar</quarkus.package.type>
     <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${version.quarkus}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
## Description
refactor: QuarkusGenerator packaging configurable from everywhere*

- Project/Maven properties
- Application properties (.properties / .yaml)
- Inference from target/build directory structure

Closes #632 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)


## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->