### PR TITLE
fix: Helm charts  generated for custom resources, even those with same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Usage:
 * Fix #639: Quotas for OpenShift BuildConfig not working
 * Fix #688: Multiple Custom Resources with same (different apiGroup) name can be added
 * Fix #689: Recreate and update of CustomResource fragments works
+* Fix: Helm charts can be generated for custom resources, even those with same name (different apiGroup)
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/ResourceUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/ResourceUtilTest.java
@@ -24,6 +24,8 @@ import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.openshift.api.model.Template;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.eclipse.jkube.kit.common.GenericCustomResource;
+import org.eclipse.jkube.kit.common.ResourceFileType;
 import org.junit.Test;
 
 import java.io.File;
@@ -129,5 +131,34 @@ public class ResourceUtilTest {
                 .withValue("replaced_value")
                 .build()
             );
+    }
+
+    @Test
+    public void load_withCustomResourceFile_shouldLoadGenericCustomResource() throws Exception {
+        // When
+        final HasMetadata result = ResourceUtil.load(
+            new File(ResourceUtilTest.class.getResource( "/util/resource-util/custom-resource-cr.yml").getFile()),
+            HasMetadata.class
+        );
+        // Then
+        assertThat(result)
+            .isInstanceOf(GenericCustomResource.class)
+            .hasFieldOrPropertyWithValue("kind", "SomeCustomResource")
+            .hasFieldOrPropertyWithValue("metadata.name", "my-custom-resource");
+    }
+
+    @Test
+    public void load_withCustomResourceStream_shouldLoadGenericCustomResource() throws Exception {
+        // When
+        final HasMetadata result = ResourceUtil.load(
+            ResourceUtilTest.class.getResourceAsStream( "/util/resource-util/custom-resource-cr.yml"),
+            HasMetadata.class,
+            ResourceFileType.yaml
+        );
+        // Then
+        assertThat(result)
+            .isInstanceOf(GenericCustomResource.class)
+            .hasFieldOrPropertyWithValue("kind", "SomeCustomResource")
+            .hasFieldOrPropertyWithValue("metadata.name", "my-custom-resource");
     }
 }

--- a/jkube-kit/common/src/test/resources/util/resource-util/custom-resource-cr.yml
+++ b/jkube-kit/common/src/test/resources/util/resource-util/custom-resource-cr.yml
@@ -1,0 +1,4 @@
+apiVersion: "custom.example.com/v1"
+kind: SomeCustomResource
+metadata:
+  name: my-custom-resource

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
@@ -370,7 +370,7 @@ public class KubernetesResourceUtil {
 
     public static String getNameWithSuffix(String name, String kind) {
         String suffix =  KIND_TO_FILENAME_MAPPER.get(kind);
-        return suffix != null ? name +  "-" + suffix : name;
+        return String.format("%s-%s", name, suffix != null ? suffix : "cr");
     }
 
     public static String extractContainerName(GroupArtifactVersion groupArtifactVersion, ImageConfiguration imageConfig) {

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtilTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtilTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.getNameWithSuffix;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -287,6 +288,16 @@ public class KubernetesResourceUtilTest {
     public void testIsExposedService() {
         assertTrue(KubernetesResourceUtil.isExposedService(new ObjectMetaBuilder().addToLabels("expose", "true").build()));
         assertTrue(KubernetesResourceUtil.isExposedService(new ObjectMetaBuilder().addToLabels("jkube.io/exposeUrl", "true").build()));
+    }
+
+    @Test
+    public void getNameWithSuffix_withKnownMapping_shouldReturnKnownMapping() {
+        assertEquals("name-pod", getNameWithSuffix("name", "Pod"));
+    }
+
+    @Test
+    public void getNameWithSuffix_withUnknownMapping_shouldReturnCR() {
+        assertEquals("name-cr", getNameWithSuffix("name", "VeryCustomKind"));
     }
 
     private PodSpec getDefaultGeneratedPodSpec() {


### PR DESCRIPTION
## Description
fix: Helm charts can be generated for custom resources, even those with same name (different apiGroup)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->