### PR TITLE
Fix #758: QuarkusHealthCheckEnricher default health path outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Usage:
 * Fix #425: Multi-layer support for Container Images
 * Fix #751: QuarkusGenerator: Multi-layer images for the different Quarkus packaging modes
 * Fix #756: Service re-apply error happening during `k8s:watch`
+* Fix #758: QuarkusHealthCheckEnricher: default health path value is outdated
 
 ### 1.3.0 (2021-05-18)
 * Fix #497: Assembly descriptor removed but still in documentation

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
@@ -13,15 +13,18 @@
  */
 package org.eclipse.jkube.quarkus;
 
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jkube.kit.common.JavaProject;
-import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
-
 import java.io.File;
 import java.net.URLClassLoader;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
+
+import org.apache.commons.lang3.StringUtils;
 
 import static org.eclipse.jkube.kit.common.util.FileUtil.stripPrefix;
 import static org.eclipse.jkube.kit.common.util.JKubeProjectUtil.getClassLoader;
@@ -31,21 +34,24 @@ import static org.eclipse.jkube.kit.common.util.YamlUtil.getPropertiesFromYamlRe
 
 public class QuarkusUtils {
 
+  public static final String QUARKUS_GROUP_ID = "io.quarkus";
   private static final String QUARKUS_HTTP_PORT = "quarkus.http.port";
   private static final String QUARKUS_PACKAGE_RUNNER_SUFFIX = "quarkus.package.runner-suffix";
-  private static final String QUARKUS_UNIVERSE_BOM_GROUP_ID = "io.quarkus";
   private static final String QUARKUS_HTTP_ROOT_PATH = "quarkus.http.root-path";
   private static final String QUARKUS_HTTP_NON_APPLICATION_ROOT_PATH = "quarkus.http.non-application-root-path";
   private static final String QUARKUS_SMALLRYE_HEALTH_ROOT_PATH = "quarkus.smallrye-health.root-path";
+  private static final String QUARKUS_SMALLRYE_HEALTH_READINESS_PATH = "quarkus.smallrye-health.readiness-path";
   private static final String QUARKUS_SMALLRYE_HEALTH_LIVENESS_PATH = "quarkus.smallrye-health.liveness-path";
   private static final int QUARKUS_MAJOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE = 1;
   private static final int QUARKUS_MINOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE = 11;
   private static final int QUARKUS2_MAJOR_VERSION = 2;
   private static final int QUARKUS2_MINOR_VERSION = 0;
-  private static final String QUARKUS_DEFAULT_LIVENESS_SUBPATH = "live";
-  private static final String QUARKUS_DEFAULT_ROOT_PATH = "/";
-  private static final String QUARKUS_DEFAULT_HEALTH_PATH_BEFORE_2_0 = "health";
-  private static final String QUARKUS_DEFAULT_HEALTH_PATH_AFTER_2_0 = "q/health";
+  private static final String DEFAULT_ROOT_PATH = "/";
+  private static final String DEFAULT_NON_APPLICATION_ROOT_BEFORE_2_0 = "";
+  private static final String DEFAULT_NON_APPLICATION_ROOT_AFTER_2_0 = "q";
+  private static final String DEFAULT_HEALTH_ROOT_PATH = "health";
+  private static final String DEFAULT_READINESS_SUBPATH = "ready";
+  private static final String DEFAULT_LIVENESS_SUBPATH = "live";
 
   private QuarkusUtils() {}
 
@@ -104,89 +110,6 @@ public class QuarkusUtils {
     return project.getProperties();
   }
 
-  /**
-   * Get Quarkus version from checking quarkus-universe-bom artifactId in project dependencies
-   *
-   * @param javaProject {@link JavaProject} project for which version is queried
-   * @return an Optional String either containing quarkus version or empty optional
-   */
-  public static Optional<String> getQuarkusVersion(JavaProject javaProject) {
-    return Optional.ofNullable(JKubeProjectUtil.getAnyDependencyVersionWithGroupId(javaProject, QUARKUS_UNIVERSE_BOM_GROUP_ID));
-  }
-
-  /**
-   * Get Quarkus SmallRye Health root path by checking project properties
-   *
-   * @param javaProject {@link JavaProject} project for which health path is required
-   * @return a string containing fully qualified health root path
-   */
-  public static String resolveCompleteQuarkusHealthRootPath(JavaProject javaProject) {
-    String healthPath = resolveQuarkusHealthRootPath(javaProject);
-    Properties properties = getQuarkusConfiguration(javaProject);
-    String quarkusVersion = getQuarkusVersion(javaProject).orElse(null);
-    if (shouldUseAbsoluteHealthPaths(quarkusVersion, healthPath)) {
-      return healthPath;
-    }
-    return resolveCompleteQuarkusHealthRootPath(quarkusVersion, properties, healthPath);
-  }
-
-  /**
-   * Get Quarkus SmallRye Health liveliness path by checking project properties
-   *
-   * @param javaProject {@link JavaProject} project for which health liveliness path is required
-   * @return a string containing liveliness path(it may or may not be absolute path dependending on user configuration)
-   */
-  public static String resolveQuarkusLivelinessRootPath(JavaProject javaProject) {
-    Properties properties = getQuarkusConfiguration(javaProject);
-    Object livenessPath = properties.get(QUARKUS_SMALLRYE_HEALTH_LIVENESS_PATH);
-    return livenessPath != null ? livenessPath.toString() : QUARKUS_DEFAULT_LIVENESS_SUBPATH;
-  }
-
-  /**
-   * Check whether Quarkus version is at least provided version
-   *
-   * @param javaProject {@link JavaProject} Project for which version is being checked
-   * @param majorVersion minimum major version
-   * @param minorVersion minimum minor version
-   * @return a boolean value which satisfies given criteria
-   */
-  public static boolean isQuarkusVersionAtLeast(JavaProject javaProject, int majorVersion, int minorVersion) {
-    return getQuarkusVersion(javaProject)
-            .filter(s -> isQuarkusVersionAtLeast(majorVersion, minorVersion, s))
-            .isPresent();
-  }
-
-  /**
-   * Create final Health Check paths
-   *
-   * @param healthPath health path (usually configured via properties, defaults to health)
-   * @param subPath sub path for liveness/readiness endpoints
-   * @return string with full health check path
-   */
-  public static String createHealthCheckPath(String healthPath, String subPath) {
-    if (healthPath.equals("/")) {
-      return String.format("/%s", stripPrefix(subPath, "/"));
-    }
-    return String.format("/%s/%s", stripPrefix(healthPath, "/"), stripPrefix(subPath, "/"));
-  }
-
-  /**
-   * Since Quarkus 1.11.5.Final Quarkus considers leading slashes in health urls
-   * configured via properties. This method checks if Quarkus version is at least
-   * required version and returns a boolean value whether leading slash should
-   * be considered or not
-   *
-   * @param quarkusVersion Project quarkus version
-   * @param healthPath health path
-   * @return boolean value whether to use absolute health path or not.
-   */
-  public static boolean shouldUseAbsoluteHealthPaths(String quarkusVersion, String healthPath) {
-    if (isQuarkusVersionAtLeast(QUARKUS_MAJOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE, QUARKUS_MINOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE, quarkusVersion)) {
-      return isAbsolutePath(healthPath);
-    }
-    return false;
-  }
-
   private static Optional<String> getActiveProfile(JavaProject project) {
     return Optional.ofNullable(project)
         .map(JavaProject::getProperties)
@@ -194,63 +117,106 @@ public class QuarkusUtils {
         .map(Object::toString);
   }
 
-  private static String resolveQuarkusHealthRootPath(JavaProject javaProject) {
-    Properties properties = getQuarkusConfiguration(javaProject);
-    String quarkusVersion = getQuarkusVersion(javaProject).orElse(null);
-    Object healthPathObj = properties.get(QUARKUS_SMALLRYE_HEALTH_ROOT_PATH);
-    if (healthPathObj != null) {
-      return healthPathObj.toString();
-    }
-    return isQuarkusVersionAtLeast(QUARKUS2_MAJOR_VERSION, QUARKUS2_MINOR_VERSION, quarkusVersion) ?
-            QUARKUS_DEFAULT_HEALTH_PATH_AFTER_2_0 :
-            QUARKUS_DEFAULT_HEALTH_PATH_BEFORE_2_0;
+  /**
+   * Get Quarkus SmallRye Health readiness path from Quarkus configuration
+   *
+   * @param javaProject {@link JavaProject} project for which health readiness path is required
+   * @return a string containing the readiness path
+   */
+  public static String resolveQuarkusReadinessPath(JavaProject javaProject) {
+    return getQuarkusConfiguration(javaProject)
+        .getProperty(QUARKUS_SMALLRYE_HEALTH_READINESS_PATH, DEFAULT_READINESS_SUBPATH);
   }
 
-  private static String resolveCompleteQuarkusHealthRootPath(String quarkusVersion, Properties properties, String subPath) {
-    Object nonApplicationRootPath = properties.get(QUARKUS_HTTP_NON_APPLICATION_ROOT_PATH);
-    if (nonApplicationRootPath != null) {
-      return createCompleteHealthPathWithNonApplicationRootPath(quarkusVersion, properties, subPath, nonApplicationRootPath);
-    }
-    return createCompleteHealthPath(null, properties, subPath);
+  /**
+   * Get Quarkus SmallRye Health liveness path from Quarkus configuration
+   *
+   * @param javaProject {@link JavaProject} project for which health liveness path is required
+   * @return a string containing the liveness path
+   */
+  public static String resolveQuarkusLivenessPath(JavaProject javaProject) {
+    return getQuarkusConfiguration(javaProject)
+        .getProperty(QUARKUS_SMALLRYE_HEALTH_LIVENESS_PATH, DEFAULT_LIVENESS_SUBPATH);
   }
 
-  private static String createCompleteHealthPathWithNonApplicationRootPath(String quarkusVersion, Properties properties, String subPath, Object nonApplicationRootPath) {
-    if (shouldUseAbsoluteHealthPaths(quarkusVersion, nonApplicationRootPath.toString())) {
-      return String.format("/%s/%s", stripPrefix(nonApplicationRootPath.toString(), "/"), subPath);
-    }
-    return createCompleteHealthPath(nonApplicationRootPath.toString(), properties, subPath);
+  /**
+   * Since Quarkus 1.11.5.Final Quarkus considers leading slashes in configured application
+   * properties health paths as absolute urls.
+   * This method checks if Quarkus version is at least required version and returns a boolean value
+   * whether leading slash should be considered or not.
+   *
+   * @param quarkusVersion Quarkus version for the current Project
+   * @param healthPath health path
+   * @return boolean value whether to use absolute health path or not.
+   * @see <a href="https://quarkus.io/blog/path-resolution-in-quarkus/">https://quarkus.io/blog/path-resolution-in-quarkus/</a>
+   */
+  static boolean shouldUseAbsoluteHealthPaths(String quarkusVersion, String healthPath) {
+    return isVersionAtLeast(QUARKUS_MAJOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE,
+        QUARKUS_MINOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE, quarkusVersion)
+        && isAbsolutePath(healthPath);
   }
 
-  private static String createCompleteHealthPath(String nonApplicationRootPath, Properties properties, String subPath) {
-    Object applicationRootPathObj = properties.get(QUARKUS_HTTP_ROOT_PATH);
-    String applicationRootPath = applicationRootPathObj != null ? applicationRootPathObj.toString() : QUARKUS_DEFAULT_ROOT_PATH;
-
-    if (StringUtils.isNotBlank(nonApplicationRootPath)) {
-      return createHealthPathWithNonApplicationRootPath(applicationRootPath, nonApplicationRootPath, subPath);
+  /**
+   * Get Quarkus SmallRye Health root path by checking project properties
+   *
+   * @param javaProject {@link JavaProject} project for which health path is required
+   * @param subPath the applicable readiness/liveness subpath to append
+   * @return a string containing fully qualified health root path
+   */
+  public static String resolveCompleteQuarkusHealthRootPath(JavaProject javaProject, String subPath) {
+    final String quarkusVersion = findQuarkusVersion(javaProject);
+    final Properties quarkusProperties = getQuarkusConfiguration(javaProject);
+    final String healthRootPath = quarkusProperties.getProperty(QUARKUS_SMALLRYE_HEALTH_ROOT_PATH, DEFAULT_HEALTH_ROOT_PATH);
+    final String nonApplicationRootPath = resolveQuarkusNonApplicationRootPath(quarkusVersion, quarkusProperties);
+    final String rootPath = quarkusProperties.getProperty(QUARKUS_HTTP_ROOT_PATH, DEFAULT_ROOT_PATH);
+    String ret = "";
+    for (String component : new String[]{subPath, healthRootPath, nonApplicationRootPath, rootPath}) {
+      ret = concatPath(component, ret);
+      if (shouldUseAbsoluteHealthPaths(quarkusVersion, component)) {
+        return ret;
+      }
     }
-    return createHealthCheckPath(applicationRootPath, subPath);
+    return ret;
   }
 
-  private static String createHealthPathWithNonApplicationRootPath(String applicationRootPath, String nonApplicationRootPath, String subPath) {
-    if (applicationRootPath.equals("/")) {
-      return String.format("%s%s/%s", applicationRootPath, nonApplicationRootPath, subPath);
-    }
-    return String.format("/%s/%s/%s", stripPrefix(applicationRootPath, "/"), nonApplicationRootPath, subPath);
+  private static String resolveQuarkusNonApplicationRootPath(String quarkusVersion, Properties quarkusProperties) {
+    final String defaultValue = isVersionAtLeast(QUARKUS2_MAJOR_VERSION, QUARKUS2_MINOR_VERSION, quarkusVersion) ?
+        DEFAULT_NON_APPLICATION_ROOT_AFTER_2_0 : DEFAULT_NON_APPLICATION_ROOT_BEFORE_2_0;
+    return quarkusProperties.getProperty(QUARKUS_HTTP_NON_APPLICATION_ROOT_PATH, defaultValue);
   }
 
-  private static boolean isQuarkusVersionAtLeast(int majorVersion, int minorVersion, String quarkusVersion) {
-    if (StringUtils.isNotBlank(quarkusVersion)) {
-      String[] quarkusVersionParts = quarkusVersion.split("\\.");
-      int projectMajorVersion = Integer.parseInt(quarkusVersionParts[0]);
-      int projectMinorVersion = Integer.parseInt(quarkusVersionParts[1]);
+  public static String concatPath(String... paths) {
+    return "/" + Stream.of(paths)
+        .filter(StringUtils::isNotBlank)
+        .filter(path -> !"/".equals(path))
+        .map(path -> stripPrefix(path, "/"))
+        .collect(Collectors.joining("/"));
+  }
 
-      if (projectMajorVersion > majorVersion) {
+  static String findQuarkusVersion(JavaProject javaProject) {
+    return Optional.ofNullable(JKubeProjectUtil.getAnyDependencyVersionWithGroupId(javaProject, QUARKUS_GROUP_ID))
+        .orElse(null);
+  }
+
+  static boolean isVersionAtLeast(int majorVersion, int minorVersion, String version) {
+    if (StringUtils.isNotBlank(version) && version.contains(".")) {
+      final String[] versionParts = version.split("\\.");
+      final int parsedMajorVersion = parseInt(versionParts[0]);
+      if (parsedMajorVersion > majorVersion) {
         return true;
-      } else if (projectMajorVersion == majorVersion) {
-        return projectMinorVersion >= minorVersion;
+      } else if (parsedMajorVersion == majorVersion) {
+        return parseInt(versionParts[1]) >= minorVersion;
       }
     }
     return false;
+  }
+
+  private static int parseInt(String toParse) {
+    try {
+      return Integer.parseInt(toParse);
+    } catch (NumberFormatException ex) {
+      return -1;
+    }
   }
 
   private static boolean isAbsolutePath(String path) {

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.quarkus;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
 
 import java.io.File;
 import java.net.URLClassLoader;
@@ -22,6 +23,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
 
+import static org.eclipse.jkube.kit.common.util.FileUtil.stripPrefix;
 import static org.eclipse.jkube.kit.common.util.JKubeProjectUtil.getClassLoader;
 import static org.eclipse.jkube.kit.common.util.PropertiesUtil.getPropertiesFromResource;
 import static org.eclipse.jkube.kit.common.util.PropertiesUtil.toMap;
@@ -31,6 +33,19 @@ public class QuarkusUtils {
 
   private static final String QUARKUS_HTTP_PORT = "quarkus.http.port";
   private static final String QUARKUS_PACKAGE_RUNNER_SUFFIX = "quarkus.package.runner-suffix";
+  private static final String QUARKUS_UNIVERSE_BOM_GROUP_ID = "io.quarkus";
+  private static final String QUARKUS_HTTP_ROOT_PATH = "quarkus.http.root-path";
+  private static final String QUARKUS_HTTP_NON_APPLICATION_ROOT_PATH = "quarkus.http.non-application-root-path";
+  private static final String QUARKUS_SMALLRYE_HEALTH_ROOT_PATH = "quarkus.smallrye-health.root-path";
+  private static final String QUARKUS_SMALLRYE_HEALTH_LIVENESS_PATH = "quarkus.smallrye-health.liveness-path";
+  private static final int QUARKUS_MAJOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE = 1;
+  private static final int QUARKUS_MINOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE = 11;
+  private static final int QUARKUS2_MAJOR_VERSION = 2;
+  private static final int QUARKUS2_MINOR_VERSION = 0;
+  private static final String QUARKUS_DEFAULT_LIVENESS_SUBPATH = "live";
+  private static final String QUARKUS_DEFAULT_ROOT_PATH = "/";
+  private static final String QUARKUS_DEFAULT_HEALTH_PATH_BEFORE_2_0 = "health";
+  private static final String QUARKUS_DEFAULT_HEALTH_PATH_AFTER_2_0 = "q/health";
 
   private QuarkusUtils() {}
 
@@ -89,10 +104,156 @@ public class QuarkusUtils {
     return project.getProperties();
   }
 
+  /**
+   * Get Quarkus version from checking quarkus-universe-bom artifactId in project dependencies
+   *
+   * @param javaProject {@link JavaProject} project for which version is queried
+   * @return an Optional String either containing quarkus version or empty optional
+   */
+  public static Optional<String> getQuarkusVersion(JavaProject javaProject) {
+    return Optional.ofNullable(JKubeProjectUtil.getAnyDependencyVersionWithGroupId(javaProject, QUARKUS_UNIVERSE_BOM_GROUP_ID));
+  }
+
+  /**
+   * Get Quarkus SmallRye Health root path by checking project properties
+   *
+   * @param javaProject {@link JavaProject} project for which health path is required
+   * @return a string containing fully qualified health root path
+   */
+  public static String resolveCompleteQuarkusHealthRootPath(JavaProject javaProject) {
+    String healthPath = resolveQuarkusHealthRootPath(javaProject);
+    Properties properties = getQuarkusConfiguration(javaProject);
+    String quarkusVersion = getQuarkusVersion(javaProject).orElse(null);
+    if (shouldUseAbsoluteHealthPaths(quarkusVersion, healthPath)) {
+      return healthPath;
+    }
+    return resolveCompleteQuarkusHealthRootPath(quarkusVersion, properties, healthPath);
+  }
+
+  /**
+   * Get Quarkus SmallRye Health liveliness path by checking project properties
+   *
+   * @param javaProject {@link JavaProject} project for which health liveliness path is required
+   * @return a string containing liveliness path(it may or may not be absolute path dependending on user configuration)
+   */
+  public static String resolveQuarkusLivelinessRootPath(JavaProject javaProject) {
+    Properties properties = getQuarkusConfiguration(javaProject);
+    Object livenessPath = properties.get(QUARKUS_SMALLRYE_HEALTH_LIVENESS_PATH);
+    return livenessPath != null ? livenessPath.toString() : QUARKUS_DEFAULT_LIVENESS_SUBPATH;
+  }
+
+  /**
+   * Check whether Quarkus version is at least provided version
+   *
+   * @param javaProject {@link JavaProject} Project for which version is being checked
+   * @param majorVersion minimum major version
+   * @param minorVersion minimum minor version
+   * @return a boolean value which satisfies given criteria
+   */
+  public static boolean isQuarkusVersionAtLeast(JavaProject javaProject, int majorVersion, int minorVersion) {
+    return getQuarkusVersion(javaProject)
+            .filter(s -> isQuarkusVersionAtLeast(majorVersion, minorVersion, s))
+            .isPresent();
+  }
+
+  /**
+   * Create final Health Check paths
+   *
+   * @param healthPath health path (usually configured via properties, defaults to health)
+   * @param subPath sub path for liveness/readiness endpoints
+   * @return string with full health check path
+   */
+  public static String createHealthCheckPath(String healthPath, String subPath) {
+    if (healthPath.equals("/")) {
+      return String.format("/%s", stripPrefix(subPath, "/"));
+    }
+    return String.format("/%s/%s", stripPrefix(healthPath, "/"), stripPrefix(subPath, "/"));
+  }
+
+  /**
+   * Since Quarkus 1.11.5.Final Quarkus considers leading slashes in health urls
+   * configured via properties. This method checks if Quarkus version is at least
+   * required version and returns a boolean value whether leading slash should
+   * be considered or not
+   *
+   * @param quarkusVersion Project quarkus version
+   * @param healthPath health path
+   * @return boolean value whether to use absolute health path or not.
+   */
+  public static boolean shouldUseAbsoluteHealthPaths(String quarkusVersion, String healthPath) {
+    if (isQuarkusVersionAtLeast(QUARKUS_MAJOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE, QUARKUS_MINOR_VERSION_SINCE_PATH_RESOLUTION_CHANGE, quarkusVersion)) {
+      return isAbsolutePath(healthPath);
+    }
+    return false;
+  }
+
   private static Optional<String> getActiveProfile(JavaProject project) {
     return Optional.ofNullable(project)
         .map(JavaProject::getProperties)
         .map(properties -> properties.get("quarkus.profile"))
         .map(Object::toString);
+  }
+
+  private static String resolveQuarkusHealthRootPath(JavaProject javaProject) {
+    Properties properties = getQuarkusConfiguration(javaProject);
+    String quarkusVersion = getQuarkusVersion(javaProject).orElse(null);
+    Object healthPathObj = properties.get(QUARKUS_SMALLRYE_HEALTH_ROOT_PATH);
+    if (healthPathObj != null) {
+      return healthPathObj.toString();
+    }
+    return isQuarkusVersionAtLeast(QUARKUS2_MAJOR_VERSION, QUARKUS2_MINOR_VERSION, quarkusVersion) ?
+            QUARKUS_DEFAULT_HEALTH_PATH_AFTER_2_0 :
+            QUARKUS_DEFAULT_HEALTH_PATH_BEFORE_2_0;
+  }
+
+  private static String resolveCompleteQuarkusHealthRootPath(String quarkusVersion, Properties properties, String subPath) {
+    Object nonApplicationRootPath = properties.get(QUARKUS_HTTP_NON_APPLICATION_ROOT_PATH);
+    if (nonApplicationRootPath != null) {
+      return createCompleteHealthPathWithNonApplicationRootPath(quarkusVersion, properties, subPath, nonApplicationRootPath);
+    }
+    return createCompleteHealthPath(null, properties, subPath);
+  }
+
+  private static String createCompleteHealthPathWithNonApplicationRootPath(String quarkusVersion, Properties properties, String subPath, Object nonApplicationRootPath) {
+    if (shouldUseAbsoluteHealthPaths(quarkusVersion, nonApplicationRootPath.toString())) {
+      return String.format("/%s/%s", stripPrefix(nonApplicationRootPath.toString(), "/"), subPath);
+    }
+    return createCompleteHealthPath(nonApplicationRootPath.toString(), properties, subPath);
+  }
+
+  private static String createCompleteHealthPath(String nonApplicationRootPath, Properties properties, String subPath) {
+    Object applicationRootPathObj = properties.get(QUARKUS_HTTP_ROOT_PATH);
+    String applicationRootPath = applicationRootPathObj != null ? applicationRootPathObj.toString() : QUARKUS_DEFAULT_ROOT_PATH;
+
+    if (StringUtils.isNotBlank(nonApplicationRootPath)) {
+      return createHealthPathWithNonApplicationRootPath(applicationRootPath, nonApplicationRootPath, subPath);
+    }
+    return createHealthCheckPath(applicationRootPath, subPath);
+  }
+
+  private static String createHealthPathWithNonApplicationRootPath(String applicationRootPath, String nonApplicationRootPath, String subPath) {
+    if (applicationRootPath.equals("/")) {
+      return String.format("%s%s/%s", applicationRootPath, nonApplicationRootPath, subPath);
+    }
+    return String.format("/%s/%s/%s", stripPrefix(applicationRootPath, "/"), nonApplicationRootPath, subPath);
+  }
+
+  private static boolean isQuarkusVersionAtLeast(int majorVersion, int minorVersion, String quarkusVersion) {
+    if (StringUtils.isNotBlank(quarkusVersion)) {
+      String[] quarkusVersionParts = quarkusVersion.split("\\.");
+      int projectMajorVersion = Integer.parseInt(quarkusVersionParts[0]);
+      int projectMinorVersion = Integer.parseInt(quarkusVersionParts[1]);
+
+      if (projectMajorVersion > majorVersion) {
+        return true;
+      } else if (projectMajorVersion == majorVersion) {
+        return projectMinorVersion >= minorVersion;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isAbsolutePath(String path) {
+    return path != null && path.startsWith("/");
   }
 }

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricher.java
@@ -13,31 +13,29 @@
  */
 package org.eclipse.jkube.quarkus.enricher;
 
-import io.fabric8.kubernetes.api.model.Probe;
-import io.fabric8.kubernetes.api.model.ProbeBuilder;
+import java.util.function.Function;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
+import org.eclipse.jkube.quarkus.QuarkusUtils;
 
-import java.util.function.Supplier;
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.ProbeBuilder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 
 import static org.eclipse.jkube.kit.common.Configs.asInteger;
-import static org.eclipse.jkube.quarkus.QuarkusUtils.createHealthCheckPath;
-import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusVersion;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.QUARKUS_GROUP_ID;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.concatPath;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.resolveCompleteQuarkusHealthRootPath;
-import static org.eclipse.jkube.quarkus.QuarkusUtils.resolveQuarkusLivelinessRootPath;
-import static org.eclipse.jkube.quarkus.QuarkusUtils.shouldUseAbsoluteHealthPaths;
 
 /**
  * Enriches Quarkus containers with health checks if the quarkus-smallrye-health is present
  */
 public class QuarkusHealthCheckEnricher extends AbstractHealthCheckEnricher {
-
-    private static final String READY_SUBPATH = "ready";
-    private static final String DEFAULT_HEALTH_PATH = "health";
 
     public QuarkusHealthCheckEnricher(JKubeEnricherContext buildContext) {
         super(buildContext, "jkube-healthcheck-quarkus");
@@ -52,7 +50,7 @@ public class QuarkusHealthCheckEnricher extends AbstractHealthCheckEnricher {
         SUCCESS_THRESHOLD("successThreshold", "1"),
         LIVENESS_INITIAL_DELAY("livenessInitialDelay", null),
         READINESS_INTIAL_DELAY("readinessIntialDelay", null),
-        HEALTH_PATH("path", DEFAULT_HEALTH_PATH);
+        HEALTH_PATH("path", null);
 
         @Getter
         protected String key;
@@ -63,24 +61,23 @@ public class QuarkusHealthCheckEnricher extends AbstractHealthCheckEnricher {
     @Override
     protected Probe getReadinessProbe() {
         return discoverQuarkusHealthCheck(asInteger(getConfig(Config.READINESS_INTIAL_DELAY, "5")),
-                this::findQuarkusHealthPathFromPropertiesOrConfig);
+            QuarkusUtils::resolveQuarkusReadinessPath);
     }
 
     @Override
     protected Probe getLivenessProbe() {
         return discoverQuarkusHealthCheck(asInteger(getConfig(Config.LIVENESS_INITIAL_DELAY, "10")),
-                this::findQuarkusHeathLivenessPath);
+            QuarkusUtils::resolveQuarkusLivenessPath);
     }
 
-    private Probe discoverQuarkusHealthCheck(int initialDelay, Supplier<String> pathSupplier) {
-        if (!getContext().hasDependency("io.quarkus", "quarkus-smallrye-health")) {
+    private Probe discoverQuarkusHealthCheck(int initialDelay, Function<JavaProject, String> pathResolver) {
+        if (!getContext().hasDependency(QUARKUS_GROUP_ID, "quarkus-smallrye-health")) {
             return null;
         }
-
         return new ProbeBuilder()
             .withNewHttpGet()
               .withNewPort(asInteger(getConfig(Config.PORT)))
-              .withPath(pathSupplier.get())
+              .withPath(resolveHealthPath(pathResolver.apply(getContext().getProject())))
               .withScheme(getConfig(Config.SCHEME))
             .endHttpGet()
             .withFailureThreshold(asInteger(getConfig(Config.FAILURE_THRESHOLD)))
@@ -89,26 +86,10 @@ public class QuarkusHealthCheckEnricher extends AbstractHealthCheckEnricher {
             .build();
     }
 
-    private String findQuarkusHealthPathFromPropertiesOrConfig() {
-        String defaultHealthPath = getConfig(Config.HEALTH_PATH);
-        if (!defaultHealthPath.equals(DEFAULT_HEALTH_PATH)) {
-            return createHealthCheckPath(defaultHealthPath, READY_SUBPATH);
+    private String resolveHealthPath(String subPath) {
+        if (StringUtils.isNotBlank(getConfig(Config.HEALTH_PATH))) {
+            return concatPath(getConfig(Config.HEALTH_PATH), subPath);
         }
-        return createHealthCheckPath(resolveCompleteQuarkusHealthRootPath(getContext().getProject()), READY_SUBPATH);
-    }
-
-    private String findQuarkusHeathLivenessPath() {
-        String defaultHealthPath = getConfig(Config.HEALTH_PATH);
-        String livelinessPath = resolveQuarkusLivelinessRootPath(getContext().getProject());
-        if (!defaultHealthPath.equals(DEFAULT_HEALTH_PATH)) {
-            return createHealthCheckPath(defaultHealthPath, livelinessPath);
-        }
-
-        String quarkusVersion = getQuarkusVersion(getContext().getProject()).orElse(null);
-        if (shouldUseAbsoluteHealthPaths(quarkusVersion, livelinessPath)) {
-            return livelinessPath;
-        }
-
-        return createHealthCheckPath(resolveCompleteQuarkusHealthRootPath(getContext().getProject()), livelinessPath);
+        return resolveCompleteQuarkusHealthRootPath(getContext().getProject(), subPath);
     }
 }

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusGenerator.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusGenerator.java
@@ -34,6 +34,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
+import static org.eclipse.jkube.quarkus.QuarkusUtils.QUARKUS_GROUP_ID;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.extractPort;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.findSingleFileThatEndsWith;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusConfiguration;
@@ -66,7 +67,7 @@ public class QuarkusGenerator extends JavaExecGenerator {
   @Override
   public boolean isApplicable(List<ImageConfiguration> configs) {
     return shouldAddGeneratedImageConfiguration(configs)
-        && JKubeProjectUtil.hasPlugin(getProject(), "io.quarkus", "quarkus-maven-plugin");
+        && JKubeProjectUtil.hasPlugin(getProject(), QUARKUS_GROUP_ID, "quarkus-maven-plugin");
   }
 
   @Override

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricherTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricherTest.java
@@ -16,17 +16,20 @@ package org.eclipse.jkube.quarkus.enricher;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.assertj.core.groups.Tuple;
+import org.eclipse.jkube.kit.common.Dependency;
+import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +39,9 @@ public class QuarkusHealthCheckEnricherTest {
 
   @Mocked
   private JKubeEnricherContext context;
+
+  @Mocked
+  private JavaProject javaProject;
 
   private Properties properties;
   private ProcessorConfig processorConfig;
@@ -71,38 +77,138 @@ public class QuarkusHealthCheckEnricherTest {
 
   @Test
   public void createWithDefaultsInKubernetes() {
+    // Given
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("1.9.0.CR1", new Properties());
     // When
     new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
     // Then
-    assertThat(klb.build().getItems())
-        .hasSize(1)
-        .extracting("spec", DeploymentSpec.class)
-        .extracting("template", PodTemplateSpec.class)
-        .extracting("spec", PodSpec.class)
-        .flatExtracting(PodSpec::getContainers)
-        .extracting(
-            "livenessProbe.httpGet.scheme", "livenessProbe.httpGet.path",
-            "readinessProbe.httpGet.scheme", "readinessProbe.httpGet.path")
-        .containsExactly(tuple("HTTP", "/health/live", "HTTP", "/health/ready"));
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/health/live", "HTTP", "/health/ready"));
   }
 
   @Test
   public void createWithCustomPathInKubernetes() {
     // Given
     properties.put("jkube.enricher.jkube-healthcheck-quarkus.path", "/my-custom-path");
+    setupJavaProjectWithOutputDirectory();
+    setupJavaProjectWithProperties(properties);
     // When
     new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
     // Then
-    assertThat(klb.build().getItems())
-        .hasSize(1)
-        .extracting("spec", DeploymentSpec.class)
-        .extracting("template", PodTemplateSpec.class)
-        .extracting("spec", PodSpec.class)
-        .flatExtracting(PodSpec::getContainers)
-        .extracting(
-            "livenessProbe.httpGet.scheme", "livenessProbe.httpGet.path",
-            "readinessProbe.httpGet.scheme", "readinessProbe.httpGet.path")
-        .containsExactly(tuple("HTTP", "/my-custom-path/live", "HTTP", "/my-custom-path/ready"));
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/my-custom-path/live", "HTTP", "/my-custom-path/ready"));
+  }
+
+  @Test
+  public void createWithDefaultQuarkusPost2_0PropertiesInKubernetes() {
+    // Given
+    Properties properties = createHttpRootPathPropertiesWithValue("/", "q", "health", "liveness");
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("2.0.1.Final", properties);
+
+    // When
+    new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
+
+    // Then
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/q/health/liveness", "HTTP", "/q/health/ready"));
+  }
+
+  @Test
+  public void createWithQuarkusPost2_0ChangedHttpRootPathInKubernetes() {
+    // Given
+    Properties properties = createHttpRootPathPropertiesWithValue("/root", "q", "health", "liveness");
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("2.0.1.Final", properties);
+
+    // When
+    new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
+
+    // Then
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/root/q/health/liveness", "HTTP", "/root/q/health/ready"));
+  }
+
+  @Test
+  public void createWithQuarkusPost2_0AbsoluteNonApplicationRootPathInKubernetes() {
+    // Given
+    Properties properties = createHttpRootPathPropertiesWithValue("/root", "/q", "health", "liveness");
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("2.0.1.Final", properties);
+
+    // When
+    new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
+
+    // Then
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/q/health/liveness", "HTTP", "/q/health/ready"));
+  }
+
+  @Test
+  public void createWithQuarkusPost2_0AbsoluteNonApplicationRootPathAndLivenessInKubernetes() {
+    // Given
+    Properties properties = createHttpRootPathPropertiesWithValue("/root", "/q", "health", "/liveness");
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("2.0.0.Final", properties);
+
+    // When
+    new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
+
+    // Then
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/liveness", "HTTP", "/q/health/ready"));
+  }
+
+  @Test
+  public void createWithQuarkusPost2_0AbsoluteHealthPathInKubernetes() {
+    // Given
+    Properties properties = createHttpRootPathPropertiesWithValue("/root", "q", "/health", "liveness");
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("2.0.0.Final", properties);
+
+    // When
+    new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
+
+    // Then
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/health/liveness", "HTTP", "/health/ready"));
+  }
+
+  @Test
+  public void createWithQuarkusPost2_0NonApplicationRootPathRemovedInKubernetes() {
+    // Given
+    Properties properties = createHttpRootPathPropertiesWithValue("/root", "/root", "health", "liveness");
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("2.0.0.Final", properties);
+
+    // When
+    new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
+
+    // Then
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/root/health/liveness", "HTTP", "/root/health/ready"));
+  }
+
+  @Test
+  public void createWithQuarkusPre2_0InKubernetes() {
+    // Given
+    Properties properties = createHttpRootPathPropertiesWithValue("/", null, "/health", "live");
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("1.10.5.Final", properties);
+    // When
+    new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
+
+    // Then
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/health/live", "HTTP", "/health/ready"));
+  }
+
+  @Test
+  public void createWithQuarkusPre2_0InKubernetesWithRootPathInProperties() {
+    // Given
+    Properties properties = createHttpRootPathPropertiesWithValue("/root", null, "/robot", "livenessapp");
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("1.10.5.Final", properties);
+    // When
+    new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
+
+    // Then
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/root/robot/livenessapp", "HTTP", "/root/robot/ready"));
+  }
+
+  @Test
+  public void createWithQuarkusPost1_11InKubernetesWithAbsoluteNonApplicationRootPath() {
+    // Given
+    Properties properties = createHttpRootPathPropertiesWithValue("/root", "/q", "health", "liveness");
+    setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties("1.13.7.Final", properties);
+    // When
+    new QuarkusHealthCheckEnricher(context).create(PlatformMode.kubernetes, klb);
+
+    // Then
+    assertLivenessReadinessProbes(klb, tuple("HTTP", "/q/health/liveness", "HTTP", "/q/health/ready"));
   }
 
   @Test
@@ -125,5 +231,60 @@ public class QuarkusHealthCheckEnricherTest {
         .extracting(
             "livenessProbe", "readinessProbe")
         .containsExactly(tuple(null, null));
+  }
+
+  private void assertLivenessReadinessProbes(KubernetesListBuilder kubernetesListBuilder, Tuple... values) {
+    assertThat(kubernetesListBuilder.build().getItems())
+            .hasSize(1)
+            .extracting("spec", DeploymentSpec.class)
+            .extracting("template", PodTemplateSpec.class)
+            .extracting("spec", PodSpec.class)
+            .flatExtracting(PodSpec::getContainers)
+            .extracting(
+                    "livenessProbe.httpGet.scheme", "livenessProbe.httpGet.path",
+                    "readinessProbe.httpGet.scheme", "readinessProbe.httpGet.path")
+            .containsExactly(values);
+  }
+
+  private Properties createHttpRootPathPropertiesWithValue(String rootPath, String nonApplicationRootPath, String healthRootPath, String livenessPath) {
+    Properties properties = new Properties();
+    properties.put("quarkus.http.root-path", rootPath);
+    if (nonApplicationRootPath != null) {
+      properties.put("quarkus.http.non-application-root-path", nonApplicationRootPath);
+    }
+    properties.put("quarkus.smallrye-health.root-path", healthRootPath);
+    properties.put("quarkus.smallrye-health.liveness-path", livenessPath);
+    return properties;
+  }
+
+  private void setupJavaProjectWithOutputDirectoryQuarkusVersionAndProperties(String version, Properties properties) {
+    setupJavaProjectWithOutputDirectory();
+    setupJavaProjectWithQuarkusVersion(version);
+    setupJavaProjectWithProperties(properties);
+  }
+
+  private void setupJavaProjectWithProperties(Properties mockProperties) {
+    new Expectations() {{
+      javaProject.getProperties();
+      result = mockProperties;
+    }};
+  }
+
+  private void setupJavaProjectWithQuarkusVersion(String quarkusVersion) {
+    new Expectations() {{
+      javaProject.getDependencies();
+      result = Collections.singletonList(Dependency.builder()
+              .groupId("io.quarkus")
+              .artifactId("quarkus-universe-bom")
+              .version(quarkusVersion)
+              .build());
+    }};
+  }
+
+  private void setupJavaProjectWithOutputDirectory() {
+    new Expectations() {{
+      javaProject.getOutputDirectory().getAbsolutePath();
+      result = "/tmp/foo/target/classes";
+    }};
   }
 }

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.kit.common.Assembly;
 import org.eclipse.jkube.kit.common.AssemblyConfiguration;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.Plugin;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
@@ -90,6 +91,31 @@ public class QuarkusGeneratorTest {
       defaultImageLookup.getImageName("java.upstream.s2i"); result = "quarkus/s2i";
     }};
     // @formatter:on
+  }
+
+  @Test
+  public void isApplicable_withNoDependencies_shouldReturnFalse() {
+    // When
+    final boolean result = new QuarkusGenerator(ctx).isApplicable(new ArrayList<>());
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void isApplicable_withDependency_shouldReturnTrue() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      project.getPlugins(); result = Collections.singletonList(Plugin.builder()
+          .groupId("io.quarkus")
+          .artifactId("quarkus-maven-plugin")
+          .build());
+    }};
+    // @formatter:on
+    // When
+    final boolean result = new QuarkusGenerator(ctx).isApplicable(new ArrayList<>());
+    // Then
+    assertThat(result).isTrue();
   }
 
   @Test

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -213,6 +213,8 @@ include::enricher/_jkube_healthcheck_wildfly_jar.adoc[]
 
 include::enricher/_jkube_service_discovery.adoc[]
 
+include::enricher/_jkube_healthcheck_quarkus.adoc[]
+
 == Enricher API
 
 _How to write your own enrichers and install them._

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_healthcheck_quarkus.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_healthcheck_quarkus.adoc
@@ -2,7 +2,7 @@
 ==== jkube-healthcheck-quarkus
 
 This enricher adds kubernetes readiness and liveness probes with Quarkus. This requires the following dependency
-has been enabled in your Quarkus project:
+to be added to your Quarkus project:
 
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]
 ----
@@ -12,14 +12,15 @@ has been enabled in your Quarkus project:
 </dependency>
 ----
 
-The enricher will try to discover the settings from the `application.properties` / `application.yaml` configuration file. These properties are looked up for resolving health check URLs:
+The enricher will try to discover the settings from the `application.properties` / `application.yaml`
+configuration file. JKube uses the following properties to resolve the health check URLs:
 
 * `quarkus.http.root-path`: Quarkus Application root path.
-* `quarkus.http.non-application-root-path`: This flag got introduced in recent versions of Quarkus(2.x) for non application endpoints.
+* `quarkus.http.non-application-root-path`: This property got introduced in recent versions of Quarkus(2.x) for non application endpoints.
 * `quarkus.smallrye-health.root-path`: The location of the all-encompassing health endpoint.
 * `quarkus.smallrye-health.liveness-path`: The location of the liveness endpoint.
 
-**Note**: Please note that behavior of these properties seem to have changed since Quarkus 1.11.x versions(e.g for health and liveness paths leading slashes are now being considered). `{plugin}` would also check quarkus version along with value of these properties in order to resolve effective health endpoints.
+**Note**: Please note that behavior of these properties seem to have changed since Quarkus 1.11.x versions (e.g for health and liveness paths leading slashes are now being considered). `{plugin}` would also check quarkus version along with value of these properties in order to resolve effective health endpoints.
 
 You can read more about these flags in https://quarkus.io/guides/smallrye-health[Quarkus Documentation].
 
@@ -39,16 +40,6 @@ These values can be configured by the enricher in the `{plugin}` configuration a
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>{plugin}</artifactId>
         <version>{version}</version>
-        <executions>
-          <execution>
-            <id>jkube</id>
-            <goals>
-              <goal>resource</goal>
-              <goal>helm</goal>
-              <goal>build</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <enricher>
             <config>

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_healthcheck_quarkus.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_healthcheck_quarkus.adoc
@@ -1,0 +1,65 @@
+[[jkube-healthcheck-quarkus]]
+==== jkube-healthcheck-quarkus
+
+This enricher adds kubernetes readiness and liveness probes with Quarkus. This requires the following dependency
+has been enabled in your Quarkus project:
+
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+----
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-smallrye-health</artifactId>
+</dependency>
+----
+
+The enricher will try to discover the settings from the `application.properties` / `application.yaml` configuration file. These properties are looked up for resolving health check URLs:
+
+* `quarkus.http.root-path`: Quarkus Application root path.
+* `quarkus.http.non-application-root-path`: This flag got introduced in recent versions of Quarkus(2.x) for non application endpoints.
+* `quarkus.smallrye-health.root-path`: The location of the all-encompassing health endpoint.
+* `quarkus.smallrye-health.liveness-path`: The location of the liveness endpoint.
+
+**Note**: Please note that behavior of these properties seem to have changed since Quarkus 1.11.x versions(e.g for health and liveness paths leading slashes are now being considered). `{plugin}` would also check quarkus version along with value of these properties in order to resolve effective health endpoints.
+
+You can read more about these flags in https://quarkus.io/guides/smallrye-health[Quarkus Documentation].
+
+The enricher will use the following settings by default:
+
+* `scheme` : `HTTP`
+* `port` : `8080`
+* `failureThreshold` : `3`
+* `successThreshold` : `1`
+* `livenessInitialDelay` : `10`
+* `readinessIntialDelay` : `5`
+
+These values can be configured by the enricher in the `{plugin}` configuration as shown below:
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+----
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>{plugin}</artifactId>
+        <version>{version}</version>
+        <executions>
+          <execution>
+            <id>jkube</id>
+            <goals>
+              <goal>resource</goal>
+              <goal>helm</goal>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <enricher>
+            <config>
+              <jkube-healthcheck-quarkus>
+                <failureThreshold>3</failureThreshold>
+                <successThreshold>1</successThreshold>
+                <livenessInitialDelay>5</livenessInitialDelay>
+              </jkube-healthcheck-quarkus>
+            </config>
+          </enricher>
+        </configuration>
+      </plugin>
+----
+


### PR DESCRIPTION
## Description
Fix #758 

QuarkusHealthCheckEnricher now reads quarkus properties related to
    rootPath(`quarkus.http.root-path`), nonApplicationRootPath(`quarkus.http.non-application-root-path`) and health checks(`quarkus.smallrye-health.root-path`,`quarkus.smallrye-health.liveness-path`) in order to
    evaluate health check endpoints for Quarkus versions  greater than 1.11.x

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->