### PR TITLE
Fix #548: Define property for skipping cluster autodetect/offline mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Usage:
 * Fix #714: feat: Helm support for Golang expressions
 * Port fabric8io/docker-maven-plugin#1318: Update ECR autorization token URL
 * Fix #710: Support DockerImage as output for Openshift builds
+* Fix #548: Define property for skipping cluster autodetect/offline mode
 
 ### 1.3.0
 * Fix #497: Assembly descriptor removed but still in documentation

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -975,4 +975,10 @@ endif::[]
 | Number of replicas for the container.
 |
 
+| *offline*
+| Whether to try detecting Kubernetes Cluster or stay offline.
+
+  Defaults to `false`.
+| `jkube.offline`
+
 |===

--- a/kubernetes-maven-plugin/it/src/it/configmap/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/configmap/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/custom-environment/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/custom-environment/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/custom-raw-resources/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/custom-raw-resources/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/dependency-resources/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/dependency-resources/invoker.properties
@@ -14,3 +14,4 @@
 
 invoker.goals.1=clean install k8s:resource
 invoker.debug=false
+invoker.mavenOpts=-Djkube.offline=true

--- a/kubernetes-maven-plugin/it/src/it/deployment-strategy-type-919/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/deployment-strategy-type-919/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/docker-health-checks/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/docker-health-checks/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/env-metadata/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/env-metadata/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/fragments/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/fragments/invoker.properties
@@ -14,3 +14,4 @@
 
 invoker.goals.1=clean k8s:resource
 invoker.debug=false
+invoker.mavenOpts=-Djkube.offline=true

--- a/kubernetes-maven-plugin/it/src/it/helm-and-fragments/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/helm-and-fragments/invoker.properties
@@ -14,3 +14,4 @@
 
 invoker.goals.1=clean k8s:resource k8s:helm
 invoker.debug=false
+invoker.mavenOpts=-Djkube.offline=true

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/invoker.properties
@@ -14,3 +14,4 @@
 
 invoker.goals.1=clean k8s:resource
 invoker.debug=false
+invoker.mavenOpts=-Djkube.offline=true

--- a/kubernetes-maven-plugin/it/src/it/java-options-env-merge/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/java-options-env-merge/invoker.properties
@@ -14,3 +14,4 @@
 
 invoker.goals.1=clean package
 invoker.debug=false
+invoker.mavenOpts=-Djkube.offline=true

--- a/kubernetes-maven-plugin/it/src/it/namespace/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/namespace/invoker.properties
@@ -17,3 +17,4 @@ invoker.goals.2=clean k8s:resource -Pcreate-namespace
 invoker.goals.3=clean k8s:resource -Pset-namespace
 invoker.goals.4=clean k8s:resource -Pcreate-and-set-namespace
 invoker.goals.5=clean k8s:resource -Pcreate-and-set-different-namespace
+invoker.mavenOpts=-Djkube.offline=true

--- a/kubernetes-maven-plugin/it/src/it/raw-resources/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/raw-resources/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose -Dkubernetes.mode=kubernetes
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true -Dkubernetes.mode=kubernetes
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/registry-286/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/registry-286/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/remote-resources/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/remote-resources/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/revisionhistory/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/revisionhistory/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/secret-config/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/secret-config/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean compile
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/sidecar/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/sidecar/invoker.properties
@@ -13,6 +13,6 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose -Djkube.sidecar=true
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true -Djkube.sidecar=true
 #-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/simple-maven-issue-mgmt/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/simple-maven-issue-mgmt/invoker.properties
@@ -13,7 +13,7 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9001 \
-  -Djkube.verbose
+  -Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/simple-maven-scm/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/simple-maven-scm/invoker.properties
@@ -13,7 +13,7 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9001 \
-  -Djkube.verbose
+  -Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/simple-with-route-flag-false/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/simple-with-route-flag-false/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/simple-with-route-flag-true/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/simple-with-route-flag-true/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/simple/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/simple/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/spring-boot/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/spring-boot/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/statefulset/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/statefulset/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/vertx-default/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/vertx-default/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/vertx-health-check/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/vertx-health-check/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/vertx/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/vertx/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/volume-enricher-custom-storage-class/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/volume-enricher-custom-storage-class/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/it/src/it/volume-enricher-storage-class-835/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/volume-enricher-storage-class-835/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean k8s:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -392,6 +392,9 @@ public abstract class AbstractDockerMojo extends AbstractMojo
     @Parameter(property = "jkube.watch.autoCreateCustomNetworks", defaultValue = "false")
     protected boolean autoCreateCustomNetworks;
 
+    @Parameter(property = "jkube.offline", defaultValue = "false")
+    protected boolean offline;
+
     @Override
     public void contextualize(Context context) throws ContextException {
         plexusContainer = ((PlexusContainer) context.get(PlexusConstants.PLEXUS_KEY));
@@ -439,6 +442,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo
                         .platformMode(getConfiguredRuntimeMode())
                         .dockerServiceHub(serviceHubFactory.createServiceHub(access, log, logSpecFactory))
                         .buildServiceConfig(buildServiceConfigBuilder().build())
+                        .offline(offline)
                         .build();
                     this.minimalApiVersion = initImageConfiguration(getBuildTimestamp());
                     executeInternal();

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractJKubeMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractJKubeMojo.java
@@ -65,6 +65,9 @@ public abstract class AbstractJKubeMojo extends AbstractMojo implements KitLogge
     @Parameter(property = "jkube.verbose", defaultValue = "false")
     protected String verbose;
 
+    @Parameter(property = "jkube.offline", defaultValue = "false")
+    protected boolean offline;
+
     // Settings holding authentication info
     @Parameter(defaultValue = "${settings}", readonly = true)
     protected Settings settings;
@@ -154,6 +157,7 @@ public abstract class AbstractJKubeMojo extends AbstractMojo implements KitLogge
                 .reactorProjects(Collections.singletonList(javaProject))
                 .build())
             .clusterAccess(clusterAccess)
+            .offline(offline)
             .platformMode(getRuntimeMode());
     }
 

--- a/openshift-maven-plugin/it/src/it/configmap/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/configmap/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/custom-environment/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/custom-environment/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/custom-raw-resources/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/custom-raw-resources/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/deployment-strategy-type-919/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/deployment-strategy-type-919/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/docker-health-checks/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/docker-health-checks/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/env-metadata/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/env-metadata/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/project/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/project/invoker.properties
@@ -17,3 +17,4 @@ invoker.goals.2=clean oc:resource -Pcreate-project
 invoker.goals.3=clean oc:resource -Pset-namespace
 invoker.goals.4=clean oc:resource -Pcreate-project-and-set-namespace
 invoker.goals.5=clean oc:resource -Pcreate-project-and-set-different-namespace
+invoker.mavenOpts=-Djkube.offline=true

--- a/openshift-maven-plugin/it/src/it/raw-resources/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/raw-resources/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose -Dopenshift.mode=openshift
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true -Dopenshift.mode=openshift
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/registry-286/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/registry-286/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/remote-resources/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/remote-resources/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/revisionhistory/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/revisionhistory/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/secret-config/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/secret-config/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean compile
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/sidecar/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/sidecar/invoker.properties
@@ -13,6 +13,6 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose -Djkube.sidecar=true
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true -Djkube.sidecar=true
 #-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/simple-maven-issue-mgmt/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/simple-maven-issue-mgmt/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/simple-maven-scm/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/simple-maven-scm/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/simple-with-route-flag-false/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/simple-with-route-flag-false/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose -Dfabric8.openshift.generateRoute=false
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true -Dfabric8.openshift.generateRoute=false
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/simple-with-route-flag-true/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/simple-with-route-flag-true/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose -Dfabric8.openshift.generateRoute=true
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true -Dfabric8.openshift.generateRoute=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/simple/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/simple/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/spring-boot/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/spring-boot/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/statefulset/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/statefulset/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/vertx-default/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/vertx-default/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/vertx-health-check/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/vertx-health-check/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/vertx/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/vertx/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/volume-enricher-custom-storage-class/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/volume-enricher-custom-storage-class/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false

--- a/openshift-maven-plugin/it/src/it/volume-enricher-storage-class-835/invoker.properties
+++ b/openshift-maven-plugin/it/src/it/volume-enricher-storage-class-835/invoker.properties
@@ -13,5 +13,5 @@
 #
 
 invoker.goals.1=clean oc:resource
-invoker.mavenOpts=-Djkube.verbose
+invoker.mavenOpts=-Djkube.verbose -Djkube.offline=true
 invoker.debug=false


### PR DESCRIPTION
## Description
    
+ Add a property `jkube.offline` which which jkube would skip
   cluster auto detection and go straight to offline mode.


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->