### PR TITLE
Define Helm Chart dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Usage:
 * Fix #630: DeploymentConfigEnricher and DefaultControllerEnricher refactored and aligned
 * Fix #639: Quotas for OpenShift BuildConfig not working
 * Fix #688: Multiple Custom Resources with same (different apiGroup) name can be added
+* Fix #676: Define Helm Chart dependencies
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/Chart.java
+++ b/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/Chart.java
@@ -60,6 +60,8 @@ public class Chart {
   private String engine;
   @JsonProperty
   private String icon;
+  @JsonProperty
+  private List<HelmDependency> dependencies;
 
   @Override
   public String toString() {

--- a/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmConfig.java
+++ b/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmConfig.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.kit.resource.helm;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.fabric8.openshift.api.model.Template;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -63,6 +64,9 @@ public class HelmConfig {
   private HelmRepository stableRepository;
   private HelmRepository snapshotRepository;
   private String security;
+
+  @JsonProperty("dependencies")
+  private List<HelmDependency> dependencies;
 
   // Plexus deserialization specific setters
   /**

--- a/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmDependency.java
+++ b/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmDependency.java
@@ -1,0 +1,39 @@
+package org.eclipse.jkube.kit.resource.helm;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Configuration for a helm dependency
+ * @author dloiacono
+ * @since 03/05/21
+ */
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@JsonInclude(NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HelmDependency {
+
+  @JsonProperty
+  private String name;
+
+  @JsonProperty
+  private String version;
+
+  @JsonProperty
+  private String repository;
+
+}

--- a/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmService.java
+++ b/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmService.java
@@ -181,6 +181,7 @@ public class HelmService {
     chart.setIcon(helmConfig.getIcon());
     chart.setKeywords(helmConfig.getKeywords());
     chart.setEngine(helmConfig.getEngine());
+    chart.setDependencies(helmConfig.getDependencies());
 
     File outputChartFile = new File(outputDir, CHART_FILENAME);
     ResourceUtil.save(outputChartFile, chart, ResourceFileType.yaml);

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmConfigTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmConfigTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.jkube.kit.common.Dependency;
 import org.eclipse.jkube.kit.resource.helm.HelmConfig.HelmType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -106,7 +107,12 @@ public class HelmConfigTest {
         "\"maintainers\":[{}]," +
         "\"sources\":[\"source\"]," +
         "\"engine\":\"V8\"," +
-        "\"keywords\":[\"SEO\"]" +
+        "\"keywords\":[\"SEO\"]," +
+        "\"dependencies\":[{" +
+        "\"name\": \"ngnix\"," +
+        "\"version\": \"1.2.3\"," +
+        "\"repository\": \"https://example.com/charts\"" +
+        "}]" +
         "}";
     // When
     final HelmConfig result = objectMapper.readValue(serializedChart, HelmConfig.class);
@@ -129,7 +135,9 @@ public class HelmConfigTest {
         .hasFieldOrPropertyWithValue("maintainers", Collections.singletonList(new Maintainer()))
         .hasFieldOrPropertyWithValue("sources", Collections.singletonList("source"))
         .hasFieldOrPropertyWithValue("engine", "V8")
-        .hasFieldOrPropertyWithValue("keywords", Collections.singletonList("SEO"));
+        .hasFieldOrPropertyWithValue("keywords", Collections.singletonList("SEO"))
+        .hasFieldOrPropertyWithValue("dependencies", Collections.singletonList(new HelmDependency()
+        .toBuilder().name("ngnix").version("1.2.3").repository("https://example.com/charts").build()));
   }
 
   @Test

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-helm.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-helm.adoc
@@ -27,6 +27,13 @@ The configuration is defined in a `<helm>` section within the plugin's configura
     <helm>
       <chart>Jenkins</chart>
       <keywords>ci,cd,server</keywords>
+      <dependencies>
+        <dependency>
+          <name>ingress-nginx</name>
+          <version>1.26.0</version>
+          <repository>https://kubernetes.github.io/ingress-nginx</repository>
+        </dependency>
+      </dependencies>
     </helm>
   </configuration>
 </plugin>
@@ -106,7 +113,10 @@ This configuration section knows the following sub-elements in order to configur
 | *chartExtension*
 | The Helm chart file extension (`tgz`, `tar.bz`, `tar.bzip2`, `tar.bz2`), default value is `tar.gz` if not provided.
 | `jkube.helm.chartExtension`
-|
+
+| *dependencies*
+| The list of dependencies for this chart
+
 |===
 
 


### PR DESCRIPTION
Signed-off-by: dloiacono <dloiacono@gmail.com>

## Description
Manage the dependencies of a chart.

Helm charts store their dependencies in 'charts/'. For chart developers, it is often easier to manage dependencies in 'Chart.yaml' which declares all dependencies.

The dependency commands operate on that file, making it easy to synchronize between the desired dependencies and the actual dependencies stored in the 'charts/' directory.

For example, this Chart.yaml declares two dependencies:

# Chart.yaml
dependencies:
- name: nginx
  version: "1.2.3"
  repository: "https://example.com/charts"
- name: memcached
  version: "3.2.1"
  repository: "https://another.example.com/charts"

A dependencies section could be added under the helm section:

```
<dependencies>
  <dependency>
    <name>ngnix</name>
    <version>1.2.3</version>
    <repository>https://example.com/charts</repository>
  </dependency>
</dependencies>
```

## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [X] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
