### PR TITLE
Refactor and document new Enricher changes

### DIFF
--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/BaseEnricher.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/BaseEnricher.java
@@ -54,6 +54,7 @@ public class BaseEnricher implements Enricher {
     private static final String SWITCH_TO_DEPLOYMENT = "jkube.build.switchToDeployment";
     public static final String CREATE_EXTERNAL_URLS = "jkube.createExternalUrls";
     public static final String JKUBE_DOMAIN = "jkube.domain";
+    public static final String JKUBE_ENFORCED_REPLICAS = "jkube.replicas";
 
     protected KitLogger log;
 
@@ -211,8 +212,8 @@ public class BaseEnricher implements Enricher {
      * @param defaultValue default value if not defined (true or false)
      * @return property value
      */
-    protected boolean getValueFromConfig(String propertyName, Boolean defaultValue) {
-        return Boolean.parseBoolean(getValueFromConfig(propertyName, defaultValue.toString()));
+    protected boolean getValueFromConfig(String propertyName, boolean defaultValue) {
+        return Boolean.parseBoolean(getValueFromConfig(propertyName, Boolean.toString(defaultValue)));
     }
 
     protected boolean useDeploymentForOpenShift() {

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ControllerHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ControllerHandler.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.kit.enricher.handler;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
@@ -25,4 +26,6 @@ public interface ControllerHandler<T extends HasMetadata> {
   T get(ResourceConfig config, List<ImageConfiguration> images);
 
   PodTemplateSpec getPodTemplateSpec(ResourceConfig config, List<ImageConfiguration> images);
+
+  void overrideReplicas(KubernetesListBuilder resources, int replicas);
 }

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DaemonSetHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DaemonSetHandler.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.kit.enricher.handler;
 
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -48,6 +49,11 @@ public class DaemonSetHandler implements ControllerHandler<DaemonSet> {
   @Override
   public PodTemplateSpec getPodTemplateSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return get(config, images).getSpec().getTemplate();
+  }
+
+  @Override
+  public void overrideReplicas(KubernetesListBuilder resources, int replicas) {
+    // NOOP
   }
 
   private ObjectMeta createDaemonSetMetaData(ResourceConfig config) {

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DeploymentConfigHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DeploymentConfigHandler.java
@@ -24,27 +24,23 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
-import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
-import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
-import io.fabric8.kubernetes.api.model.apps.ReplicaSetSpec;
-import io.fabric8.kubernetes.api.model.apps.ReplicaSetSpecBuilder;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import io.fabric8.openshift.api.model.DeploymentConfigSpec;
+import io.fabric8.openshift.api.model.DeploymentConfigSpecBuilder;
 
-/**
- * @author roland
- */
-public class ReplicaSetHandler implements ControllerHandler<ReplicaSet> {
-
+public class DeploymentConfigHandler implements ControllerHandler<DeploymentConfig> {
   private final PodTemplateHandler podTemplateHandler;
 
-  ReplicaSetHandler(PodTemplateHandler podTemplateHandler) {
+  DeploymentConfigHandler(PodTemplateHandler podTemplateHandler) {
     this.podTemplateHandler = podTemplateHandler;
   }
 
   @Override
-  public ReplicaSet get(ResourceConfig config, List<ImageConfiguration> images) {
-    return new ReplicaSetBuilder()
-        .withMetadata(createRsMetaData(config))
-        .withSpec(createSpec(config, images))
+  public DeploymentConfig get(ResourceConfig config, List<ImageConfiguration> images) {
+    return new DeploymentConfigBuilder()
+        .withMetadata(createMetaData(config))
+        .withSpec(createDeploymentConfigSpec(config, images))
         .build();
   }
 
@@ -55,22 +51,22 @@ public class ReplicaSetHandler implements ControllerHandler<ReplicaSet> {
 
   @Override
   public void overrideReplicas(KubernetesListBuilder resources, int replicas) {
-    resources.accept(new TypedVisitor<ReplicaSetBuilder>() {
+    resources.accept(new TypedVisitor<DeploymentConfigBuilder>() {
       @Override
-      public void visit(ReplicaSetBuilder builder) {
+      public void visit(DeploymentConfigBuilder builder) {
         builder.editOrNewSpec().withReplicas(replicas).endSpec();
       }
     });
   }
 
-  private ObjectMeta createRsMetaData(ResourceConfig config) {
+  private ObjectMeta createMetaData(ResourceConfig config) {
     return new ObjectMetaBuilder()
         .withName(KubernetesHelper.validateKubernetesId(config.getControllerName(), "controller name"))
         .build();
   }
 
-  private ReplicaSetSpec createSpec(ResourceConfig config, List<ImageConfiguration> images) {
-    return new ReplicaSetSpecBuilder()
+  private DeploymentConfigSpec createDeploymentConfigSpec(ResourceConfig config, List<ImageConfiguration> images) {
+    return new DeploymentConfigSpecBuilder()
         .withReplicas(config.getReplicas())
         .withTemplate(podTemplateHandler.getPodTemplate(config, images))
         .build();

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DeploymentHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DeploymentHandler.java
@@ -19,6 +19,8 @@ import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -45,6 +47,16 @@ public class DeploymentHandler implements ControllerHandler<Deployment> {
   @Override
   public PodTemplateSpec getPodTemplateSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return get(config, images).getSpec().getTemplate();
+  }
+
+  @Override
+  public void overrideReplicas(KubernetesListBuilder resources, int replicas) {
+    resources.accept(new TypedVisitor<DeploymentBuilder>() {
+      @Override
+      public void visit(DeploymentBuilder builder) {
+        builder.editOrNewSpec().withReplicas(replicas).endSpec();
+      }
+    });
   }
 
   private ObjectMeta createDeploymentMetaData(ResourceConfig config) {

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/HandlerHub.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/HandlerHub.java
@@ -17,6 +17,8 @@ package org.eclipse.jkube.kit.enricher.handler;
 import org.eclipse.jkube.kit.common.util.LazyBuilder;
 import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -27,6 +29,7 @@ public class HandlerHub {
 
     private final PodTemplateHandler podTemplateHandler;
     private final LazyBuilder<DeploymentHandler> deploymentHandler;
+    private final LazyBuilder<DeploymentConfigHandler> deploymentConfigHandler;
     private final LazyBuilder<ReplicaSetHandler> replicaSetHandler;
     private final LazyBuilder<ReplicationControllerHandler> replicationControllerHandler;
     private final LazyBuilder<StatefulSetHandler> statefulSetHandler;
@@ -41,6 +44,7 @@ public class HandlerHub {
         ContainerHandler containerHandler = new ContainerHandler(configuration, groupArtifactVersion, probeHandler);
         podTemplateHandler = new PodTemplateHandler(containerHandler);
         deploymentHandler = new LazyBuilder<>(() -> new DeploymentHandler(podTemplateHandler));
+        deploymentConfigHandler = new LazyBuilder<>(() -> new DeploymentConfigHandler(podTemplateHandler));
         replicaSetHandler = new LazyBuilder<>(() -> new ReplicaSetHandler(podTemplateHandler));
         replicationControllerHandler = new LazyBuilder<>(() -> new ReplicationControllerHandler(podTemplateHandler));
         statefulSetHandler = new LazyBuilder<>(() -> new StatefulSetHandler(podTemplateHandler));
@@ -51,8 +55,23 @@ public class HandlerHub {
         serviceHandler = new LazyBuilder<>(ServiceHandler::new);
     }
 
+    public List<? extends ControllerHandler<?>> getControllerHandlers() {
+        return Arrays.asList(
+            getDaemonSetHandler(),
+            getDeploymentConfigHandler(),
+            getDeploymentHandler(),
+            getJobHandler(),
+            getReplicaSetHandler(),
+            getReplicationControllerHandler(),
+            getStatefulSetHandler()
+        );
+    }
     public DeploymentHandler getDeploymentHandler() {
         return deploymentHandler.get();
+    }
+
+    public DeploymentConfigHandler getDeploymentConfigHandler() {
+        return deploymentConfigHandler.get();
     }
 
     public ReplicaSetHandler getReplicaSetHandler() {

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/JobHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/JobHandler.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.kit.enricher.handler;
 
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -50,6 +51,11 @@ public class JobHandler implements ControllerHandler<Job> {
   @Override
   public PodTemplateSpec getPodTemplateSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return get(config, images).getSpec().getTemplate();
+  }
+
+  @Override
+  public void overrideReplicas(KubernetesListBuilder resources, int replicas) {
+    // NOOP
   }
 
   private ObjectMeta createJobSpecMetaData(ResourceConfig config) {

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/PodTemplateHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/PodTemplateHandler.java
@@ -30,7 +30,6 @@ import java.util.List;
 
 /**
  * @author roland
- * @since 08/04/16
  */
 public class PodTemplateHandler {
 
@@ -42,14 +41,13 @@ public class PodTemplateHandler {
 
     public PodTemplateSpec getPodTemplate(ResourceConfig config, List<ImageConfiguration> images)  {
         return new PodTemplateSpecBuilder()
-            .withMetadata(createPodMetaData(config))
+            .withMetadata(createPodMetaData())
             .withSpec(createPodSpec(config, images))
             .build();
     }
 
-    private ObjectMeta createPodMetaData(ResourceConfig config) {
-        return new ObjectMetaBuilder()
-            .build();
+    private ObjectMeta createPodMetaData() {
+        return new ObjectMetaBuilder().build();
     }
 
     private PodSpec createPodSpec(ResourceConfig config, List<ImageConfiguration> images) {

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ReplicationControllerHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ReplicationControllerHandler.java
@@ -13,6 +13,14 @@
  */
 package org.eclipse.jkube.kit.enricher.handler;
 
+import java.util.List;
+
+import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
+
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -20,11 +28,6 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerSpec;
 import io.fabric8.kubernetes.api.model.ReplicationControllerSpecBuilder;
-import org.eclipse.jkube.kit.config.image.ImageConfiguration;
-import org.eclipse.jkube.kit.config.resource.ResourceConfig;
-import org.eclipse.jkube.kit.common.util.KubernetesHelper;
-
-import java.util.List;
 
 /**
  * @author roland
@@ -50,7 +53,16 @@ public class ReplicationControllerHandler implements ControllerHandler<Replicati
     return get(config, images).getSpec().getTemplate();
   }
 
-  // ===========================================================
+  @Override
+  public void overrideReplicas(KubernetesListBuilder resources, int replicas) {
+    resources.accept(new TypedVisitor<ReplicationControllerBuilder>() {
+      @Override
+      public void visit(ReplicationControllerBuilder builder) {
+        builder.editOrNewSpec().withReplicas(replicas).endSpec();
+      }
+    });
+  }
+// ===========================================================
   // TODO: "replica set" config used
 
   private ObjectMeta createRcMetaData(ResourceConfig config) {

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/StatefulSetHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/StatefulSetHandler.java
@@ -13,6 +13,14 @@
  */
 package org.eclipse.jkube.kit.enricher.handler;
 
+import java.util.List;
+
+import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
+
+import io.fabric8.kubernetes.api.builder.TypedVisitor;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
@@ -20,11 +28,6 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetSpecBuilder;
-import org.eclipse.jkube.kit.config.image.ImageConfiguration;
-import org.eclipse.jkube.kit.config.resource.ResourceConfig;
-import org.eclipse.jkube.kit.common.util.KubernetesHelper;
-
-import java.util.List;
 
 /**
  * Handler for StatefulSets
@@ -50,6 +53,16 @@ public class StatefulSetHandler implements ControllerHandler<StatefulSet> {
   @Override
   public PodTemplateSpec getPodTemplateSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return get(config, images).getSpec().getTemplate();
+  }
+
+  @Override
+  public void overrideReplicas(KubernetesListBuilder resources, int replicas) {
+    resources.accept(new TypedVisitor<StatefulSetBuilder>() {
+      @Override
+      public void visit(StatefulSetBuilder builder) {
+        builder.editOrNewSpec().withReplicas(replicas).endSpec();
+      }
+    });
   }
 
   private ObjectMeta createStatefulSetMetaData(ResourceConfig config) {

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/DeploymentConfigHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/DeploymentConfigHandlerTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.enricher.handler;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
+
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import org.assertj.core.groups.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class DeploymentConfigHandlerTest {
+
+  private ResourceConfig.ResourceConfigBuilder resourceConfigBuilder;
+  private DeploymentConfigHandler deploymentConfigHandler;
+
+  @Before
+  public void before(){
+    resourceConfigBuilder = ResourceConfig.builder();
+    deploymentConfigHandler = new DeploymentConfigHandler(new PodTemplateHandler(new ContainerHandler(new Properties(),
+        new GroupArtifactVersion("g", "a", "v"), new ProbeHandler())));
+  }
+
+  @Test
+  public void get_withNoImagesAndNoControllerName_shouldThrowException() {
+    // Given
+    final ResourceConfig resourceConfig = resourceConfigBuilder.build();
+    final List<ImageConfiguration> images = Collections.emptyList();
+    // When
+    final IllegalArgumentException result = assertThrows(IllegalArgumentException.class,
+        () -> deploymentConfigHandler.get(resourceConfig, images));
+    // Then
+    assertThat(result).hasMessage("No controller name is specified!");
+  }
+
+  @Test
+  public void get_withNoImages_shouldReturnConfigWithNoContainers() {
+    // Given
+    final ResourceConfig resourceConfig = resourceConfigBuilder.controllerName("controller").build();
+    final List<ImageConfiguration> images = Collections.emptyList();
+    // When
+    final DeploymentConfig result = deploymentConfigHandler.get(resourceConfig, images);
+    // Then
+    assertThat(result)
+        .hasFieldOrPropertyWithValue("metadata.name", "controller")
+        .extracting("spec.template.spec.containers").asList().isEmpty();
+  }
+
+  @Test
+  public void get_withImages_shouldReturnConfigWithContainers() {
+    // Given
+    final ResourceConfig resourceConfig = resourceConfigBuilder.controllerName("controller").build();
+    final List<ImageConfiguration> images = Arrays.asList(
+        ImageConfiguration.builder().name("busybox").build(BuildConfiguration.builder().build()).build(),
+        ImageConfiguration.builder().name("jkubeio/java:latest").build(BuildConfiguration.builder().build()).build()
+    );
+    // When
+    final DeploymentConfig result = deploymentConfigHandler.get(resourceConfig, images);
+    // Then
+    assertThat(result)
+        .hasFieldOrPropertyWithValue("metadata.name", "controller")
+        .extracting("spec.template.spec.containers").asList().hasSize(2)
+        .extracting("image", "name")
+        .containsExactly(new Tuple("busybox:latest", "g-a"), new Tuple("jkubeio/java:latest", "jkubeio-a"));
+  }
+
+  @Test
+  public void getPodTemplateSpec_withNoImages_shouldReturnPodTemplateSpecWithNoContainers() {
+    // Given
+    final ResourceConfig resourceConfig = resourceConfigBuilder.controllerName("controller").build();
+    final List<ImageConfiguration> images = Collections.emptyList();
+    // When
+    final PodTemplateSpec result = deploymentConfigHandler.getPodTemplateSpec(resourceConfig, images);
+    // Then
+    assertThat(result).extracting("spec.containers").asList().isEmpty();
+  }
+
+  @Test
+  public void overrideReplicas() {
+    // Given
+    final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(new DeploymentConfigBuilder()
+        .editOrNewSpec().withReplicas(1).endSpec()
+        .build());
+    // When
+    deploymentConfigHandler.overrideReplicas(klb, 1337);
+    // Then
+    assertThat(klb.buildItems())
+        .hasSize(1)
+        .first().hasFieldOrPropertyWithValue("spec.replicas", 1337);
+  }
+}

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/DeploymentHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/DeploymentHandlerTest.java
@@ -13,20 +13,24 @@
  */
 package org.eclipse.jkube.kit.enricher.handler;
 
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
-import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.resource.VolumeConfig;
+
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import mockit.Mocked;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -47,6 +51,8 @@ public class DeploymentHandlerTest {
     List<String> ports = new ArrayList<>();
 
     List<String> tags = new ArrayList<>();
+
+    private DeploymentHandler deploymentHandler;
 
     @Before
     public void before(){
@@ -75,17 +81,13 @@ public class DeploymentHandlerTest {
                 .registry("docker.io").build();
 
         images.add(imageConfiguration);
+
+        deploymentHandler = new DeploymentHandler(new PodTemplateHandler(new ContainerHandler(project.getProperties(),
+            new GroupArtifactVersion("g", "a", "v"), probeHandler)));
     }
 
     @Test
     public void deploymentTemplateHandlerTest() {
-
-        ContainerHandler containerHandler = getContainerHandler();
-
-        PodTemplateHandler podTemplateHandler = new PodTemplateHandler(containerHandler);
-
-        DeploymentHandler deploymentHandler = new DeploymentHandler(podTemplateHandler);
-
         ResourceConfig config = ResourceConfig.builder()
                 .imagePullPolicy("IfNotPresent")
                 .controllerName("testing")
@@ -113,20 +115,9 @@ public class DeploymentHandlerTest {
 
     }
 
-    private ContainerHandler getContainerHandler() {
-        return new ContainerHandler(project.getProperties(), new GroupArtifactVersion("g","a","v"), probeHandler);
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void deploymentTemplateHandlerWithInvalidNameTest() {
-        //invalid controller name
-        ContainerHandler containerHandler = getContainerHandler();
-
-        PodTemplateHandler podTemplateHandler = new PodTemplateHandler(containerHandler);
-
-        DeploymentHandler deploymentHandler = new DeploymentHandler(podTemplateHandler);
-
-        //with invalid controller name
+        // with invalid controller name
         ResourceConfig config = ResourceConfig.builder()
                 .imagePullPolicy("IfNotPresent")
                 .controllerName("TesTing")
@@ -140,14 +131,7 @@ public class DeploymentHandlerTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void deploymentTemplateHandlerWithoutControllerTest() {
-        //without controller name
-        ContainerHandler containerHandler = getContainerHandler();
-
-        PodTemplateHandler podTemplateHandler = new PodTemplateHandler(containerHandler);
-
-        DeploymentHandler deploymentHandler = new DeploymentHandler(podTemplateHandler);
-
-        //without controller name
+        // without controller name
         ResourceConfig config = ResourceConfig.builder()
                 .imagePullPolicy("IfNotPresent")
                 .serviceAccount("test-account")
@@ -156,5 +140,19 @@ public class DeploymentHandlerTest {
                 .build();
 
         deploymentHandler.get(config, images);
+    }
+
+    @Test
+    public void overrideReplicas() {
+        // Given
+        final KubernetesListBuilder klb = new KubernetesListBuilder().addToItems(new DeploymentBuilder()
+            .editOrNewSpec().withReplicas(1).endSpec()
+            .build());
+        // When
+        deploymentHandler.overrideReplicas(klb, 1337);
+        // Then
+        assertThat(klb.buildItems())
+            .hasSize(1)
+            .first().hasFieldOrPropertyWithValue("spec.replicas", 1337);
     }
 }

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/HandlerHubControllerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/HandlerHubControllerTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.enricher.handler;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HandlerHubControllerTest {
+
+  private HandlerHub handlerHub;
+
+  @Before
+  public void setUp() throws Exception {
+    handlerHub = new HandlerHub(new GroupArtifactVersion("com.example", "artifact", "1.33.7"), new Properties());
+  }
+
+  @Test
+  public void getControllerHandlers_shouldReturnAllImplementationsOfControllerHandler() {
+    // When
+    final List<? extends ControllerHandler<?>> result = handlerHub.getControllerHandlers();
+    // Then
+    assertThat(result)
+        .hasSize(7)
+        .flatExtracting(Object::getClass)
+        .containsExactlyInAnyOrder(
+            DaemonSetHandler.class,
+            DeploymentConfigHandler.class,
+            DeploymentHandler.class,
+            JobHandler.class,
+            ReplicaSetHandler.class,
+            ReplicationControllerHandler.class,
+            StatefulSetHandler.class
+        );
+  }
+
+}

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/HandlerHubTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/HandlerHubTest.java
@@ -34,6 +34,7 @@ public class HandlerHubTest {
   public static Collection<Function<HandlerHub, Supplier<Object>>> data() {
     return Arrays.asList(
         hh -> hh::getDeploymentHandler,
+        hh -> hh::getDeploymentConfigHandler,
         hh -> hh::getReplicaSetHandler,
         hh -> hh::getReplicationControllerHandler,
         hh -> hh::getStatefulSetHandler,

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
@@ -76,6 +76,8 @@ public class DefaultControllerEnricher extends BaseEnricher {
     }
 
     private static ControllerType fromType(String type) {
+      // There's no DEPLOYMENTCONFIG entry since it will be taken care of by DeploymentConfigEnricher
+      // where the resulting Deployment is converted to a DeploymentConfig
       switch (Optional.ofNullable(type).orElse("").toUpperCase(Locale.ENGLISH)) {
         case "STATEFULSET":
           return STATEFUL_SET;

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricher.java
@@ -32,15 +32,12 @@ import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 import org.eclipse.jkube.kit.enricher.handler.HandlerHub;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 public class DefaultNamespaceEnricher extends BaseEnricher {
 
     private static final String NAMESPACE = "namespace";
     protected static final String[] NAMESPACE_KINDS = {"Project", "Namespace" };
-    protected static final List<String> NAMESPACE_KINDS_LIST = Arrays.asList(NAMESPACE_KINDS);
 
     private final HandlerHub handlerHub;
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -82,7 +82,7 @@ This plugin comes with a set of default enrichers. In addition custom enrichers 
 | Add a default name to every object which misses a name.
 
 | <<jkube-namespace>>
-| Add specified _Namespace_ to Kubernetes resources metadata or create a new Namespace
+| Set the _Namespace_ of the generated and processed Kubernetes resources metadata and optionally create a new Namespace
 
 | <<jkube-pod-annotation>>
 | Copy over annotations from a `Deployment` to a `Pod`
@@ -95,6 +95,9 @@ This plugin comes with a set of default enrichers. In addition custom enrichers 
 
 | <<jkube-prometheus>>
 | Add Prometheus annotations.
+
+| <<jkube-replicas>>
+| Override number of replicas for any controller processed by JKube.
 
 | <<jkube-revision-history-enricher>>
 | Add revision history limit (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit[Kubernetes doc]) as a deployment spec property to the Kubernetes/OpenShift resources.
@@ -169,6 +172,8 @@ include::enricher/_jkube_openshift_autotls.adoc[]
 include::enricher/_jkube_project_label.adoc[]
 
 include::enricher/_jkube_prometheus.adoc[]
+
+include::enricher/_jkube_replicas.adoc[]
 
 include::enricher/_jkube_revision_history.adoc[]
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_namespace.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_namespace.adoc
@@ -1,7 +1,11 @@
 [[jkube-namespace]]
 ==== jkube-namespace
 
-This enricher adds `Namespace`/`Project` to Kubernetes Resources list or append an already existing `Namespace`/`Project` to all Kubernetes resources' in `.metadata` which are present during the enrichment phase.
+This enricher adds a `Namespace`/`Project` resource to the Kubernetes Resources list in case the namespace
+configuration (`jkube.enricher.jkube-namespace.namespace`) is provided.
+
+In addition, this enricher sets the namespace (`.metadata.namespace` ) of the JKube generated and processed Kubernetes
+resources in case they don't already have one configured (see the `force` configuration).
 
 The following configuration parameters can be used to influence the behaviour of this enricher:
 
@@ -12,7 +16,7 @@ The following configuration parameters can be used to influence the behaviour of
 | Element | Description | Property
 
 | *namespace*
-| Namespace as string which we want to create. A new `Namespace` object would be created and added to the list of Kubernetes resources generated during the enrichment phase.
+| Namespace as string which we want to create. A new `Namespace` object will be created and added to the list of Kubernetes resources generated during the enrichment phase.
 | `jkube.enricher.jkube-namespace.namespace`
 
 | *type*
@@ -20,6 +24,12 @@ The following configuration parameters can be used to influence the behaviour of
 
   Defaults to `Namespace`.
 | `jkube.enricher.jkube-namespace.type`
+
+| *force*
+| If the `.metadata.namespace` field must be forced even if the resource has already one configured.
+
+  Defaults to false.
+| `jkube.enricher.jkube-namespace.force`
 |===
 
 This enricher also configures generated Namespace in `.metadata.namespace` field for Kubernetes resources as per provided XML configuration too. Here is an example:

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_replicas.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_replicas.adoc
@@ -1,0 +1,27 @@
+
+[[jkube-replicas]]
+==== jkube-replicas
+
+This enricher overrides the number of replicas for *every* controller
+(_DaemonSet_, _Deployment_, _DeploymentConfig_, _Job_, _ReplicationController_, _ReplicaSet_, _StatefulSet_)
+generated or processed by JKube (including those from <<jkube-dependency, dependencies>>).
+
+In order to use this enricher you need to configure the `jkube.replicas` property:
+
+[source, sh, subs="+attributes"]
+----
+mvn -Djkube.replicas=42 {goal-prefix}:resource
+----
+
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+----
+<project>
+ <!-- ... -->
+  <properties>
+    <!-- ... -->
+     <jkube.replicas>42</jkube.replicas>
+  </properties>
+</project>
+----
+
+You can use this Enricher at runtime to temporarily force the number of replicas to a given value.

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -973,6 +973,6 @@ endif::[]
 
 | *replicas*
 | Number of replicas for the container.
-| `jkube.replicas`
+|
 
 |===

--- a/kubernetes-maven-plugin/it/src/it/dependency-resources/dependency/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/dependency-resources/dependency/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jkube</groupId>
+    <artifactId>jkube-maven-sample-dependency-resources</artifactId>
+    <version>0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jkube-maven-sample-dependency-resources-dependency</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <jkube.skip.resource>true</jkube.skip.resource>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kubernetes-maven-plugin/it/src/it/dependency-resources/dependency/src/main/resources/META-INF/jkube/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/dependency-resources/dependency/src/main/resources/META-INF/jkube/kubernetes.yml
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1
+  kind: ReplicaSet
+  metadata:
+    name: web
+    labels:
+      env: dev
+      role: web
+  spec:
+    replicas: 4
+    selector:
+      matchLabels:
+        role: web
+    template:
+      metadata:
+        labels:
+          role: web
+      spec:
+        containers:
+          - name: nginx
+            image: nginx

--- a/kubernetes-maven-plugin/it/src/it/dependency-resources/dependent/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/dependency-resources/dependent/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jkube</groupId>
+    <artifactId>jkube-maven-sample-dependency-resources</artifactId>
+    <version>0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jkube-maven-sample-dependency-resources-dependent</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <artifactId>jkube-maven-sample-dependency-resources-dependency</artifactId>
+      <groupId>org.eclipse.jkube</groupId>
+      <version>0.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kubernetes-maven-plugin/it/src/it/dependency-resources/dependent/src/main/jkube/example-deployment.yml
+++ b/kubernetes-maven-plugin/it/src/it/dependency-resources/dependent/src/main/jkube/example-deployment.yml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+spec:
+  template:
+    spec:
+      containers:
+        - image: busybox

--- a/kubernetes-maven-plugin/it/src/it/dependency-resources/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/dependency-resources/expected/kubernetes.yml
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: jkube-maven-sample-dependency-resources-dependent
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube
+    name: example
+  spec:
+    replicas: 1337
+    revisionHistoryLimit: 2
+    selector:
+      matchLabels:
+        app: jkube-maven-sample-dependency-resources-dependent
+        provider: jkube
+        group: org.eclipse.jkube
+    template:
+      metadata:
+        annotations:
+          jkube.io/git-url: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: jkube-maven-sample-dependency-resources-dependent
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube
+      spec:
+        containers:
+        - env:
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: busybox
+          name: jkube-maven-sample-dependency-resources-dependent
+- apiVersion: apps/v1
+  kind: ReplicaSet
+  metadata:
+    annotations:
+      image.openshift.io/triggers: "@ignore@"
+    labels:
+      env: dev
+      role: web
+    name: web
+  spec:
+    replicas: 1337
+    selector:
+      matchLabels:
+        role: web
+    template:
+      metadata:
+        labels:
+          role: web
+      spec:
+        containers:
+          - image: nginx
+            name: nginx

--- a/kubernetes-maven-plugin/it/src/it/dependency-resources/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/dependency-resources/invoker.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+invoker.goals.1=clean install k8s:resource
+invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/dependency-resources/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/dependency-resources/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>jkube-maven-sample-dependency-resources</artifactId>
+  <groupId>org.eclipse.jkube</groupId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>dependency</module>
+    <module>dependent</module>
+  </modules>
+
+  <properties>
+    <jkube.replicas>1337</jkube.replicas>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.jkube</groupId>
+          <artifactId>kubernetes-maven-plugin</artifactId>
+          <version>@jkube.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/kubernetes-maven-plugin/it/src/it/dependency-resources/verify.groovy
+++ b/kubernetes-maven-plugin/it/src/it/dependency-resources/verify.groovy
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+import org.eclipse.jkube.maven.it.Verify
+
+["kubernetes"].each {
+  Verify.verifyResourceDescriptors(
+          new File(basedir, sprintf("/dependent/target/classes/META-INF/jkube/%s.yml", it)),
+          new File(basedir, sprintf("/expected/%s.yml", it)), true) // strict checking
+}
+
+true

--- a/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -41,7 +41,6 @@
     - jkube-volume-permission
     - jkube-configmap-file
     - jkube-secret-file
-    - jkube-replicas
 
     # Route exposure
     - jkube-openshift-service-expose
@@ -77,6 +76,9 @@
     - jkube-docker-registry-secret
     - jkube-triggers-annotation
     - jkube-openshift-imageChangeTrigger
+
+    # ReplicaCountEnricher overrides .spec.replicas field of any resource (even dependencies)
+    - jkube-replicas
 
   generator:
     # The order given in "includes" is the order in which generators are called

--- a/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -41,7 +41,6 @@
     - jkube-volume-permission
     - jkube-configmap-file
     - jkube-secret-file
-    - jkube-replicas
 
     # Route exposure
     - jkube-openshift-service-expose
@@ -74,6 +73,9 @@
     - jkube-docker-registry-secret
     - jkube-triggers-annotation
     - jkube-openshift-imageChangeTrigger
+
+      # ReplicaCountEnricher overrides .spec.replicas field of any resource (even dependencies)
+    - jkube-replicas
 
   generator:
     # The order given in "includes" is the order in which generators are called


### PR DESCRIPTION
## Description

- Documented the `force` flag in `DefaultNamespaceEnricher`
- Refactored `ReplicaCountEnricher` to use Controller Handlers
  - Replicas are now overridden for the rest of (applicable) controllers
- Added Integration Test for case described in #658 (related to #640, [ENTESB-16172](https://issues.redhat.com/browse/ENTESB-16172))
-  Documented `ReplicaCountEnricher`

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->