### PR TITLE
Fix #253: JKubeServiceHub BuildService implementations are now loaded via ServiceLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.4.0-SNAPSHOT
+* Fix #253: Refactor JKubeServiceHub's BuildService election mechanism via ServiceLoader
 * Fix #741: Private constructor added to Utility classes
 * Fix #725: Upgrade HttpClient from 4.5.10 to 4.5.13
 * Fix #653: `k8s:watch` port-forward websocket error due to wrong arguments in PortForwardService

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/BuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/BuildService.java
@@ -48,4 +48,18 @@ public interface BuildService {
      */
     void postProcess(BuildServiceConfig config);
 
+    /**
+     * Check whether provided Build Service implementation is applicable in current context or not.
+     *
+     * @param jKubeServiceHub {@link JKubeServiceHub}
+     * @return boolean value specifying whether provided BuildService implementation should be used.
+     */
+    boolean isApplicable(JKubeServiceHub jKubeServiceHub);
+
+    /**
+     * Set {@link JKubeServiceHub}
+     *
+     * @param jKubeServiceHub {@link JKubeServiceHub}
+     */
+    void setJKubeServiceHub(JKubeServiceHub jKubeServiceHub);
 }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildService.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.RegistryConfig;
+import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 import org.eclipse.jkube.kit.config.service.BuildService;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceException;
@@ -32,7 +33,9 @@ public class DockerBuildService implements BuildService {
 
     private JKubeServiceHub jKubeServiceHub;
 
-    public DockerBuildService(JKubeServiceHub jKubeServiceHub) {
+    public DockerBuildService() { }
+
+    DockerBuildService(JKubeServiceHub jKubeServiceHub) {
         Objects.requireNonNull(jKubeServiceHub.getDockerServiceHub(), "dockerServiceHub");
         Objects.requireNonNull(jKubeServiceHub.getBuildServiceConfig(), "BuildServiceConfig is required");
         this.jKubeServiceHub = jKubeServiceHub;
@@ -68,4 +71,13 @@ public class DockerBuildService implements BuildService {
         // No post processing required
     }
 
+    @Override
+    public boolean isApplicable(JKubeServiceHub jKubeServiceHub) {
+        return jKubeServiceHub.getRuntimeMode() == RuntimeMode.KUBERNETES;
+    }
+
+    @Override
+    public void setJKubeServiceHub(JKubeServiceHub jKubeServiceHub) {
+        this.jKubeServiceHub = jKubeServiceHub;
+    }
 }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildService.java
@@ -30,6 +30,7 @@ import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.common.RegistryConfig;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
 import org.eclipse.jkube.kit.config.service.BuildService;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceException;
@@ -53,13 +54,14 @@ public class JibBuildService implements BuildService {
             "docker.io", "index.docker.io", "registry.hub.docker.com"
     );
     private static final String PUSH_REGISTRY = "jkube.docker.push.registry";
-    private final JKubeServiceHub jKubeServiceHub;
-    private final KitLogger log;
+    private JKubeServiceHub jKubeServiceHub;
+    private KitLogger log;
 
-    public JibBuildService(JKubeServiceHub jKubeServiceHub, KitLogger logger) {
+    public JibBuildService() { }
+
+    JibBuildService(JKubeServiceHub jKubeServiceHub) {
         Objects.requireNonNull(jKubeServiceHub.getBuildServiceConfig(), "BuildServiceConfig is required");
-        this.jKubeServiceHub = jKubeServiceHub;
-        this.log = logger;
+        setJKubeServiceHub(jKubeServiceHub);
     }
 
     @Override
@@ -116,6 +118,17 @@ public class JibBuildService implements BuildService {
     @Override
     public void postProcess(BuildServiceConfig config) {
         // No post processing required
+    }
+
+    @Override
+    public boolean isApplicable(JKubeServiceHub jKubeServiceHub) {
+        return jKubeServiceHub.getBuildServiceConfig().getJKubeBuildStrategy() == JKubeBuildStrategy.jib;
+    }
+
+    @Override
+    public void setJKubeServiceHub(JKubeServiceHub jKubeServiceHub) {
+        this.jKubeServiceHub = jKubeServiceHub;
+        this.log = jKubeServiceHub.getLog();
     }
 
     static ImageConfiguration prependRegistry(ImageConfiguration imageConfiguration, String registry) {

--- a/jkube-kit/config/service/src/main/resources/META-INF/services/org.eclipse.jkube.kit.config.service.BuildService
+++ b/jkube-kit/config/service/src/main/resources/META-INF/services/org.eclipse.jkube.kit.config.service.BuildService
@@ -1,0 +1,3 @@
+org.eclipse.jkube.kit.config.service.kubernetes.JibBuildService
+org.eclipse.jkube.kit.config.service.kubernetes.DockerBuildService
+org.eclipse.jkube.kit.config.service.openshift.OpenshiftBuildService

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/JKubeServiceHubTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/JKubeServiceHubTest.java
@@ -31,12 +31,7 @@ import org.junit.Test;
 
 import java.util.Properties;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings({"ResultOfMethodCallIgnored", "unused"})
@@ -101,9 +96,9 @@ public class JKubeServiceHubTest {
             .build()
     ) {
       // Then
-      assertThat(jKubeServiceHub, notNullValue());
-      assertThat(jKubeServiceHub.getClient(), notNullValue());
-      assertThat(jKubeServiceHub.getRuntimeMode(), is(RuntimeMode.KUBERNETES));
+      assertThat(jKubeServiceHub).isNotNull();
+      assertThat(jKubeServiceHub.getClient()).isNotNull();
+      assertThat(jKubeServiceHub.getRuntimeMode()).isEqualTo(RuntimeMode.KUBERNETES);
     }
   }
 
@@ -116,8 +111,8 @@ public class JKubeServiceHubTest {
     // When
     BuildService buildService = hub.getBuildService();
     // Then
-    assertNotNull(buildService);
-    assertTrue(buildService instanceof DockerBuildService);
+    assertThat(buildService).isNotNull();
+    assertThat(buildService).isInstanceOf(DockerBuildService.class);
   }
 
   @Test
@@ -126,7 +121,6 @@ public class JKubeServiceHubTest {
     // @formatter:off
     new Expectations() {{
       buildServiceConfig.getJKubeBuildStrategy(); result = null;
-      openShiftClient.isAdaptable(OpenShiftClient.class); result = true;
     }};
     // @formatter:on
     JKubeServiceHub hub = commonInit()
@@ -135,8 +129,8 @@ public class JKubeServiceHubTest {
     // When
     BuildService buildService = hub.getBuildService();
     // Then
-    assertNotNull(buildService);
-    assertTrue(buildService instanceof OpenshiftBuildService);
+    assertThat(buildService).isNotNull();
+    assertThat(buildService).isInstanceOf(OpenshiftBuildService.class);
   }
 
   @Test
@@ -145,7 +139,7 @@ public class JKubeServiceHubTest {
             .platformMode(RuntimeMode.KUBERNETES)
             .build();
 
-    assertNotNull(hub.getArtifactResolverService());
+    assertThat(hub.getArtifactResolverService()).isNotNull();
   }
 
   @Test
@@ -162,8 +156,8 @@ public class JKubeServiceHubTest {
     // When
     BuildService buildService = hub.getBuildService();
     // Then
-    assertNotNull(buildService);
-    assertTrue(buildService instanceof JibBuildService);
+    assertThat(buildService).isNotNull();
+    assertThat(buildService).isInstanceOf(JibBuildService.class);
   }
 
   @Test
@@ -175,8 +169,8 @@ public class JKubeServiceHubTest {
     // When
     final UndeployService result = hub.getUndeployService();
     // Then
-    assertNotNull(result);
-    assertTrue(result instanceof KubernetesUndeployService);
+    assertThat(result).isNotNull();
+    assertThat(result).isInstanceOf(KubernetesUndeployService.class);
   }
 
   @Test
@@ -193,8 +187,8 @@ public class JKubeServiceHubTest {
     // When
     final UndeployService result = hub.getUndeployService();
     // Then
-    assertNotNull(result);
-    assertTrue(result instanceof KubernetesUndeployService);
+    assertThat(result).isNotNull();
+    assertThat(result).isInstanceOf(KubernetesUndeployService.class);
   }
 
   @Test
@@ -211,8 +205,8 @@ public class JKubeServiceHubTest {
     // When
     final UndeployService result = hub.getUndeployService();
     // Then
-    assertNotNull(result);
-    assertTrue(result instanceof OpenshiftUndeployService);
+    assertThat(result).isNotNull();
+    assertThat(result).isInstanceOf(OpenshiftUndeployService.class);
   }
 
   @Test
@@ -226,7 +220,7 @@ public class JKubeServiceHubTest {
     final PortForwardService portForwardService = hub.getPortForwardService();
 
     // Then
-    assertNotNull(portForwardService);
+    assertThat(portForwardService).isNotNull();
   }
 
   @Test
@@ -240,7 +234,7 @@ public class JKubeServiceHubTest {
     final DebugService debugService = hub.getDebugService();
 
     // Then
-    assertNotNull(debugService);
+    assertThat(debugService).isNotNull();
   }
 
   @Test
@@ -248,8 +242,8 @@ public class JKubeServiceHubTest {
     // Given + When
     try (final JKubeServiceHub jKubeServiceHub = commonInit().platformMode(RuntimeMode.KUBERNETES).offline(true).build()) {
       // Then
-      assertThat(jKubeServiceHub, notNullValue());
-      assertThat(jKubeServiceHub.getClient(), nullValue());
+      assertThat(jKubeServiceHub).isNotNull();
+      assertThat(jKubeServiceHub.getClient()).isNull();
     }
   }
 
@@ -258,7 +252,7 @@ public class JKubeServiceHubTest {
     // Given + When
     try (final JKubeServiceHub jKubeServiceHub = commonInit().platformMode(RuntimeMode.KUBERNETES).offline(true).build()) {
       // Then
-      assertThat(jKubeServiceHub, notNullValue());
+      assertThat(jKubeServiceHub).isNotNull();
       assertThrows(IllegalArgumentException.class, jKubeServiceHub::getApplyService);
     }
   }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildServiceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.kit.config.service.kubernetes;
 
 import mockit.Expectations;
+import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.build.service.docker.ImagePullManager;

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceBuildIntegrationTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceBuildIntegrationTest.java
@@ -82,9 +82,10 @@ public class JibBuildServiceBuildIntegrationTest {
     // @formatter:off
     new Expectations() {{
       hub.getConfiguration(); result = configuration;
+      hub.getLog(); result = log;
     }};
     // @formatter:on
-    jibBuildService = new JibBuildService(hub, log);
+    jibBuildService = new JibBuildService(hub);
   }
 
   @Test

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
@@ -138,7 +138,7 @@ public class JibBuildServiceTest {
     @Test
     public void testPushWithNoConfigurations(@Mocked JibServiceUtil jibServiceUtil) throws Exception {
         // When
-        new JibBuildService(serviceHub, logger).push(Collections.emptyList(), 1, null, false);
+        new JibBuildService(serviceHub).push(Collections.emptyList(), 1, null, false);
         // Then
         // @formatter:off
         new Verifications() {{
@@ -155,7 +155,7 @@ public class JibBuildServiceTest {
         final RegistryConfig registryConfig = RegistryConfig.builder()
             .build();
         // When
-        new JibBuildService(serviceHub, logger).push(Collections.singletonList(imageConfiguration), 1, registryConfig, false);
+        new JibBuildService(serviceHub).push(Collections.singletonList(imageConfiguration), 1, registryConfig, false);
         // Then
         // @formatter:off
         new Verifications() {{

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceTest.java
@@ -44,7 +44,6 @@ import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceException;
 import mockit.Expectations;
 import mockit.Mocked;
-import mockit.Tested;
 import mockit.Verifications;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -192,7 +191,7 @@ public class OpenshiftBuildServiceTest {
             LOG.info("Current write timeout is : {}", client.getHttpClient().writeTimeoutMillis());
             LOG.info("Current read timeout is : {}", client.getHttpClient().readTimeoutMillis());
             LOG.info("Retry on failure : {}", client.getHttpClient().retryOnConnectionFailure());
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             service.build(image);
 
             // we should Foadd a better way to assert that a certain call has been made
@@ -221,7 +220,7 @@ public class OpenshiftBuildServiceTest {
             LOG.info("Current write timeout is : {}", client.getHttpClient().writeTimeoutMillis());
             LOG.info("Current read timeout is : {}", client.getHttpClient().readTimeoutMillis());
             LOG.info("Retry on failure : {}", client.getHttpClient().retryOnConnectionFailure());
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             service.build(image);
 
             // we should Foadd a better way to assert that a certain call has been made
@@ -249,7 +248,7 @@ public class OpenshiftBuildServiceTest {
                     false, false);
 
             DefaultOpenShiftClient client = (DefaultOpenShiftClient) mockServer.getOpenshiftClient();
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             service.build(image);
 
             assertTrue(mockServer.getMockServer().getRequestCount() > 8);
@@ -277,7 +276,7 @@ public class OpenshiftBuildServiceTest {
                 dockerConfig, true, 50, false, false);
 
             DefaultOpenShiftClient client = (DefaultOpenShiftClient) mockServer.getOpenshiftClient();
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             service.build(image);
 
             assertTrue(mockServer.getMockServer().getRequestCount() > 8);
@@ -304,7 +303,7 @@ public class OpenshiftBuildServiceTest {
                     false, false);
 
             DefaultOpenShiftClient client = (DefaultOpenShiftClient) mockServer.getOpenshiftClient();
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             service.build(image);
 
             assertTrue(mockServer.getMockServer().getRequestCount() > 8);
@@ -332,7 +331,7 @@ public class OpenshiftBuildServiceTest {
                     false, false);
 
             DefaultOpenShiftClient client = (DefaultOpenShiftClient) mockServer.getOpenshiftClient();
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             Map<String,String> fromExt = ImmutableMap.of("name", "app:1.2-1",
                     "kind", "ImageStreamTag",
                     "namespace", "my-project");
@@ -368,7 +367,7 @@ public class OpenshiftBuildServiceTest {
             LOG.info("Current write timeout is : {}", client.getHttpClient().writeTimeoutMillis());
             LOG.info("Current read timeout is : {}", client.getHttpClient().readTimeoutMillis());
             LOG.info("Retry on failure : {}", client.getHttpClient().retryOnConnectionFailure());
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             service.build(image);
 
             // we should Foadd a better way to assert that a certain call has been made
@@ -388,7 +387,7 @@ public class OpenshiftBuildServiceTest {
         // @formatter:off
 
         OpenShiftClient client = mockServer.getOpenshiftClient();
-        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+        OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
         service.build(image);
     }
 
@@ -402,7 +401,7 @@ public class OpenshiftBuildServiceTest {
         // @formatter:off
 
         OpenShiftClient client = mockServer.getOpenshiftClient();
-        OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+        OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
         service.build(image);
     }
 
@@ -418,7 +417,7 @@ public class OpenshiftBuildServiceTest {
             WebServerEventCollector collector = createMockServer(config, true, 50, true, true);
 
             OpenShiftClient client = mockServer.getOpenshiftClient();
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             service.build(image);
 
             assertTrue(mockServer.getMockServer().getRequestCount() > 8);
@@ -438,7 +437,7 @@ public class OpenshiftBuildServiceTest {
             // @formatter:off
 
             OpenShiftClient client = mockServer.getOpenshiftClient();
-            final OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            final OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
 
             ImageConfiguration imageWithEnv = image.toBuilder()
                     .build(image.getBuildConfiguration().toBuilder()
@@ -486,7 +485,7 @@ public class OpenshiftBuildServiceTest {
             // @formatter:off
 
             OpenShiftClient client = mockServer.getOpenshiftClient();
-            final OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            final OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
 
             ImageConfiguration imageWithEnv = image.toBuilder()
                     .build(image.getBuildConfiguration().toBuilder()
@@ -542,7 +541,7 @@ public class OpenshiftBuildServiceTest {
             // @formatter:off
 
             OpenShiftClient client = mockServer.getOpenshiftClient();
-            final OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            final OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
 
             ImageConfiguration imageWithEnv = image.toBuilder()
                     .build(image.getBuildConfiguration().toBuilder()
@@ -579,7 +578,7 @@ public class OpenshiftBuildServiceTest {
             LOG.info("Current write timeout is : {}", client.getHttpClient().writeTimeoutMillis());
             LOG.info("Current read timeout is : {}", client.getHttpClient().readTimeoutMillis());
             LOG.info("Retry on failure : {}", client.getHttpClient().retryOnConnectionFailure());
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             service.build(image);
 
             // we should add a better way to assert that a certain call has been made
@@ -606,7 +605,7 @@ public class OpenshiftBuildServiceTest {
             LOG.info("Current write timeout is : {}", client.getHttpClient().writeTimeoutMillis());
             LOG.info("Current read timeout is : {}", client.getHttpClient().readTimeoutMillis());
             LOG.info("Retry on failure : {}", client.getHttpClient().retryOnConnectionFailure());
-            OpenshiftBuildService service = new OpenshiftBuildService(client, logger, jKubeServiceHub);
+            OpenshiftBuildService service = new OpenshiftBuildService(client, jKubeServiceHub);
             service.build(image);
 
             // we should add a better way to assert that a certain call has been made


### PR DESCRIPTION
## Description
Fix #253 
+ Use ServiceLoader to load all Build Services and pick up service
  which is applicable in current context. This requires BuildService
  implementations to have zero-arg constructors so I need to set the
  elements from setters instead.

+ Added isApplicable(), setJKubeServiceHub() methods in
  BuildService interface

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->