### PR TITLE
Chore #673: Remove unused ports mapping field from ResourceConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Usage:
 * Fix #677: KarafGenerator includes Jolokia port (8778)
 * Fix #682: Update CircleCI image to new version
 * Fix #666: Replace deprecated JsonParser
+* Fix #673: Remove unused `ports` field in ResourceConfig
 * Fix #679: Quarkus package detection improvements
 * Fix #622: Corrected documentation for `jkube-healthcheck-karaf`
 * Fix #630: DeploymentConfigEnricher and DefaultControllerEnricher refactored and aligned

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
@@ -62,12 +62,6 @@ public class ResourceConfig {
   private String imagePullPolicy;
 
   /**
-   * Mapping of port to names.
-   */
-  @Singular
-  private Map<String, Integer> ports;
-
-  /**
    * Number of replicas to create.
    */
   private Integer replicas;


### PR DESCRIPTION
## Description
Fix #673 

ResourceConfig's port mapping doesn't seem to be getting used anywhere
neither there is any documentation about it's usage. I only see port
configuration via ServiceConfig or via <image> configuration.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->