### PR TITLE
Fix #672: Add missing fields in ProbeConfig for configuring Readiness/Liveness Probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Usage:
 * Fix #741: Private constructor added to Utility classes
 * Fix #725: Upgrade HttpClient from 4.5.10 to 4.5.13
 * Fix #653: `k8s:watch` port-forward websocket error due to wrong arguments in PortForwardService
+* Fix #672: Add missing fields in ProbeConfig for configuring Readiness/Liveness Probes
 * Fix #704: NPE when using Service fragment with no port specified
 * Fix #705: JIB assembly works on Windows
 * Fix #714: feat: Helm support for Golang expressions

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -40,6 +40,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import io.fabric8.kubernetes.api.model.HTTPHeader;
 import org.eclipse.jkube.kit.common.GenericCustomResource;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.ResourceFileType;
@@ -955,6 +956,16 @@ public class KubernetesHelper {
         return findCrdForCustomResource(customResourceDefinitionList, customResource)
             .map(CustomResourceDefinitionContext::fromCrd)
             .orElse(null);
+    }
+
+    public static List<HTTPHeader> convertMapToHTTPHeaderList(Map<String, String> headers) {
+        List<HTTPHeader> httpHeaders = new ArrayList<>();
+        if (headers != null) {
+            for (Map.Entry<String, String> header : headers.entrySet()) {
+                httpHeaders.add(new HTTPHeader(header.getKey(), header.getValue()));
+            }
+        }
+        return httpHeaders;
     }
 
     private static Optional<CustomResourceDefinition> findCrdForCustomResource(CustomResourceDefinitionList crdList, GenericCustomResource gcr) {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.fabric8.kubernetes.api.model.HTTPHeader;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.eclipse.jkube.kit.common.GenericCustomResource;
 import org.eclipse.jkube.kit.common.KitLogger;
 
@@ -490,6 +492,26 @@ public class KubernetesHelperTest {
         CustomResourceDefinitionContext crdContext = KubernetesHelper.getCrdContext(crdList, genericCustomResource);
         // Then
         assertThat(crdContext).isNull();
+    }
+
+    @Test
+    public void testConvertMapToHTTPHeaderList() {
+        // Given
+        Map<String, String> headerAsMap = new HashMap<>();
+        headerAsMap.put("Accept", "application/json");
+        headerAsMap.put("User-Agent", "MyUserAgent");
+
+        // When
+        List<HTTPHeader> httpHeaders = KubernetesHelper.convertMapToHTTPHeaderList(headerAsMap);
+
+        // Then
+        assertThat(httpHeaders).isNotNull().hasSize(2)
+                .satisfies(h -> assertThat(h).element(0)
+                     .hasFieldOrPropertyWithValue("name", "Accept")
+                     .hasFieldOrPropertyWithValue("value", "application/json"))
+                .satisfies(h -> assertThat(h).element(1)
+                     .hasFieldOrPropertyWithValue("name", "User-Agent")
+                     .hasFieldOrPropertyWithValue("value", "MyUserAgent"));
     }
 
     private void assertLocalFragments(File[] fragments, int expectedSize) {

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ProbeConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ProbeConfig.java
@@ -19,6 +19,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
+
 /**
  * @author roland
  */
@@ -38,6 +40,10 @@ public class ProbeConfig {
      */
     private Integer timeoutSeconds;
     /**
+     * How often in seconds to perform the probe. Defaults to 10 seconds. Minimum value is 1.
+     */
+    private Integer periodSeconds;
+    /**
      * Command to execute for probing.
      */
     private String exec;
@@ -45,6 +51,11 @@ public class ProbeConfig {
      * Probe this URL.
      */
     private String getUrl;
+
+    /**
+     * Custom headers to set in the request.
+     */
+    private Map<String, String> httpHeaders;
     /**
      * TCP port to probe.
      */

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ProbeHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ProbeHandlerTest.java
@@ -13,10 +13,15 @@
  */
 package org.eclipse.jkube.kit.enricher.handler;
 
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.Probe;
 import org.eclipse.jkube.kit.config.resource.ProbeConfig;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -296,5 +301,51 @@ public class ProbeHandlerTest {
                 .build();
 
         probe = probeHandler.getProbe(probeConfig);
+    }
+
+    @Test
+    public void testHttpGetProbeWithLocalhostInUrl() {
+        // Given
+        probeConfig = ProbeConfig.builder()
+                .getUrl("http://:8080/healthz")
+                .build();
+
+        // When
+        probe = probeHandler.getProbe(probeConfig);
+
+        // Then
+        assertThat(probe)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("httpGet.host", "")
+                .hasFieldOrPropertyWithValue("httpGet.scheme", "HTTP")
+                .hasFieldOrPropertyWithValue("httpGet.port", new IntOrString(8080));
+    }
+
+    @Test
+    public void testHttpGetProbeWithCustomHeaders() {
+        // Given
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Accept", "application/json");
+        headers.put("User-Agent", "MyUserAgent");
+        probeConfig = ProbeConfig.builder()
+                .getUrl("https://www.example.com:8080/healthz")
+                .httpHeaders(headers)
+                .build();
+
+        // When
+        probe = probeHandler.getProbe(probeConfig);
+
+        // Then
+        assertThat(probe)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("httpGet.host", "www.example.com")
+                .hasFieldOrPropertyWithValue("httpGet.port", new IntOrString(8080))
+                .hasFieldOrPropertyWithValue("httpGet.scheme", "HTTPS")
+                .satisfies(p -> assertThat(p).extracting("httpGet.httpHeaders").asList().element(0)
+                       .hasFieldOrPropertyWithValue("name", "Accept")
+                       .hasFieldOrPropertyWithValue("value", "application/json"))
+                .satisfies(p -> assertThat(p).extracting("httpGet.httpHeaders").asList().element(1)
+                       .hasFieldOrPropertyWithValue("name", "User-Agent")
+                       .hasFieldOrPropertyWithValue("value", "MyUserAgent"));
     }
 }

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
@@ -317,7 +317,7 @@ An extract of the plugin configuration is shown below:
     </configMap>
 
     <liveness> <!--13-->
-      <getUrl>http://localhost:8080/q/health</getUrl>
+      <getUrl>http://:8080/q/health</getUrl>
       <initialDelaySeconds>3</initialDelaySeconds>
       <timeoutSeconds>3</timeoutSeconds>
     </liveness>

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -138,7 +138,7 @@ By default Deployment is generated in Kubernetes mode. You can easily configure 
         <imagePullPolicy>Always</imagePullPolicy> <!--4-->
         <replicas>3</replicas> <!--5-->
         <liveness> <!--6-->
-            <getUrl>http://localhost:8080/q/health</getUrl>
+            <getUrl>http://:8080/q/health</getUrl>
             <tcpPort>8080</tcpPort>
             <initialDelaySeconds>3</initialDelaySeconds>
             <timeoutSeconds>3</timeoutSeconds>
@@ -219,7 +219,17 @@ Probe configuration is used for configuring https://kubernetes.io/docs/tasks/con
 | Command to execute for probing.
 
 | `getUrl`
-| Probe this URL.
+| Probe URL for HTTP Probe. Configures HTTP probe fields like `host`, `scheme`, `path` etc by parsing URL. For example, a `<getUrl>http://:8080/health</getUrl>` would result in probe generated with fields set like this:
+
+  host: ""
+
+  path: /health
+
+  port: 8080
+
+  scheme: HTTP
+
+Host name with empty value defaults to Pod IP. You probably want to set "Host" in httpHeaders instead.
 
 | `tcpPort`
 | TCP port to probe.
@@ -229,6 +239,12 @@ Probe configuration is used for configuring https://kubernetes.io/docs/tasks/con
 
 | `successThreshold`
 |  Minimum consecutive successes for the probe to be considered successful after having failed.
+
+|  `httpHeaders`
+| Custom headers to set in the request.
+
+| `periodSeconds`
+| How often in seconds to perform the probe. Defaults to 10 seconds. Minimum value is 1.
 |===
 
 [[volume-xml-configuration]]

--- a/kubernetes-maven-plugin/it/src/it/probes-xml-config/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/probes-xml-config/expected/kubernetes.yml
@@ -1,0 +1,124 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      jkube.io/git-commit: "@ignore@"
+      prometheus.io/scrape: "true"
+      jkube.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+    labels:
+      expose: "true"
+      provider: jkube
+      app: jkube-maven-sample-xml-probe-config
+      version: "@ignore@"
+      group: org.eclipse.jkube
+    name: jkube-maven-sample-xml-probe-config
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: jkube-maven-sample-xml-probe-config
+      provider: jkube
+      group: org.eclipse.jkube
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      provider: jkube
+      app: jkube-maven-sample-xml-probe-config
+      version: "@ignore@"
+      group: org.eclipse.jkube
+    name: jkube-maven-sample-xml-probe-config
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: jkube-maven-sample-xml-probe-config
+        provider: jkube
+        group: org.eclipse.jkube
+    template:
+      metadata:
+        annotations:
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          provider: jkube
+          app: jkube-maven-sample-xml-probe-config
+          version: "@ignore@"
+          group: org.eclipse.jkube
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: "@matches('jkube/jkube-maven-sample-xml-probe-config:.*$')@"
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false
+          readinessProbe:
+            failureThreshold: 1
+            httpGet:
+              httpHeaders:
+              - name: Accept
+                value: application/json
+              - name: User-agent
+                value: MyUserAgent
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10  
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              httpHeaders:
+              - name: Accept
+                value: application/json
+              - name: User-agent
+                value: MyUserAgent
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10    

--- a/kubernetes-maven-plugin/it/src/it/probes-xml-config/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/probes-xml-config/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+invoker.goals.1=clean k8s:resource
+invoker.mavenOpts=-Djkube.verbose
+invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/probes-xml-config/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/probes-xml-config/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>jkube-maven-sample-xml-probe-config</artifactId>
+  <groupId>org.eclipse.jkube</groupId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>1.3.6.RELEASE</version>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+        <version>@jkube.version@</version>
+        <configuration>
+          <resources>
+            <liveness>
+              <initialDelaySeconds>0</initialDelaySeconds>
+              <timeoutSeconds>10</timeoutSeconds>
+              <periodSeconds>30</periodSeconds>
+              <failureThreshold>1</failureThreshold>
+              <successThreshold>1</successThreshold>
+              <getUrl>http://:8080/actuator/health</getUrl>
+              <httpHeaders>
+                <Accept>application/json</Accept>
+                <User-agent>MyUserAgent</User-agent>
+              </httpHeaders>
+            </liveness>
+            <readiness>
+              <initialDelaySeconds>0</initialDelaySeconds>
+              <timeoutSeconds>10</timeoutSeconds>
+              <periodSeconds>30</periodSeconds>
+              <failureThreshold>1</failureThreshold>
+              <successThreshold>1</successThreshold>
+              <getUrl>http://:8080/actuator/health</getUrl>
+              <httpHeaders>
+                <Accept>application/json</Accept>
+                <User-agent>MyUserAgent</User-agent>
+              </httpHeaders>
+            </readiness>
+          </resources>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/kubernetes-maven-plugin/it/src/it/probes-xml-config/src/main/java/probe/Application.java
+++ b/kubernetes-maven-plugin/it/src/it/probes-xml-config/src/main/java/probe/Application.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package zero;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/kubernetes-maven-plugin/it/src/it/probes-xml-config/src/main/java/probe/HelloController.java
+++ b/kubernetes-maven-plugin/it/src/it/probes-xml-config/src/main/java/probe/HelloController.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package zero;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @RequestMapping("/")
+    public String index() {
+        return "Greetings from Spring Boot!";
+    }
+
+}

--- a/kubernetes-maven-plugin/it/src/it/probes-xml-config/verify.groovy
+++ b/kubernetes-maven-plugin/it/src/it/probes-xml-config/verify.groovy
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+import org.eclipse.jkube.maven.it.Verify
+
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertNull;
+
+[ "kubernetes"   ].each {
+  Verify.verifyResourceDescriptors(
+          new File(basedir, sprintf("/target/classes/META-INF/jkube/%s.yml",it)),
+          new File(basedir, sprintf("/expected/%s.yml",it)))
+}
+
+Map selector = Verify.readWithPath(
+        new File(basedir,"/target/classes/META-INF/jkube/kubernetes/jkube-maven-sample-xml-probe-config-deployment.yml"),
+        "spec.selector.matchLabels")
+
+assertNotNull(selector)
+assertNull(selector.get("version"))
+
+true


### PR DESCRIPTION
## Description
Fix #672 
+ Add missing fields in ProbeConfig for configuring liveness/readiness
+ Added a check to keep host null in case it matches localhost


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->