### PR TITLE
feat: QuarkusGenerator: Multi-layer images for the different Quarkus packaging modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Usage:
 * Fix #548: Define property for skipping cluster autodetect/offline mode
 * Fix #701: Update Fabric8 Kubernetes Client to 5.4.0
 * Fix #425: Multi-layer support for Container Images
+* Fix #751: QuarkusGenerator: Multi-layer images for the different Quarkus packaging modes
 
 ### 1.3.0 (2021-05-18)
 * Fix #497: Assembly descriptor removed but still in documentation

--- a/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorTest.java
+++ b/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorTest.java
@@ -82,13 +82,11 @@ public class JavaExecGeneratorTest {
   }
 
   @Test
-  public void addAssemblyWithNoFatJarShouldAddDefaultFileSets() {
-    // Given
-    final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
+  public void createAssemblyWithNoFatJarShouldAddDefaultFileSets() {
     // When
-    new JavaExecGenerator(generatorContext).addAssembly(builder);
+    final AssemblyConfiguration result = new JavaExecGenerator(generatorContext).createAssembly();
     // Then
-    assertThat(builder.build())
+    assertThat(result)
         .hasFieldOrPropertyWithValue("excludeFinalOutputArtifact", false)
         .extracting(AssemblyConfiguration::getLayers).asList().hasSize(1)
         .first().asInstanceOf(InstanceOfAssertFactories.type(Assembly.class))
@@ -97,7 +95,7 @@ public class JavaExecGeneratorTest {
   }
 
   @Test
-  public void addAssemblyWithFatJarShouldAddDefaultFileSetsAndFatJar(
+  public void createAssemblyWithFatJarShouldAddDefaultFileSetsAndFatJar(
       @Mocked FatJarDetector fatJarDetector, @Mocked FatJarDetector.Result fjResult) {
     // Given
     // @formatter:off
@@ -108,11 +106,10 @@ public class JavaExecGeneratorTest {
       fatJarDetector.scan(); result = fjResult;
     }};
     // @formatter:on
-    final AssemblyConfiguration.AssemblyConfigurationBuilder builder = AssemblyConfiguration.builder();
     // When
-    new JavaExecGenerator(generatorContext).addAssembly(builder);
+    final AssemblyConfiguration result = new JavaExecGenerator(generatorContext).createAssembly();
     // Then
-    assertThat(builder.build())
+    assertThat(result)
         .hasFieldOrPropertyWithValue("excludeFinalOutputArtifact", true)
         .extracting(AssemblyConfiguration::getLayers).asList().hasSize(1)
         .first().asInstanceOf(InstanceOfAssertFactories.type(Assembly.class))

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusAssemblies.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusAssemblies.java
@@ -13,17 +13,15 @@
  */
 package org.eclipse.jkube.quarkus.generator;
 
+import java.io.File;
+import java.util.Properties;
+
 import org.eclipse.jkube.kit.common.Assembly;
 import org.eclipse.jkube.kit.common.AssemblyConfiguration;
 import org.eclipse.jkube.kit.common.AssemblyFileSet;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
 
 import static org.eclipse.jkube.quarkus.QuarkusUtils.findSingleFileThatEndsWith;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusConfiguration;
@@ -34,14 +32,14 @@ public class QuarkusAssemblies {
   public static final QuarkusAssembly NATIVE = quarkusGenerator -> {
     final JavaProject project = quarkusGenerator.getContext().getProject();
     final Properties quarkusConfiguration = getQuarkusConfiguration(project);
-    final List<String> relativePaths = new ArrayList<>();
-    relativePaths.add(findSingleFileThatEndsWith(project, runnerSuffix(quarkusConfiguration)));
-    final AssemblyFileSet fileSet = AssemblyFileSet.builder()
+    final AssemblyFileSet artifactFileSet = createFileSet(project)
         .directory(FileUtil.getRelativePath(project.getBaseDirectory(), project.getBuildDirectory()))
-        .includes(relativePaths)
+        .include(findSingleFileThatEndsWith(project, runnerSuffix(quarkusConfiguration)))
         .fileMode("0755")
         .build();
-    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir(), fileSet);
+    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir())
+        .layer(Assembly.builder().fileSet(artifactFileSet).build())
+        .build();
   };
 
   public static final QuarkusAssembly FAST_JAR = quarkusGenerator -> {
@@ -50,52 +48,66 @@ public class QuarkusAssemblies {
     if (!quarkusAppDirectory.exists()) {
       throw new IllegalStateException("The quarkus-app directory required in Quarkus Fast Jar mode was not found");
     }
-    AssemblyFileSet.AssemblyFileSetBuilder fileSetBuilder = AssemblyFileSet.builder()
+    AssemblyFileSet.AssemblyFileSetBuilder libFileSet = createFileSet(project)
+        .directory(FileUtil.getRelativePath(project.getBaseDirectory(), quarkusAppDirectory))
+        .include("lib")
+        .fileMode("0640");
+    AssemblyFileSet.AssemblyFileSetBuilder fastJarFileSet = createFileSet(project)
         .directory(FileUtil.getRelativePath(project.getBaseDirectory(), quarkusAppDirectory))
         .include("quarkus-run.jar")
         .include("*")
         .include("**/*")
+        .exclude("lib/**/*")
+        .exclude("lib/*")
         .fileMode("0640");
-    addDefaultArtifactExclude(project, fileSetBuilder);
-    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir(), fileSetBuilder.build());
+    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir())
+        .layer(Assembly.builder().id("lib").fileSet(libFileSet.build()).build())
+        .layer(Assembly.builder().id("fast-jar").fileSet(fastJarFileSet.build()).build())
+        .build();
   };
 
   public static final QuarkusAssembly LEGACY_JAR = quarkusGenerator -> {
     final JavaProject project = quarkusGenerator.getContext().getProject();
-    AssemblyFileSet.AssemblyFileSetBuilder fileSetBuilder = AssemblyFileSet.builder()
+    AssemblyFileSet.AssemblyFileSetBuilder libFileSet = createFileSet(project)
         .directory(FileUtil.getRelativePath(project.getBaseDirectory(), project.getBuildDirectory()))
-        .include(findSingleFileThatEndsWith(project, runnerSuffix(getQuarkusConfiguration(project)) + ".jar"))
         .include("lib")
         .fileMode("0640");
-    addDefaultArtifactExclude(project, fileSetBuilder);
-    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir(), fileSetBuilder.build());
+    AssemblyFileSet.AssemblyFileSetBuilder artifactFileSet = createFileSet(project)
+        .directory(FileUtil.getRelativePath(project.getBaseDirectory(), project.getBuildDirectory()))
+        .include(findSingleFileThatEndsWith(project, runnerSuffix(getQuarkusConfiguration(project)) + ".jar"))
+        .fileMode("0640");
+    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir())
+        .layer(Assembly.builder().id("lib").fileSet(libFileSet.build()).build())
+        .layer(Assembly.builder().id("artifact").fileSet(artifactFileSet.build()).build())
+        .build();
   };
 
   public static final QuarkusAssembly UBER_JAR = quarkusGenerator -> {
     final JavaProject project = quarkusGenerator.getContext().getProject();
-    AssemblyFileSet.AssemblyFileSetBuilder fileSetBuilder = AssemblyFileSet.builder()
+    final AssemblyFileSet.AssemblyFileSetBuilder fileSetBuilder = createFileSet(project)
         .directory(FileUtil.getRelativePath(project.getBaseDirectory(), project.getBuildDirectory()))
         .include(findSingleFileThatEndsWith(project, runnerSuffix(getQuarkusConfiguration(project)) + ".jar"))
         .fileMode("0640");
-    addDefaultArtifactExclude(project, fileSetBuilder);
-    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir(), fileSetBuilder.build());
+    return createAssemblyConfiguration(quarkusGenerator.getBuildWorkdir())
+        .layer(Assembly.builder().fileSet(fileSetBuilder.build()).build())
+        .build();
   };
 
-  private static void addDefaultArtifactExclude(JavaProject project, AssemblyFileSet.AssemblyFileSetBuilder fileSetBuilder) {
+  private static AssemblyFileSet.AssemblyFileSetBuilder createFileSet(JavaProject project) {
+    final AssemblyFileSet.AssemblyFileSetBuilder assemblyFileSetBuilder = AssemblyFileSet.builder()
+        .outputDirectory(new File("."));
     // We also need to exclude default jar file
     File defaultJarFile = JKubeProjectUtil.getFinalOutputArtifact(project);
     if (defaultJarFile != null) {
-      fileSetBuilder.exclude(defaultJarFile.getName());
+      assemblyFileSetBuilder.exclude(defaultJarFile.getName());
     }
+    return assemblyFileSetBuilder;
   }
 
-  private static AssemblyConfiguration createAssemblyConfiguration(String targetDir, AssemblyFileSet jKubeAssemblyFileSet) {
-    jKubeAssemblyFileSet.setOutputDirectory(".");
+  private static AssemblyConfiguration.AssemblyConfigurationBuilder createAssemblyConfiguration(String targetDir) {
     return AssemblyConfiguration.builder()
         .targetDir(targetDir)
-        .excludeFinalOutputArtifact(true)
-        .inline(Assembly.builder().fileSet(jKubeAssemblyFileSet).build())
-        .build();
+        .excludeFinalOutputArtifact(true);
   }
 
   @FunctionalInterface

--- a/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGenerator.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGenerator.java
@@ -77,7 +77,7 @@ public class WildflyJARGenerator extends JavaExecGenerator {
     }
 
     @Override
-    public List<AssemblyFileSet> addAdditionalFiles() {
+    protected List<AssemblyFileSet> addAdditionalFiles() {
         List<AssemblyFileSet> set = super.addAdditionalFiles();
         if (localRepoCache != null) {
             Path parentDir;
@@ -90,7 +90,7 @@ public class WildflyJARGenerator extends JavaExecGenerator {
             }
             if (Files.notExists(repoDir)) {
                throw new RuntimeException("Error, WildFly bootable JAR generator can't retrieve "
-                       + "generated maven local cache, directory " + repoDir + " doesn't exist."); 
+                       + "generated maven local cache, directory " + repoDir + " doesn't exist.");
             }
             set.add(AssemblyFileSet.builder()
                     .directory(parentDir.toFile())


### PR DESCRIPTION
## Description

Improved the Quarkus generator to make use of the new multi-layer feature (#425).

#### Implemented behavior for each of the Quarkus packaging modes

##### Native
Produces a single layer image with the native binary

##### Uber-Jar
Produces a single layer image with the runner fat-jar

##### Legacy-Jar
Produces a 2 layer image:
- `lib` contains the libraries and dependencies
- `artifact` contains the slim runner jar

##### Fast-Jar
Produces a 2 layer image:
- `lib` contains **only** the libraries and dependencies
- `fast-jar` contains the every other file and directory (excluding lib/**/*) in the `quarkus-app` directory


### Tests
| Cluster   | Packaging mode | Build strategy |                    |
|-----------|----------------|----------------|--------------------|
| Minikube  | native         | docker         | :heavy_check_mark: |
| Minikube  | native         | jib            | :heavy_check_mark: |
| Minikube  | uber-jar       | docker         | :heavy_check_mark: |
| Minikube  | uber-jar       | jib            | :heavy_check_mark: |
| Minikube  | legacy-jar     | docker         | :heavy_check_mark: |
| Minikube  | legacy-jar     | jib            | :heavy_check_mark: |
| Minikube  | fast-jar       | docker         | :heavy_check_mark: |
| Minikube  | fast-jar       | jib            | :heavy_check_mark: |
| OpenShift | fast-jar       | s2i            | :heavy_check_mark: |
| OpenShift | fast-jar       | docker            | :heavy_check_mark: |
| OpenShift | legacy-jar       | s2i            | :heavy_check_mark: |
| OpenShift | legacy-jar       | docker            | :heavy_check_mark: |
| OpenShift  | uber-jar       | s2i         | :heavy_check_mark: |
| OpenShift  | uber-jar       | docker            | :heavy_check_mark: |
| OpenShift  | native       | s2i         | :heavy_check_mark: |
| OpenShift  | native       | docker            | :heavy_check_mark: |

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->