### PR TITLE
change the visibility of constructor to protected

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/ExternalCommand.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/ExternalCommand.java
@@ -40,7 +40,7 @@ public abstract class ExternalCommand {
 
     private int statusCode;
 
-    public ExternalCommand(KitLogger log) {
+    protected ExternalCommand(KitLogger log) {
         this.log = log;
     }
 


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #785
Change the visibility of the constructor to protected in `ExternalCommand.java`.

Hi @manusa, how does this look?
Let me know if this needs any changes.
Thanks

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->