### PR TITLE
Changed hamcrest to assertj for unit test

### DIFF
--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/LazyBuilderTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/LazyBuilderTest.java
@@ -24,8 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LazyBuilderTest {
 
@@ -41,8 +40,8 @@ public class LazyBuilderTest {
     // When
     final int result = IntStream.rangeClosed(1, 10).map(t -> lazyBuilder.get()).sum();
     // Then
-    assertThat(result, is(10));
-    assertThat(count.get(), is(1));
+    assertThat(result).isEqualTo(10);
+    assertThat(count.get()).isEqualTo(1);
   }
 
   @Test
@@ -66,8 +65,8 @@ public class LazyBuilderTest {
     final int result = IntStream.rangeClosed(1, 10).map(t -> lazyBuilder.get()).sum();
     cdl.countDown();
     // Then
-    assertThat(count.get(), is(2));
-    assertThat(result, is(10));
-    assertThat(concurrentResult.get(100, TimeUnit.MILLISECONDS), is(1));
+    assertThat(count.get()).isEqualTo(2);
+    assertThat(result).isEqualTo(10);
+    assertThat(concurrentResult.get(100, TimeUnit.MILLISECONDS)).isEqualTo(1);
   }
 }


### PR DESCRIPTION
## Description

Changed LazyBuilderTest to use AssertJ in place of hamcrest
Fix https://github.com/eclipse/jkube/issues/786

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->