### PR TITLE
fix: Custom Resource fragments can be replaced and recreated with FKC 5.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Usage:
 * Fix #630: DeploymentConfigEnricher and DefaultControllerEnricher refactored and aligned
 * Fix #639: Quotas for OpenShift BuildConfig not working
 * Fix #688: Multiple Custom Resources with same (different apiGroup) name can be added
+* Fix #689: Recreate and update of CustomResource fragments works
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
@@ -18,14 +18,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionList;
 import org.eclipse.jkube.kit.common.GenericCustomResource;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
@@ -35,6 +33,7 @@ import org.eclipse.jkube.kit.config.service.UndeployService;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionList;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 
 import static org.eclipse.jkube.kit.common.util.KubernetesHelper.getCrdContext;
@@ -106,7 +105,7 @@ public class KubernetesUndeployService implements UndeployService {
   }
 
   private void deleteCustomResourceIfPresent(GenericCustomResource customResource, String namespace, CustomResourceDefinitionContext crdContext) {
-    Map<String, Object> cr = KubernetesClientUtil.doGetCustomResource(jKubeServiceHub.getClient(), crdContext, namespace, customResource.getMetadata().getName());
+    final GenericCustomResource cr = KubernetesClientUtil.doGetCustomResource(jKubeServiceHub.getClient(), crdContext, namespace, customResource.getMetadata().getName());
     if (cr != null) {
       deleteCustomResource(customResource, namespace, crdContext);
     }
@@ -117,8 +116,8 @@ public class KubernetesUndeployService implements UndeployService {
     String apiVersionAndKind = KubernetesHelper.getFullyQualifiedApiGroupWithKind(crdContext);
     try {
       logger.info("Deleting Custom Resource %s %s", apiVersionAndKind, name);
-      KubernetesClientUtil.doDeleteCustomResource(jKubeServiceHub.getClient(), crdContext, namespace, name);
-    } catch (IOException exception) {
+      jKubeServiceHub.getClient().customResource(crdContext).inNamespace(namespace).withName(name).delete();
+    } catch (Exception exception) {
       logger.error("Unable to undeploy %s %s/%s", apiVersionAndKind, namespace, name);
     }
   }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesClientUtilTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesClientUtilTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.service.kubernetes;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.junit.Test;
+
+import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil.doDeleteAndWait;
+
+public class KubernetesClientUtilTest {
+
+  @Mocked
+  private KubernetesClient kubernetesClient;
+
+  @Test
+  public void doDeleteAndWait_withExistingResource_shouldDeleteAndReachWaitLimit() {
+    // Given
+    final CustomResourceDefinitionContext context = new CustomResourceDefinitionContext();
+    // When
+    doDeleteAndWait(kubernetesClient, context, "namespace", "name", 2L);
+    // Then
+    // @formatter:off
+    new Verifications(){{
+      kubernetesClient.customResource(context).inNamespace("namespace").withName("name").delete(); times = 1;
+      kubernetesClient.customResource(context).inNamespace("namespace").withName("name").get(); times = 2;
+    }};
+    // @formatter:on
+  }
+
+}

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
@@ -138,7 +138,7 @@ public class KubernetesUndeployServiceTest {
     // Then
     // @formatter:off
     new Verifications() {{
-      jKubeServiceHub.getClient().customResource((CustomResourceDefinitionContext)any).delete("my-cr");
+      jKubeServiceHub.getClient().customResource((CustomResourceDefinitionContext)any).inNamespace(null).withName("my-cr").delete();
       times = 1;
     }};
     // @formatter:on


### PR DESCRIPTION
## Description
fix: Custom Resource fragments can be replaced and recreated with FKC 5.3.x

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->