### PR TITLE
Remove redundant code from Arguments.java

### DIFF
--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/Arguments.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/Arguments.java
@@ -19,13 +19,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.Singular;
+
+import org.eclipse.jkube.kit.common.util.EnvUtil;
 
 @Getter
 @Setter
@@ -111,12 +112,7 @@ public class Arguments implements Serializable {
 
     public List<String> asStrings() {
         if (shell != null) {
-            String[] split = shell.split("(?<!" + Pattern.quote("\\") + ")\\s+");
-            String[] res = new String[split.length];
-            for (int i = 0; i < split.length; i++) {
-                res[i] = split[i].replaceAll("\\\\ "," ");
-            }
-            return Arrays.asList(res);
+            return Arrays.asList(EnvUtil.splitOnSpaceWithEscape(shell));
         }
         if (exec != null) {
             return Collections.unmodifiableList(exec);

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/Arguments.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/Arguments.java
@@ -54,7 +54,7 @@ public class Arguments implements Serializable {
      *     &lt;exec&gt;
      *       &lt;arg&gt;echo&lt;/arg&gt;
      *       &lt;arg&gt;Hello, world!&lt;/arg&gt;
-     *     &lt;exec&gt;
+     *     &lt;/exec&gt;
      *   &lt;/cmd&gt;
      * </pre>
      *

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/ArgumentsTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/ArgumentsTest.java
@@ -24,8 +24,7 @@ public class ArgumentsTest {
     @Test
     public void testShellArgWithSpaceEscape() {
       String[] testSubject = { "java", "-jar", "$HOME/name with space.jar" };
-      Arguments arg = (new Arguments()).builder().build();
-      arg.set("java -jar $HOME/name\\ with\\ space.jar");
-      assertThat(arg.asStrings()).isEqualTo(Arrays.asList(testSubject));
+      Arguments arg = Arguments.builder().shell("java -jar $HOME/name\\ with\\ space.jar").build();
+      assertThat(arg.asStrings()).containsExactly(testSubject);
     }
 }

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/ArgumentsTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/ArgumentsTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.image.build;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArgumentsTest {
+
+    @Test
+    public void testShellArgWithSpaceEscape() {
+      String[] testSubject = { "java", "-jar", "$HOME/name with space.jar" };
+      Arguments arg = (new Arguments()).builder().build();
+      arg.set("java -jar $HOME/name\\ with\\ space.jar");
+      assertThat(arg.asStrings()).isEqualTo(Arrays.asList(testSubject));
+    }
+}


### PR DESCRIPTION
## Description
Fixes #755

This PR removes redundant code from `Arguments.java` as pointed by Sonar Cloud and https://github.com/eclipse/jkube/issues/755#issue-935580117.

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->