### PR TITLE
Fix #653: `k8s:watch` port-forward websocket error due to wrong arguments in PortForwardService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ### 1.4.0-SNAPSHOT
 * Fix #741: Private constructor added to Utility classes
 * Fix #725: Upgrade HttpClient from 4.5.10 to 4.5.13
+* Fix #653: `k8s:watch` port-forward websocket error due to wrong arguments in PortForwardService
 * Fix #704: NPE when using Service fragment with no port specified
 * Fix #705: JIB assembly works on Windows
 * Fix #714: feat: Helm support for Golang expressions

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/DebugService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/DebugService.java
@@ -60,7 +60,7 @@ public class DebugService {
     private final PortForwardService portForwardService;
     private final ApplyService applyService;
     private String debugSuspendValue;
-    private String remoteDebugPort = DebugConstants.ENV_VAR_JAVA_DEBUG_PORT_DEFAULT;
+    private String debugPortInContainer = DebugConstants.ENV_VAR_JAVA_DEBUG_PORT_DEFAULT;
 
     public DebugService(KitLogger log, KubernetesClient kubernetesClient, PortForwardService portForwardService, ApplyService applyService) {
         this.log = log;
@@ -116,7 +116,7 @@ public class DebugService {
         if (firstSelector != null) {
             Map<String, String> envVars = initDebugEnvVarsMap(debugSuspend);
             String podName = waitForRunningPodWithEnvVar(namespace, firstSelector, envVars, podWaitLog);
-            portForwardService.startPortForward(podName, namespace, portToInt(remoteDebugPort, "remoteDebugPort"), portToInt(localDebugPort, "localDebugPort"));
+            portForwardService.startPortForward(podName, namespace, portToInt(debugPortInContainer, "containerDebugPort"), portToInt(localDebugPort, "localDebugPort"));
         }
     }
 
@@ -257,8 +257,8 @@ public class DebugService {
         if (ports == null) {
             ports = new ArrayList<>();
         }
-        if (!KubernetesHelper.containsPort(ports, remoteDebugPort)) {
-            ContainerPort port = KubernetesHelper.addPort(remoteDebugPort, "debug", log);
+        if (!KubernetesHelper.containsPort(ports, debugPortInContainer)) {
+            ContainerPort port = KubernetesHelper.addPort(debugPortInContainer, "debug", log);
             if (port != null) {
                 ports.add(port);
                 container.setPorts(ports);
@@ -274,7 +274,7 @@ public class DebugService {
         if (env == null) {
             env = new ArrayList<>();
         }
-        remoteDebugPort = KubernetesHelper.getEnvVar(env, DebugConstants.ENV_VAR_JAVA_DEBUG_PORT, DebugConstants.ENV_VAR_JAVA_DEBUG_PORT_DEFAULT);
+        debugPortInContainer = KubernetesHelper.getEnvVar(env, DebugConstants.ENV_VAR_JAVA_DEBUG_PORT, DebugConstants.ENV_VAR_JAVA_DEBUG_PORT_DEFAULT);
         if (KubernetesHelper.setEnvVar(env, DebugConstants.ENV_VAR_JAVA_DEBUG, "true")) {
             container.setEnv(env);
             enabled = true;

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServicePortOrderTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServicePortOrderTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.service;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.junit.Test;
+
+public class PortForwardServicePortOrderTest {
+    @Mocked
+    private KubernetesClient kubernetesClient;
+
+    @Mocked
+    private KitLogger logger;
+
+    @Test
+    public void testPortsSpecifiedInCorrectOrderPortForward() {
+        // Given
+        PortForwardService portForwardService = new PortForwardService(kubernetesClient, logger);
+
+        // When
+        portForwardService.forwardPortAsync("foo-pod", "foo-ns", 8080, 312323);
+
+        // Then
+        new Verifications() {{
+            kubernetesClient.pods().inNamespace("foo-ns").withName("foo-pod").portForward(8080, 312323);
+            times = 1;
+        }};
+    }
+}

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServiceTest.java
@@ -82,8 +82,8 @@ public class PortForwardServiceTest {
         OpenShiftClient client = mockServer.getOpenshiftClient();
         PortForwardService service = new PortForwardService(client, logger) {
             @Override
-            public LocalPortForward forwardPortAsync(String podName, String namespace, int remotePort, int localPort) {
-                return client.pods().inNamespace(namespace).withName(podName).portForward(localPort, remotePort);
+            public LocalPortForward forwardPortAsync(String podName, String namespace, int containerPort, int localPort) {
+                return client.pods().inNamespace(namespace).withName(podName).portForward(containerPort, localPort);
             }
         };
 

--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcher.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcher.java
@@ -110,7 +110,7 @@ public class SpringBootWatcher extends BaseWatcher {
         }
     }
 
-    private String getPortForwardUrl(final Collection<HasMetadata> resources) {
+    String getPortForwardUrl(final Collection<HasMetadata> resources) {
         LabelSelector selector = KubernetesHelper.extractPodLabelSelector(resources);
         if (selector == null) {
             log.warn("Unable to determine a selector for application pods");
@@ -122,11 +122,11 @@ public class SpringBootWatcher extends BaseWatcher {
         SpringBootConfigurationHelper propertyHelper = new SpringBootConfigurationHelper(
             SpringBootUtil.getSpringBootVersion(getContext().getBuildContext().getProject()));
 
-        int port = IoUtil.getFreeRandomPort();
+        int localHostPort = IoUtil.getFreeRandomPort();
         int containerPort = propertyHelper.getServerPort(properties);
-        portForwardService.forwardPortAsync(selector, containerPort, port);
+        portForwardService.forwardPortAsync(selector, containerPort, localHostPort);
 
-        return createForwardUrl(propertyHelper, properties, port);
+        return createForwardUrl(propertyHelper, properties, localHostPort);
     }
 
     private String createForwardUrl(SpringBootConfigurationHelper propertyHelper, Properties properties, int localPort) {

--- a/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcherTest.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcherTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.springboot.watcher;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.common.util.SpringBootUtil;
+import org.eclipse.jkube.kit.config.service.PortForwardService;
+import org.eclipse.jkube.watcher.api.WatcherContext;
+import org.junit.Test;
+
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings({"ResultOfMethodCallIgnored", "AccessStaticViaInstance", "unused"})
+public class SpringBootWatcherTest {
+    @Mocked
+    private PortForwardService portForwardService;
+
+    @Mocked
+    private WatcherContext watcherContext;
+
+    @Mocked
+    private JKubeConfiguration jkubeConfiguration;
+
+    @Mocked
+    private JavaProject javaProject;
+
+    @Mocked
+    private KubernetesHelper kubernetesHelper;
+
+    @Mocked
+    private SpringBootUtil springBootUtil;
+
+    @Test
+    public void testGetPortForwardUrl() {
+        // Given
+        List<HasMetadata> resources = new ArrayList<>();
+        resources.add(new DeploymentBuilder().withNewMetadata().withName("d1").endMetadata()
+                .withNewSpec()
+                .withNewSelector()
+                .withMatchLabels(Collections.singletonMap("foo", "bar"))
+                .endSelector()
+                .endSpec()
+                .build());
+        resources.add(new ServiceBuilder().withNewMetadata().withName("s1").endMetadata().build());
+        new Expectations() {{
+            watcherContext.getBuildContext();
+            result = jkubeConfiguration;
+
+            jkubeConfiguration.getProject();
+            result = javaProject;
+
+            javaProject.getProperties();
+            result = new Properties();
+
+            javaProject.getCompileClassPathElements();
+            result = Collections.singletonList("/foo");
+
+            javaProject.getOutputDirectory().getAbsolutePath();
+            result = "target/classes";
+
+            Properties properties = new Properties();
+            properties.put("server.port", "9001");
+            springBootUtil.getSpringBootApplicationProperties((URLClassLoader) any);
+            result = properties;
+        }};
+        SpringBootWatcher springBootWatcher = new SpringBootWatcher(watcherContext);
+
+        // When
+        String portForwardUrl = springBootWatcher.getPortForwardUrl(resources);
+
+        // Then
+        assertTrue(portForwardUrl.contains("http://localhost:"));
+        new Verifications() {{
+            portForwardService.forwardPortAsync((LabelSelector) any, 9001, anyInt);
+        }};
+    }
+}


### PR DESCRIPTION
## Description
Fix #653

Make order of port forward arguments consistent across Service classes.
Now all methods have containerPort, remotePort argument format

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->