### PR TITLE
Fix #756: Service re-apply error happening during `k8s:watch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Usage:
 * Fix #701: Update Fabric8 Kubernetes Client to 5.4.0
 * Fix #425: Multi-layer support for Container Images
 * Fix #751: QuarkusGenerator: Multi-layer images for the different Quarkus packaging modes
+* Fix #756: Service re-apply error happening during `k8s:watch`
 
 ### 1.3.0 (2021-05-18)
 * Fix #497: Assembly descriptor removed but still in documentation

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/PatchService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/PatchService.java
@@ -170,7 +170,7 @@ public class PatchService {
             return client.services()
                     .inNamespace(namespace)
                     .withName(newObj.getMetadata().getName())
-                    .edit(p -> entity.build());
+                    .patch(entity.build());
         };
     }
 


### PR DESCRIPTION

## Description
Fix #756 

Use patch() instead of edit() since we don't seem to be making use of the `p`(argument in UnaryOperator which is usually resource fetched from Server).

Based on discussion here https://github.com/fabric8io/kubernetes-client/pull/3221#discussion_r665441853

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->