### PR TITLE
Fix #704: NPE when using Service fragment with no port specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.4.0-SNAPSHOT
+* Fix #704: NPE when using Service fragment with no port specified
 * Fix #705: JIB assembly works on Windows
 
 ### 1.3.0

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricher.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class ServiceDiscoveryEnricher extends BaseEnricher {
     private static final String ENRICHER_NAME = "jkube-service-discovery";
@@ -97,6 +98,8 @@ public class ServiceDiscoveryEnricher extends BaseEnricher {
             List<ServicePort> ports = serviceBuilder.buildSpec().getPorts();
             if (! ports.isEmpty()) {
                 ServicePort firstServicePort = ports.iterator().next();
+                Objects.requireNonNull(firstServicePort.getPort(),
+                        String.format("Service %s .spec.ports[0].port: required value", serviceBuilder.buildMetadata().getName()));
                 port = firstServicePort.getPort().toString();
                 log.info("Using first mentioned service port '%s' " , port);
             } else {

--- a/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricherTest.java
+++ b/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricherTest.java
@@ -26,7 +26,10 @@ import mockit.Mocked;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.validation.constraints.Null;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ServiceDiscoveryEnricherTest {
 
@@ -113,6 +116,24 @@ public class ServiceDiscoveryEnricherTest {
     public void testSchemeAnnotation() {
         enricher.addAnnotations(builder);
         assertAnnotation(scheme, "scheme");
+    }
+
+    @Test
+    public void testServiceWithNullPort() {
+        // Given
+        ServiceBuilder serviceBuilder = new ServiceBuilder()
+                .withNewMetadata().withName("test-svc").endMetadata()
+                .withNewSpec()
+                .addNewPort()
+                .withName("foo")
+                .endPort()
+                .endSpec();
+
+        // When
+        NullPointerException npe = assertThrows(NullPointerException.class, () -> enricher.addAnnotations(serviceBuilder));
+
+        // Then
+        assertEquals("Service test-svc .spec.ports[0].port: required value", npe.getMessage());
     }
 
     private void assertAnnotation(String expectedValue, String annotation) {


### PR DESCRIPTION

## Description
Fix #704 
Add a user friendly message to NPE whenever Service Port is not provided
by user in fragment

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->