### PR TITLE
Fix #777: Failure in processing generated tarball by old Docker versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Usage:
 * Fix #751: QuarkusGenerator: Multi-layer images for the different Quarkus packaging modes
 * Fix #756: Service re-apply error happening during `k8s:watch`
 * Fix #758: QuarkusHealthCheckEnricher: default health path value is outdated
+* Fix #777: Error processing tar file(archive/tar: missed writing 4096 bytes) on Docker 1.12.1
 
 ### 1.3.0 (2021-05-18)
 * Fix #497: Assembly descriptor removed but still in documentation

--- a/jkube-kit/common-test/src/main/java/org/eclipse/jkube/kit/common/assertj/ArchiveAssertions.java
+++ b/jkube-kit/common-test/src/main/java/org/eclipse/jkube/kit/common/assertj/ArchiveAssertions.java
@@ -19,6 +19,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -92,10 +93,8 @@ public class ArchiveAssertions extends AbstractFileAssert<ArchiveAssertions> {
     }
   }
 
-  public AbstractListAssert<ListAssert<String>, List<? extends String>, String, ObjectAssert<String>> fileTree()
-      throws IOException {
-    final List<String> archiveFileTree = new ArrayList<>();
-
+  private List<TarArchiveEntry> loadEntries() throws IOException {
+    final List<TarArchiveEntry> archiveEntries = new ArrayList<>();
     try (
         FileInputStream fis = new FileInputStream(actual);
         BufferedInputStream bis = new BufferedInputStream(fis);
@@ -103,9 +102,20 @@ public class ArchiveAssertions extends AbstractFileAssert<ArchiveAssertions> {
     ) {
       TarArchiveEntry entry;
       while ((entry = tis.getNextTarEntry()) != null) {
-        archiveFileTree.add(entry.getName());
+        archiveEntries.add(entry);
       }
     }
-    return org.assertj.core.api.Assertions.assertThat(archiveFileTree);
+    return archiveEntries;
+  }
+
+  public AbstractListAssert<ListAssert<TarArchiveEntry>, List<? extends TarArchiveEntry>, TarArchiveEntry, ObjectAssert<TarArchiveEntry>> entries()
+      throws IOException {
+    return org.assertj.core.api.Assertions.assertThat(loadEntries());
+  }
+
+  public AbstractListAssert<ListAssert<String>, List<? extends String>, String, ObjectAssert<String>> fileTree()
+      throws IOException {
+    return org.assertj.core.api.Assertions.assertThat(
+        loadEntries().stream().map(TarArchiveEntry::getName).collect(Collectors.toList()));
   }
 }

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiver.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiver.java
@@ -74,13 +74,7 @@ public class JKubeTarArchiver {
         String relativeFilePath = inputDirectory.toURI().relativize(
             new File(currentFile.getAbsolutePath()).toURI()).getPath();
 
-        final TarArchiveEntry tarEntry = new TarArchiveEntry(currentFile, relativeFilePath);
-        tarEntry.setSize(currentFile.length());
-        if (fileModeMap.containsKey(currentFile)) {
-          tarEntry.setMode(Integer.parseInt(fileModeMap.get(currentFile), 8));
-        } else if (currentFile.isDirectory()) {
-          tarEntry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
-        }
+        final TarArchiveEntry tarEntry = createTarArchiveEntry(fileModeMap, currentFile, relativeFilePath);
         Optional.ofNullable(tarArchiveEntryCustomizer).ifPresent(tac -> tac.accept(tarEntry));
         tarArchiveOutputStream.putArchiveEntry(tarEntry);
         if (currentFile.isFile()) {
@@ -92,5 +86,17 @@ public class JKubeTarArchiver {
     }
 
     return outputFile;
+  }
+
+  static TarArchiveEntry createTarArchiveEntry(Map<File, String> fileModeMap, File currentFile, String relativeFilePath) {
+    final TarArchiveEntry tarEntry = new TarArchiveEntry(currentFile, relativeFilePath);
+    tarEntry.setSize(currentFile.length());
+    if (fileModeMap.containsKey(currentFile)) {
+      tarEntry.setMode(Integer.parseInt(fileModeMap.get(currentFile), 8));
+    } else if (currentFile.isDirectory()) {
+      tarEntry.setSize(0L);
+      tarEntry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
+    }
+    return tarEntry;
   }
 }

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiver.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiver.java
@@ -74,7 +74,14 @@ public class JKubeTarArchiver {
         String relativeFilePath = inputDirectory.toURI().relativize(
             new File(currentFile.getAbsolutePath()).toURI()).getPath();
 
-        final TarArchiveEntry tarEntry = createTarArchiveEntry(fileModeMap, currentFile, relativeFilePath);
+        final TarArchiveEntry tarEntry = new TarArchiveEntry(currentFile, relativeFilePath);
+        tarEntry.setSize(currentFile.length());
+        if (fileModeMap.containsKey(currentFile)) {
+          tarEntry.setMode(Integer.parseInt(fileModeMap.get(currentFile), 8));
+        } else if (currentFile.isDirectory()) {
+          tarEntry.setSize(0L);
+          tarEntry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
+        }
         Optional.ofNullable(tarArchiveEntryCustomizer).ifPresent(tac -> tac.accept(tarEntry));
         tarArchiveOutputStream.putArchiveEntry(tarEntry);
         if (currentFile.isFile()) {
@@ -86,17 +93,5 @@ public class JKubeTarArchiver {
     }
 
     return outputFile;
-  }
-
-  static TarArchiveEntry createTarArchiveEntry(Map<File, String> fileModeMap, File currentFile, String relativeFilePath) {
-    final TarArchiveEntry tarEntry = new TarArchiveEntry(currentFile, relativeFilePath);
-    tarEntry.setSize(currentFile.length());
-    if (fileModeMap.containsKey(currentFile)) {
-      tarEntry.setMode(Integer.parseInt(fileModeMap.get(currentFile), 8));
-    } else if (currentFile.isDirectory()) {
-      tarEntry.setSize(0L);
-      tarEntry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
-    }
-    return tarEntry;
   }
 }

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiverTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiverTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.function.Consumer;
 
 import org.eclipse.jkube.kit.common.assertj.ArchiveAssertions;
@@ -29,6 +30,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class JKubeTarArchiverTest {
 
@@ -152,4 +155,32 @@ public class JKubeTarArchiverTest {
             "nested/directory/01234567890123456789012345678901234567890123456789012345678901234567890123456789012");
   }
 
+  @Test
+  public void createTarArchiveEntry_whenUsedForDirectories_shouldCreateEntryWithZeroSize() {
+    // Given
+    File tmpDir = new File(getClass().getResource("/jkubetararchiver-directory/").getFile());
+
+    // When
+    TarArchiveEntry tarArchiveEntry = JKubeTarArchiver.createTarArchiveEntry(Collections.emptyMap(), tmpDir, "/tmp/foo");
+
+    // Then
+    assertThat(tarArchiveEntry)
+            .isNotNull()
+            .hasFieldOrPropertyWithValue("size", 0L);
+  }
+
+  @Test
+  public void createTarArchiveEntry_whenUsedForFiles_shouldCreateEntryWithNonZeroSize() {
+    // Given
+    File tmpFile = new File(getClass().getResource("/jkubetararchiver-directory/jkubetararchiver-non-empty-file.txt").getFile());
+
+    // When
+    TarArchiveEntry tarArchiveEntry = JKubeTarArchiver.createTarArchiveEntry(Collections.singletonMap(tmpFile, "0644"), tmpFile, "/tmp/foo");
+
+    // Then
+    assertThat(tarArchiveEntry)
+            .isNotNull()
+            .hasFieldOrPropertyWithValue("size", 10L)
+            .hasFieldOrPropertyWithValue("mode", Integer.parseInt("0644", 8));
+  }
 }

--- a/jkube-kit/common/src/test/resources/jkubetararchiver-directory/jkubetararchiver-non-empty-file.txt
+++ b/jkube-kit/common/src/test/resources/jkubetararchiver-directory/jkubetararchiver-non-empty-file.txt
@@ -1,1 +1,0 @@
-Not Empty.

--- a/jkube-kit/common/src/test/resources/jkubetararchiver-directory/jkubetararchiver-non-empty-file.txt
+++ b/jkube-kit/common/src/test/resources/jkubetararchiver-directory/jkubetararchiver-non-empty-file.txt
@@ -1,0 +1,1 @@
+Not Empty.


### PR DESCRIPTION

## Description
Fix #777 
Tar files generated during `k8s:build` were getting rejected from Docker
v1.12.1 (API version 1.24). Not setting size of TarArchiveEntry in case
of directories seem to fix this issue

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->