### PR TITLE
Fetch AWS Credentials from AWS SDK/Environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Usage:
 * Fix #705: JIB assembly works on Windows
 * Fix #714: feat: Helm support for Golang expressions
 * Port fabric8io/docker-maven-plugin#1318: Update ECR autorization token URL
+* Port fabric8io/docker-maven-plugin#1311: Use AWS SDK to fetch AWS credentials
 * Fix #710: Support DockerImage as output for Openshift builds
 * Fix #548: Define property for skipping cluster autodetect/offline mode
 

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -88,7 +88,7 @@ public class FromConfigRegistryAuthHandlerTest {
     }
 
     private void verifyAuthConfig(AuthConfig config, String username, String password, String email) {
-        JsonObject params = new Gson().fromJson(new String(Base64.getDecoder().decode(config.toHeaderValue().getBytes())), JsonObject.class);
+        JsonObject params = new Gson().fromJson(new String(Base64.getDecoder().decode(config.toHeaderValue(log).getBytes())), JsonObject.class);
         assertEquals(username, params.get("username").getAsString());
         assertEquals(password, params.get("password").getAsString());
         if (email != null) {

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/OpenShiftRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/OpenShiftRegistryAuthHandlerTest.java
@@ -141,7 +141,7 @@ public class OpenShiftRegistryAuthHandlerTest {
     }
 
     private void verifyAuthConfig(AuthConfig config, String username, String password, String email) {
-        JsonObject params = new Gson().fromJson(new String(Base64.getDecoder().decode(config.toHeaderValue().getBytes())), JsonObject.class);
+        JsonObject params = new Gson().fromJson(new String(Base64.getDecoder().decode(config.toHeaderValue(log).getBytes())), JsonObject.class);
         assertEquals(username,params.get("username").getAsString());
         assertEquals(password,params.get("password").getAsString());
         if (email != null) {

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/SystemPropertyRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/SystemPropertyRegistryAuthHandlerTest.java
@@ -100,7 +100,7 @@ public class SystemPropertyRegistryAuthHandlerTest {
     }
 
     private void verifyAuthConfig(AuthConfig config, String username, String password, String email) {
-        JsonObject params = new Gson().fromJson(new String(Base64.getDecoder().decode(config.toHeaderValue().getBytes())), JsonObject.class);
+        JsonObject params = new Gson().fromJson(new String(Base64.getDecoder().decode(config.toHeaderValue(log).getBytes())), JsonObject.class);
         assertEquals(username,params.get("username").getAsString());
         assertEquals(password,params.get("password").getAsString());
         if (email != null) {

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/DockerAccessWithHcClient.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/DockerAccessWithHcClient.java
@@ -637,7 +637,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
         if (authConfig == null) {
             authConfig = AuthConfig.EMPTY_AUTH_CONFIG;
         }
-        return Collections.singletonMap("X-Registry-Auth", authConfig.toHeaderValue());
+        return Collections.singletonMap("X-Registry-Auth", authConfig.toHeaderValue(log));
     }
 
     private boolean isRetryableErrorCode(int errorCode) {

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/auth/CredentialHelperClient.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/auth/CredentialHelperClient.java
@@ -28,6 +28,7 @@ public class CredentialHelperClient {
 
     static final String SECRET_KEY = "Secret";
     static final String USERNAME_KEY = "Username";
+    static final String TOKEN_USERNAME = "<token>";
     private final String credentialHelperName;
     private final KitLogger log;
 
@@ -61,12 +62,16 @@ public class CredentialHelperClient {
         }
     }
 
-    private AuthConfig toAuthConfig(JsonObject credential){
+    AuthConfig toAuthConfig(JsonObject credential){
         if (credential == null) {
             return null;
         }
         String password = credential.get(CredentialHelperClient.SECRET_KEY).getAsString();
         String userKey = credential.get(CredentialHelperClient.USERNAME_KEY).getAsString();
+        if (TOKEN_USERNAME.equals(userKey)) {
+            // If userKey is <token>, the password is actually a token
+            return new AuthConfig(null, null, null, null, password);
+        }
         return new AuthConfig(userKey,password, null,null);
     }
 

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/AwsSdkAuthConfigFactory.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/AwsSdkAuthConfigFactory.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.service.docker.auth.ecr;
+
+import org.eclipse.jkube.kit.build.api.auth.AuthConfig;
+import org.eclipse.jkube.kit.common.KitLogger;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class AwsSdkAuthConfigFactory {
+
+    private final KitLogger log;
+    private AwsSdkHelper awsSdkHelper;
+
+    public AwsSdkAuthConfigFactory(KitLogger log, AwsSdkHelper awsSdkHelper) {
+        this.log = log;
+        this.awsSdkHelper = awsSdkHelper;
+    }
+
+    public AuthConfig createAuthConfig() {
+        try {
+            Object credentials = awsSdkHelper.getCredentialsFromDefaultAWSCredentialsProviderChain();
+            if (credentials == null) {
+                return null;
+            }
+
+            return AuthConfig.builder()
+                    .username(awsSdkHelper.getAWSAccessKeyIdFromCredentials(credentials))
+                    .password(awsSdkHelper.getAwsSecretKeyFromCredentials(credentials))
+                    .email("none")
+                    .auth(awsSdkHelper.getSessionTokenFromCrendentials(credentials))
+                    .build();
+        } catch (Exception t) {
+            String issueTitle = null;
+            try {
+                issueTitle = URLEncoder.encode("Failed calling AWS SDK: " + t.getMessage(), UTF_8.name());
+            } catch (UnsupportedEncodingException ignore) {
+            }
+            log.warn("Failed to fetch AWS credentials: %s", t.getMessage());
+            if (t.getCause() != null) {
+                log.warn("Caused by: %s", t.getCause().getMessage());
+            }
+            log.warn("Please report a bug at https://github.com/eclipse/jkube/issues/new?%s",
+                    issueTitle == null ? "" : "title=?" + issueTitle);
+            log.warn("%s", t);
+            return null;
+        }
+    }
+
+}

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/AwsSdkHelper.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/AwsSdkHelper.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.service.docker.auth.ecr;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class AwsSdkHelper {
+    private static final String ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
+    private static final String SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
+    private static final String SESSION_TOKEN = "AWS_SESSION_TOKEN";
+    private static final String CONTAINER_CREDENTIALS_RELATIVE_URI = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+    private static final String METADATA_ENDPOINT = "ECS_METADATA_ENDPOINT";
+    private static final String AWS_INSTANCE_LINK_LOCAL_ADDRESS = "http://169.254.170.2";
+    private static final String DEFAULT_AWSCREDENTIALS_PROVIDER_CHAIN = "com.amazonaws.auth.DefaultAWSCredentialsProviderChain";
+    private static final String AWS_SESSION_CREDENTIALS = "com.amazonaws.auth.AWSSessionCredentials";
+    private static final String AWS_CREDENTIALS = "com.amazonaws.auth.AWSCredentials";
+
+    public boolean isDefaultAWSCredentialsProviderChainPresentInClassPath() {
+        try {
+            Class.forName(DEFAULT_AWSCREDENTIALS_PROVIDER_CHAIN);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    public String getAwsAccessKeyIdEnvVar() {
+        return System.getenv(ACCESS_KEY_ID);
+    }
+
+    public String getAwsSecretAccessKeyEnvVar() {
+        return System.getenv(SECRET_ACCESS_KEY);
+    }
+
+    public String getAwsSessionTokenEnvVar() {
+        return System.getenv(SESSION_TOKEN);
+    }
+
+    public String getAwsContainerCredentialsRelativeUri() {
+        return System.getenv(CONTAINER_CREDENTIALS_RELATIVE_URI);
+    }
+
+    public String getEcsMetadataEndpoint() {
+        String endpoint = System.getenv(METADATA_ENDPOINT);
+        if (endpoint == null) {
+            return AWS_INSTANCE_LINK_LOCAL_ADDRESS;
+        }
+        return endpoint;
+    }
+
+    public Object getCredentialsFromDefaultAWSCredentialsProviderChain() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        Class<?> credentialsProviderChainClass = Class.forName(DEFAULT_AWSCREDENTIALS_PROVIDER_CHAIN);
+        Object credentialsProviderChain = credentialsProviderChainClass.getDeclaredConstructor().newInstance();
+        return credentialsProviderChainClass.getMethod("getCredentials").invoke(credentialsProviderChain);
+    }
+
+    public String getSessionTokenFromCrendentials(Object credentials) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Class<?> sessionCredentialsClass = Class.forName(AWS_SESSION_CREDENTIALS);
+        return sessionCredentialsClass.isInstance(credentials)
+                ? (String) sessionCredentialsClass.getMethod("getSessionToken").invoke(credentials) : null;
+    }
+
+    public String getAWSAccessKeyIdFromCredentials(Object credentials) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Class<?> credentialsClass = Class.forName(AWS_CREDENTIALS);
+        return (String) credentialsClass.getMethod("getAWSAccessKeyId").invoke(credentials);
+    }
+
+    public String getAwsSecretKeyFromCredentials(Object credentials) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Class<?> credentialsClass = Class.forName(AWS_CREDENTIALS);
+        return (String) credentialsClass.getMethod("getAWSSecretKey").invoke(credentials);
+    }
+}

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/AuthConfigFactoryTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/AuthConfigFactoryTest.java
@@ -13,28 +13,69 @@
  */
 package org.eclipse.jkube.kit.build.service.docker.auth;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
 import org.eclipse.jkube.kit.build.api.auth.AuthConfig;
 import org.eclipse.jkube.kit.build.api.helper.DockerFileUtil;
+import org.eclipse.jkube.kit.build.service.docker.auth.ecr.AwsSdkAuthConfigFactory;
+import org.eclipse.jkube.kit.build.service.docker.auth.ecr.AwsSdkHelper;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.RegistryServerConfiguration;
 import org.eclipse.jkube.kit.common.SystemMock;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.UUID.randomUUID;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class AuthConfigFactoryTest {
+    public static final String ECR_NAME = "123456789012.dkr.ecr.bla.amazonaws.com";
+    private AuthConfigFactory factory;
+    private GsonBuilder gsonBuilder;
+
+    @Mocked
+    private KitLogger log;
+
+    @Mocked
+    private AwsSdkHelper awsSdkHelper;
+
+    private HttpServer httpServer;
+
+    @Before
+    public void containerSetup() {
+        factory = new AuthConfigFactory(log, awsSdkHelper);
+        gsonBuilder = new GsonBuilder();
+    }
+
+    @After
+    public void shutdownHttpServer() {
+        if (httpServer != null) {
+            httpServer.stop();
+            httpServer = null;
+        }
+    }
+
     @Test
     public void testGetAuthConfigFromSystemProperties() throws IOException {
         // Given
@@ -195,6 +236,181 @@ public class AuthConfigFactoryTest {
 
         // Then
         assertAuthConfig(authConfig, "testuser", "testpass");
+    }
+
+    @Test
+    public void getAuthConfigViaAwsSdk() throws IOException {
+        new Expectations() {{
+            awsSdkHelper.isDefaultAWSCredentialsProviderChainPresentInClassPath();
+            result = true;
+        }};
+        String accessKeyId = randomUUID().toString();
+        String secretAccessKey = randomUUID().toString();
+        new MockedAwsSdkAuthConfigFactory(accessKeyId, secretAccessKey);
+
+        AuthConfig authConfig = factory.createAuthConfig(false, true, null, Collections.emptyList(), "user", ECR_NAME, s -> s);
+
+        verifyAuthConfig(authConfig, accessKeyId, secretAccessKey, null, null);
+    }
+
+    @Test
+    public void ecsTaskRole() throws IOException {
+        givenAwsSdkIsDisabled();
+        String containerCredentialsUri = "/v2/credentials/" + randomUUID().toString();
+        String accessKeyId = randomUUID().toString();
+        String secretAccessKey = randomUUID().toString();
+        String sessionToken = randomUUID().toString();
+        givenEcsMetadataService(containerCredentialsUri, accessKeyId, secretAccessKey, sessionToken);
+        setupEcsMetadataConfiguration(httpServer, containerCredentialsUri);
+
+        AuthConfig authConfig = factory.createAuthConfig(false, true, null, Collections.emptyList(), "user", ECR_NAME, s -> s);
+
+        verifyAuthConfig(authConfig, accessKeyId, secretAccessKey, null, sessionToken);
+    }
+
+    @Test
+    public void fargateTaskRole() throws IOException {
+        givenAwsSdkIsDisabled();
+        String containerCredentialsUri = "v2/credentials/" + randomUUID();
+        String accessKeyId = randomUUID().toString();
+        String secretAccessKey = randomUUID().toString();
+        String sessionToken = randomUUID().toString();
+        givenEcsMetadataService("/" + containerCredentialsUri, accessKeyId, secretAccessKey, sessionToken);
+        setupEcsMetadataConfiguration(httpServer, containerCredentialsUri);
+
+        AuthConfig authConfig = factory.createAuthConfig(false, true, null, Collections.emptyList(), "user", ECR_NAME, s -> s);
+
+        verifyAuthConfig(authConfig, accessKeyId, secretAccessKey, null, sessionToken);
+    }
+
+    @Test
+    public void awsTemporaryCredentialsArePickedUpFromEnvironment() throws IOException {
+        givenAwsSdkIsDisabled();
+        String accessKeyId = randomUUID().toString();
+        String secretAccessKey = randomUUID().toString();
+        String sessionToken = randomUUID().toString();
+        new Expectations() {{
+            awsSdkHelper.getAwsAccessKeyIdEnvVar();
+            result = accessKeyId;
+            awsSdkHelper.getAwsSecretAccessKeyEnvVar();
+            result = secretAccessKey;
+            awsSdkHelper.getAwsSessionTokenEnvVar();
+            result = sessionToken;
+        }};
+
+        AuthConfig authConfig = factory.createAuthConfig(false, true, null, Collections.emptyList(), "user", ECR_NAME, s -> s);
+
+        verifyAuthConfig(authConfig, accessKeyId, secretAccessKey, null, sessionToken);
+    }
+
+    @Test
+    public void awsStaticCredentialsArePickedUpFromEnvironment() throws IOException {
+        givenAwsSdkIsDisabled();
+        String accessKeyId = randomUUID().toString();
+        String secretAccessKey = randomUUID().toString();
+        new Expectations() {{
+            awsSdkHelper.getAwsAccessKeyIdEnvVar();
+            result = accessKeyId;
+            awsSdkHelper.getAwsSecretAccessKeyEnvVar();
+            result = secretAccessKey;
+        }};
+
+        AuthConfig authConfig = factory.createAuthConfig(false, true, null, Collections.emptyList(), "user", ECR_NAME, s -> s);
+
+        verifyAuthConfig(authConfig, accessKeyId, secretAccessKey, null, null);
+    }
+
+    @Test
+    public void incompleteAwsCredentialsAreIgnored() throws IOException {
+        givenAwsSdkIsDisabled();
+        System.setProperty("AWS_ACCESS_KEY_ID", randomUUID().toString());
+
+        AuthConfig authConfig = factory.createAuthConfig(false, true, null, Collections.emptyList(), "user", ECR_NAME, s -> s);
+
+        assertNull(authConfig);
+    }
+
+    private void givenEcsMetadataService(String containerCredentialsUri, String accessKeyId, String secretAccessKey, String sessionToken) throws IOException {
+        httpServer =
+                ServerBootstrap.bootstrap()
+                        .setLocalAddress(InetAddress.getLoopbackAddress())
+                        .registerHandler("*", (request, response, context) -> {
+                            System.out.println("REQUEST: " + request.getRequestLine());
+                            if (containerCredentialsUri.matches(request.getRequestLine().getUri())) {
+                                response.setEntity(new StringEntity(gsonBuilder.create().toJson(ImmutableMap.of(
+                                        "AccessKeyId", accessKeyId,
+                                        "SecretAccessKey", secretAccessKey,
+                                        "Token", sessionToken
+                                ))));
+                            } else {
+                                response.setStatusCode(SC_NOT_FOUND);
+                            }
+                        })
+                        .create();
+        httpServer.start();
+    }
+
+    private void setupEcsMetadataConfiguration(HttpServer httpServer, String containerCredentialsUri) {
+        new Expectations() {{
+            awsSdkHelper.getEcsMetadataEndpoint();
+            result = "http://" +
+                    httpServer.getInetAddress().getHostAddress()+":" + httpServer.getLocalPort();
+
+            awsSdkHelper.getAwsContainerCredentialsRelativeUri();
+            result = containerCredentialsUri;
+        }};
+    }
+
+    private static void givenAwsSdkIsDisabled() {
+        new DisableAwsSdkAuthConfigFactory();
+    }
+
+    private void verifyAuthConfig(AuthConfig config, String username, String password, String email, String auth) {
+        assertNotNull(config);
+        JsonObject params = gsonBuilder.create().fromJson(new String(Base64.decodeBase64(config.toHeaderValue(log).getBytes())), JsonObject.class);
+        assertEquals(username, params.get("username").getAsString());
+        assertEquals(password, params.get("password").getAsString());
+        if (email != null) {
+            assertEquals(email, params.get("email").getAsString());
+        }
+        if (auth != null) {
+            assertEquals(auth, params.get("auth").getAsString());
+        }
+    }
+
+    private static class MockedAwsSdkAuthConfigFactory extends MockUp<AwsSdkAuthConfigFactory> {
+        private final String accessKeyId;
+        private final String secretAccessKey;
+
+        public MockedAwsSdkAuthConfigFactory(String accessKeyId, String secretAccessKey) {
+            this.accessKeyId = accessKeyId;
+            this.secretAccessKey = secretAccessKey;
+        }
+
+        @Mock
+        public void $init(KitLogger log) { }
+
+        @Mock
+        public AuthConfig createAuthConfig() {
+            return AuthConfig.builder()
+                    .username(accessKeyId)
+                    .password(secretAccessKey)
+                    .email(null)
+                    .auth(null)
+                    .identityToken(null)
+                    .build();
+        }
+
+    }
+
+    private static class DisableAwsSdkAuthConfigFactory extends MockUp<AwsSdkAuthConfigFactory> {
+        @Mock
+        public void $init(KitLogger log) { }
+
+        @Mock
+        public AuthConfig createAuthConfig() {
+            return null;
+        }
     }
 
     private void assertAuthConfig(AuthConfig authConfig, String username, String password) {

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/CredentialHelperClientTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/CredentialHelperClientTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.service.docker.auth;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import mockit.Mocked;
+import org.eclipse.jkube.kit.build.api.auth.AuthConfig;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class CredentialHelperClientTest {
+    private final Gson gson = new Gson();
+
+    @Mocked
+    private KitLogger logger;
+
+    private CredentialHelperClient credentialHelperClient;
+
+    private JsonObject jsonObject;
+
+    private AuthConfig authConfig;
+
+    @Before
+    public void givenCredentialHelperClient() {
+        this.credentialHelperClient = new CredentialHelperClient(logger, "desktop");
+    }
+
+    @Test
+    public void testUsernamePasswordAuthConfig() {
+        givenJson("{\"ServerURL\":\"registry.mycompany.com\",\"Username\":\"jane_doe\",\"Secret\":\"not-really\"}");
+
+        whenJsonObjectConvertedToAuthConfig();
+        
+        assertEquals("username should match", "jane_doe", this.authConfig.getUsername());
+        assertEquals("password should match", "not-really", this.authConfig.getPassword());
+        assertNull("identityToken should not be set", this.authConfig.getIdentityToken());
+    }
+
+    @Test
+    public void testTokenAuthConfig() {
+        givenJson("{\"ServerURL\":\"registry.cloud-provider.com\",\"Username\":\"<token>\",\"Secret\":\"gigantic-mess-of-jwt\"}");
+
+        whenJsonObjectConvertedToAuthConfig();
+
+        assertNull("username should not be set", this.authConfig.getUsername());
+        assertNull("password should not be set", this.authConfig.getPassword());
+        assertEquals("identity token should match", "gigantic-mess-of-jwt", this.authConfig.getIdentityToken());
+    }
+
+    private void givenJson(String json) {
+        this.jsonObject = this.gson.fromJson(json, JsonObject.class);
+    }
+
+    private void whenJsonObjectConvertedToAuthConfig() {
+        this.authConfig = this.credentialHelperClient.toAuthConfig(this.jsonObject);
+    }
+}

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/AwsSdkAuthConfigFactoryTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/AwsSdkAuthConfigFactoryTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.service.docker.auth.ecr;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.eclipse.jkube.kit.build.api.auth.AuthConfig;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.UUID.randomUUID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class AwsSdkAuthConfigFactoryTest {
+    @Mocked
+    private KitLogger log;
+
+    @Mocked
+    private AwsSdkHelper awsSdkHelper;
+
+    private AwsSdkAuthConfigFactory objectUnderTest;
+
+    @Before
+    public void setup() {
+        objectUnderTest = new AwsSdkAuthConfigFactory(log, awsSdkHelper);
+    }
+
+    @Test
+    public void nullValueIsPassedOn() {
+        AuthConfig authConfig = objectUnderTest.createAuthConfig();
+
+        assertNull(authConfig);
+    }
+
+    @Test
+    public void reflectionWorksForBasicCredentials() throws Exception {
+        String accessKey = randomUUID().toString();
+        String secretKey = randomUUID().toString();
+        Object credentials = new Object();
+        new Expectations() {{
+            awsSdkHelper.getCredentialsFromDefaultAWSCredentialsProviderChain();
+            result = credentials;
+            awsSdkHelper.getAWSAccessKeyIdFromCredentials(any);
+            result = accessKey;
+            awsSdkHelper.getAwsSecretKeyFromCredentials(any);
+            result = secretKey;
+        }};
+
+        AuthConfig authConfig = objectUnderTest.createAuthConfig();
+
+        assertNotNull(authConfig);
+        assertEquals(accessKey, authConfig.getUsername());
+        assertEquals(secretKey, authConfig.getPassword());
+        assertNull(authConfig.getAuth());
+        assertNull(authConfig.getIdentityToken());
+    }
+
+    @Test
+    public void reflectionWorksForSessionCredentials() throws Exception {
+        String accessKey = randomUUID().toString();
+        String secretKey = randomUUID().toString();
+        String sessionToken = randomUUID().toString();
+        Object credentials = new Object();
+        new Expectations() {{
+            awsSdkHelper.getCredentialsFromDefaultAWSCredentialsProviderChain();
+            result = credentials;
+            awsSdkHelper.getAWSAccessKeyIdFromCredentials(any);
+            result = accessKey;
+            awsSdkHelper.getAwsSecretKeyFromCredentials(any);
+            result = secretKey;
+            awsSdkHelper.getSessionTokenFromCrendentials(any);
+            result = sessionToken;
+        }};
+        AuthConfig authConfig = objectUnderTest.createAuthConfig();
+
+        assertNotNull(authConfig);
+        assertEquals(accessKey, authConfig.getUsername());
+        assertEquals(secretKey, authConfig.getPassword());
+        assertEquals(sessionToken, authConfig.getAuth());
+        assertNull(authConfig.getIdentityToken());
+    }
+
+}

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/DockerRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/auth/ecr/DockerRegistryAuthHandlerTest.java
@@ -207,7 +207,7 @@ public class DockerRegistryAuthHandlerTest {
     }
 
     private void verifyAuthConfig(AuthConfig config, String username, String password, String email) {
-        JsonObject params = new Gson().fromJson(new String(Base64.getDecoder().decode(config.toHeaderValue().getBytes())), JsonObject.class);
+        JsonObject params = new Gson().fromJson(new String(Base64.getDecoder().decode(config.toHeaderValue(log).getBytes())), JsonObject.class);
         assertEquals(username,params.get("username").getAsString());
         assertEquals(password,params.get("password").getAsString());
         if (email != null) {

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_authentication.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_authentication.adoc
@@ -176,7 +176,7 @@ password.
 
 Some docker registries require additional steps to authenticate.
 link:https://docs.aws.amazon.com/AmazonECR/latest/userguide/ECR_GetStarted.html[Amazon ECR] requires using an IAM access key to obtain temporary docker login credentials.
-The <<jkube:push>> and <<jkube:build>> goals automatically execute this exchange for any registry of the form
+The <<jkube:push>> and <<jkube:build>> goals  automatically execute this exchange for any registry of the form
 _<awsAccountId>_ *.dkr.ecr.* _<awsRegion>_ *.amazonaws.com*, unless the `skipExtendedAuth` configuration
 (`jkube.docker.skip.extendedAuth` property) is set true.
 
@@ -185,10 +185,38 @@ Note that for an ECR repository with URI `123456789012.dkr.ecr.eu-west-1.amazona
 You can use any IAM access key with the necessary permissions in any of the locations mentioned above except `~/.docker/config.json`.
 Use the IAM *Access key ID* as the username and the *Secret access key* as the password.
 In case you're using temporary security credentials provided by the AWS Security Token Service (AWS STS), you have to provide the *security token* as well.
-To do so, either specify the `docker.authToken` system property or provide an `<auth>` element alongside username & password in the `authConfig`.
+To do so, either specify the an `<auth>` element alongside username & password in the `authConfig`.
 
-In case you are running on an EC2 instance that has an appropriate IAM role assigned
-(e.g. a role that grants the AWS built-in policy _AmazonEC2ContainerRegistryPowerUser_)
-authentication information doesn't need to be provided at all. Instead the instance
-meta-data service is queried for temporary access credentials supplied by the
-assigned role.
+Plugin will attempt to read AWS credentials from some well-known spots in case there is no explicit configuration:
+
+* it will pick up ENV variables link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html[as documented for the AWS CLI]
+
+* it will pick up temporary credentials of link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html[the IAM role of an EC2 instance]
+
+* it will pick up temporary credentials of link:https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html[the IAM role of a fargate task (OR ECS with EC2 with ECS_AWSVPC_BLOCK_IMDS as "true")]
+
+If any of these authentication information is accessible, it will be used.
+
+[NOTE]
+For a more complete, robust and reliable authentication experience, you can add the AWS SDK for Java as a dependency.
+
+[source,xml]
+----
+<plugins>
+    <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-core</artifactId>
+                <version>1.11.707</version>
+            </dependency>
+        </dependencies>
+    </plugin>
+</plugins>
+----
+
+This extra dependency allows the usage of all link:https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html[options] that the AWS default credential provider chain provides.
+
+If the AWS SDK is found in the classpath, it takes precedence over the custom AWS credentials lookup mechanisms listed above.


### PR DESCRIPTION
## Description
Add support in AuthConfigFactory to retrieve credentials from
different mechanisms for AWS.

Port of https://github.com/fabric8io/docker-maven-plugin/pull/1311
Port of https://github.com/fabric8io/docker-maven-plugin/pull/1310

Related to #702


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->