### PR TITLE
fix: Only assembled files are copied to 'Docker' build target directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ Usage:
 * Fix #639: Quotas for OpenShift BuildConfig not working
 * Fix #688: Multiple Custom Resources with same (different apiGroup) name can be added
 * Fix #689: Recreate and update of CustomResource fragments works
-* Fix: Helm charts can be generated for custom resources, even those with same name (different apiGroup)
+* Fix #690: Helm charts can be generated for custom resources, even those with same name (different apiGroup)
 * Fix #676: Define Helm Chart dependencies
+* Fix #590: Only assembled files are copied to 'Docker' build target directory
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/jkube-kit/build/api/pom.xml
+++ b/jkube-kit/build/api/pom.xml
@@ -50,6 +50,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.jkube</groupId>
+      <artifactId>jkube-kit-common-test</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
+++ b/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
@@ -490,7 +490,7 @@ public class AssemblyManager {
     private static List<String> createDockerExcludesList(File directory, String outputDirectory) throws IOException {
         List<String> excludes = new ArrayList<>();
         // Output directory will be always excluded
-        excludes.add(outputDirectory);
+        excludes.add(String.format("%s{/**,}", outputDirectory));
         for (String dockerConfigFile : new String[] { DOCKER_EXCLUDE, DOCKER_IGNORE } ) {
             File dockerIgnore = new File(directory, dockerConfigFile);
             if (dockerIgnore.exists()) {

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManagerCreateDockerTarArchiveTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManagerCreateDockerTarArchiveTest.java
@@ -17,12 +17,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import org.eclipse.jkube.kit.common.Assembly;
 import org.eclipse.jkube.kit.common.AssemblyConfiguration;
@@ -30,11 +28,11 @@ import org.eclipse.jkube.kit.common.AssemblyFile;
 import org.eclipse.jkube.kit.common.AssemblyFileEntry;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.PrefixedLogger;
+import org.eclipse.jkube.kit.common.assertj.FileAssertions;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.image.build.JKubeConfiguration;
 
 import mockit.Mocked;
-import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.AbstractFileAssert;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.ListAssert;
@@ -335,12 +333,7 @@ public class AssemblyManagerCreateDockerTarArchiveTest {
 
   private AbstractListAssert<ListAssert<String>, List<? extends String>, String, ObjectAssert<String>> assertBuildDirectoryFileTree(
       String imageDirName) throws IOException {
-    final Path buildPath = resolveDockerBuild(imageDirName);
-    return assertThat(Files.walk(buildPath)
-        .map(buildPath::relativize)
-        .map(Path::toString)
-        .filter(StringUtils::isNotBlank)
-        .collect(Collectors.toList()));
+    return FileAssertions.assertThat(resolveDockerBuild(imageDirName).toFile()).fileTree();
   }
 
   private static void writeLineToFile(File file, String line) throws IOException {

--- a/jkube-kit/common-test/src/main/java/org/eclipse/jkube/kit/common/assertj/FileAssertions.java
+++ b/jkube-kit/common-test/src/main/java/org/eclipse/jkube/kit/common/assertj/FileAssertions.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.assertj;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.AbstractFileAssert;
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
+
+public class FileAssertions extends AbstractFileAssert<FileAssertions> {
+
+  public FileAssertions(File actual) {
+    super(actual, FileAssertions.class);
+  }
+
+  public static FileAssertions assertThat(File file) {
+    return new FileAssertions(file);
+  }
+
+  public AbstractListAssert<ListAssert<String>, List<? extends String>, String, ObjectAssert<String>> fileTree()
+      throws IOException {
+
+    final Path actualPath = actual.toPath().normalize();
+    final List<String> paths = new ArrayList<>();
+    try (Stream<Path> pathStream = Files.walk(actualPath)) {
+      for (Path temp : pathStream.filter(p -> !p.equals(actualPath)).collect(Collectors.toList())) {
+        paths.add(actualPath.relativize(temp.normalize().toRealPath()).toString());
+      }
+    }
+    return org.assertj.core.api.Assertions.assertThat(paths);
+  }
+}

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileSetUtilsExcludesTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileSetUtilsExcludesTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.archive;
+
+import org.eclipse.jkube.kit.common.AssemblyFileSet;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AssemblyFileSetUtilsExcludesTest {
+
+  private List<Path> paths;
+
+  @Before
+  public void setUp() throws Exception {
+    paths = Arrays.asList(
+        Paths.get("usr", "bin"),
+        Paths.get("usr", ".git"),
+        Paths.get("var", ".git", "refs"),
+        Paths.get("var", ".git", "..", "normalized")
+    );
+  }
+
+  @Test
+  public void isNotExcluded_withNoExcludes() {
+    // Given
+    final AssemblyFileSet afs = AssemblyFileSet.builder().build();
+    // When
+    final List<Path> filtered = paths.stream()
+        .filter(AssemblyFileSetUtils.isNotExcluded(Paths.get(""), afs))
+        .collect(Collectors.toList());
+    // Then
+    assertThat(filtered).isNotEmpty().containsExactlyInAnyOrder(
+        Paths.get("usr", "bin"),
+        Paths.get("usr", ".git"),
+        Paths.get("var", ".git", "refs"),
+        Paths.get("var", ".git", "..", "normalized")
+    );
+  }
+
+  @Test
+  public void isNotExcluded_withExcludes() {
+    // Given
+    final AssemblyFileSet afs = AssemblyFileSet.builder()
+        .exclude("**/.git/**")
+        .exclude("**/other/**")
+        .build();
+    // When
+    final List<Path> filtered = paths.stream()
+        .filter(AssemblyFileSetUtils.isNotExcluded(Paths.get(""), afs))
+        .collect(Collectors.toList());
+    // Then
+    assertThat(filtered).isNotEmpty().containsExactlyInAnyOrder(
+        Paths.get("usr", "bin"),
+        Paths.get("usr", ".git"),
+        Paths.get("var", ".git", "..", "normalized")
+    );
+  }
+
+}


### PR DESCRIPTION
## Description
fix: Only assembled files are copied to 'Docker' build target directory
- Increase in performance
- Avoids problems with excluded .git directories

Fixes (tentatively) #590

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->