### PR TITLE
KubernetesBuildTask Prequisire Refactor: Move code from AbstractDockerMojo to JKube Kit

### DIFF
--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/ImagePullManager.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/ImagePullManager.java
@@ -19,6 +19,8 @@ import org.eclipse.jkube.kit.build.service.docker.helper.AutoPullMode;
 import org.eclipse.jkube.kit.common.JsonFactory;
 import org.eclipse.jkube.kit.config.image.build.ImagePullPolicy;
 
+import java.util.Properties;
+
 /**
  * Simple interface for a ImagePullCache manager, to load and persist the cache.
  */
@@ -68,6 +70,9 @@ public class ImagePullManager {
         save(load().add(image));
     }
 
+    public static ImagePullManager createImagePullManager(String imagePullPolicy, String autoPull, Properties properties) {
+        return new ImagePullManager(createSessionCacheStore(properties), imagePullPolicy, autoPull);
+    }
 
     public interface CacheStore {
         String get(String key);
@@ -123,5 +128,19 @@ public class ImagePullManager {
         public String toString() {
             return cache.toString();
         }
+    }
+
+    private static ImagePullManager.CacheStore createSessionCacheStore(Properties properties) {
+        return new ImagePullManager.CacheStore() {
+            @Override
+            public String get(String key) {
+                return properties.getProperty(key);
+            }
+
+            @Override
+            public void put(String key, String value) {
+                properties.setProperty(key, value);
+            }
+        };
     }
 }

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/ImagePullManagerTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/ImagePullManagerTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.service.docker;
+
+import org.eclipse.jkube.kit.config.image.build.ImagePullPolicy;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class ImagePullManagerTest {
+  @Test
+  public void testCreateImagePullManagerWithNotNullImagePullPolicy() {
+    // Given + When
+    ImagePullManager imagePullManager = ImagePullManager.createImagePullManager("Always", null, new Properties());
+
+    // Then
+    assertThat(imagePullManager)
+        .hasFieldOrPropertyWithValue("imagePullPolicy", ImagePullPolicy.Always)
+        .extracting("cacheStore").isNotNull();
+  }
+
+  @Test
+  public void testCreateImagePullManagerWithAutoPullModeOnce() {
+    // Given + When
+    ImagePullManager imagePullManager = ImagePullManager.createImagePullManager(null, "always", new Properties());
+
+    // Then
+    assertThat(imagePullManager)
+        .hasFieldOrPropertyWithValue("imagePullPolicy", ImagePullPolicy.Always)
+        .extracting("cacheStore").isNotNull();
+  }
+
+  @Test
+  public void testCreateImagePullManagerWithAutoPullModeOff() {
+    // Given + When
+    ImagePullManager imagePullManager = ImagePullManager.createImagePullManager(null, "off", new Properties());
+
+    // Then
+    assertThat(imagePullManager)
+        .hasFieldOrPropertyWithValue("imagePullPolicy", ImagePullPolicy.Never)
+        .extracting("cacheStore").isNotNull();
+  }
+
+  @Test
+  public void testCreateImagePullManagerWithAutoPullModeAlways() {
+    // Given + When
+    ImagePullManager imagePullManager = ImagePullManager.createImagePullManager(null, "always", new Properties());
+
+    // Then
+    assertThat(imagePullManager)
+        .hasFieldOrPropertyWithValue("imagePullPolicy", ImagePullPolicy.Always)
+        .extracting("cacheStore").isNotNull();
+  }
+
+  @Test
+  public void testCreateImagePullManagerWithNullImagePullPolicyNullAutoPullMode() {
+    // Given + When
+    ImagePullManager imagePullManager = ImagePullManager.createImagePullManager(null, null, new Properties());
+
+    // Then
+    assertThat(imagePullManager)
+        .hasFieldOrPropertyWithValue("imagePullPolicy", ImagePullPolicy.IfNotPresent)
+        .extracting("cacheStore").isNotNull();
+  }
+
+}

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/helper/ConfigHelperTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/helper/ConfigHelperTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.service.docker.helper;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.eclipse.jkube.kit.build.service.docker.config.handler.ImageConfigResolver;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+public class ConfigHelperTest {
+  @Mocked
+  private ImageConfigResolver imageConfigResolver;
+
+  @Mocked
+  private KitLogger logger;
+
+  @Mocked
+  private JavaProject javaProject;
+
+  @Test
+  public void initImageConfiguration_withSimpleImageConfiguration_shouldReturnImageConfiguration() {
+    // Given
+    ImageConfiguration dummyImageConfiguration = ImageConfiguration.builder()
+        .name("foo/bar:latest")
+        .build(BuildConfiguration.builder()
+            .from("foobase:latest")
+            .build())
+        .build();
+    List<ImageConfiguration> images = new ArrayList<>();
+    images.add(dummyImageConfiguration);
+    new Expectations() {{
+      imageConfigResolver.resolve(dummyImageConfiguration, javaProject);
+      result = dummyImageConfiguration;
+
+      javaProject.getBaseDirectory();
+      result = new File("dummydir");
+    }};
+
+    // When
+    List<ImageConfiguration> resolvedImages = ConfigHelper.initImageConfiguration("1.12", new Date(), javaProject, images, imageConfigResolver, logger, null, configs -> configs);
+
+    // Then
+    assertThat(resolvedImages)
+        .isNotNull()
+        .hasSize(1)
+        .element(0).isEqualTo(dummyImageConfiguration);
+  }
+
+  @Test
+  public void initImageConfiguration_withSimpleDockerFileInProjectBaseDir_shouldCreateImageConfiguration() {
+    List<ImageConfiguration> images = new ArrayList<>();
+    File dockerFile = new File(getClass().getResource("/dummy-javaproject/Dockerfile").getFile());
+    new Expectations() {{
+      javaProject.getBaseDirectory();
+      result = dockerFile.getParentFile();
+
+      javaProject.getProperties();
+      result = new Properties();
+
+      javaProject.getGroupId();
+      result = "org.eclipse.jkube";
+
+      javaProject.getArtifactId();
+      result = "test-java-project";
+
+      javaProject.getVersion();
+      result = "0.0.1-SNAPSHOT";
+    }};
+
+    // When
+    List<ImageConfiguration> resolvedImages = ConfigHelper.initImageConfiguration("1.12", new Date(), javaProject, images, imageConfigResolver, logger, null, configs -> configs);
+
+    // Then
+    assertThat(resolvedImages)
+        .isNotNull()
+        .hasSize(1)
+        .element(0)
+        .hasFieldOrPropertyWithValue("name", "jkube/test-java-project:latest")
+        .hasFieldOrPropertyWithValue("build.dockerFile", dockerFile)
+        .hasFieldOrPropertyWithValue("build.ports", Collections.singletonList("8080"));
+  }
+
+  @Test
+  public void initImageConfiguration_withSimpleDockerFileModeEnabledAndImageConfigurationWithNoBuild_shouldModifyExistingImageConfiguration() {
+    ImageConfiguration dummyImageConfiguration = ImageConfiguration.builder()
+        .name("imageconfiguration-no-build:latest")
+        .build();
+    List<ImageConfiguration> images = new ArrayList<>();
+    images.add(dummyImageConfiguration);
+    File dockerFile = new File(getClass().getResource("/dummy-javaproject/Dockerfile").getFile());
+    new Expectations() {{
+      imageConfigResolver.resolve(dummyImageConfiguration, javaProject);
+      result = dummyImageConfiguration;
+
+      javaProject.getBaseDirectory();
+      result = dockerFile.getParentFile();
+
+      javaProject.getProperties();
+      result = new Properties();
+    }};
+
+    // When
+    List<ImageConfiguration> resolvedImages = ConfigHelper.initImageConfiguration("1.12", new Date(), javaProject, images, imageConfigResolver, logger, null, configs -> configs);
+
+    // Then
+    assertThat(resolvedImages)
+        .isNotNull()
+        .hasSize(1)
+        .element(0)
+        .hasFieldOrPropertyWithValue("name", "imageconfiguration-no-build:latest")
+        .hasFieldOrPropertyWithValue("build.dockerFile", dockerFile)
+        .hasFieldOrPropertyWithValue("build.ports", Collections.singletonList("8080"));
+  }
+}

--- a/jkube-kit/build/service/docker/src/test/resources/dummy-javaproject/Dockerfile
+++ b/jkube-kit/build/service/docker/src/test/resources/dummy-javaproject/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8-jdk-alpine
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/BuildReferenceDateUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/BuildReferenceDateUtil.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+
+public class BuildReferenceDateUtil {
+  private BuildReferenceDateUtil() { }
+
+  static Date getBuildReferenceDate(String buildDirectory, String dockerBuildTimestampFile) throws IOException {
+    return Optional.ofNullable(EnvUtil.loadTimestamp(getBuildTimestampFile(buildDirectory, dockerBuildTimestampFile)))
+        .orElse(new Date());
+  }
+
+  public static File getBuildTimestampFile(String projectBuildDirectory, String dockerBuildTimestampFile) {
+    return new File(projectBuildDirectory, dockerBuildTimestampFile);
+  }
+
+  /**
+   * Get the current build timestamp. this has either already been created by a previous
+   * call or a new current date is created
+   *
+   * @param pluginContext Plugin Context
+   * @param buildTimestampContextKey Plugin Context's key for build timestamp
+   * @param projectBuildDir project's build directory
+   * @param dockerBuildTimestampFile docker build timestamp file
+   * @return timestamp to use
+   */
+  public static Date getBuildTimestamp(Map<String, Object> pluginContext, String buildTimestampContextKey,
+                                                    String projectBuildDir, String dockerBuildTimestampFile) throws IOException {
+    Date now = (Date) (pluginContext != null ? pluginContext.get(buildTimestampContextKey) : null);
+    if (now == null) {
+      now = getBuildReferenceDate(projectBuildDir, dockerBuildTimestampFile);
+      if (pluginContext != null) {
+        pluginContext.put(buildTimestampContextKey, now);
+      }
+    }
+    return now;
+  }
+}

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/BuildReferenceDateUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/BuildReferenceDateUtilTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class BuildReferenceDateUtilTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testGetBuildReferenceDateWhenFileDoesntExist() throws IOException {
+    assertNotNull(BuildReferenceDateUtil.getBuildReferenceDate("target", "docker"));
+  }
+
+  @Test
+  public void testGetBuildReferenceDate() throws IOException {
+    // Given
+    File buildDirectory = temporaryFolder.newFolder("testGetBuildReferenceDate");
+    File buildTimestampFile = new File(buildDirectory, "build.timestamp");
+    String timestamp = "1605029866235";
+    boolean fileCreated = buildTimestampFile.createNewFile();
+    try (FileWriter fileWriter = new FileWriter(buildTimestampFile)) {
+      fileWriter.write(timestamp);
+    }
+
+    // When
+    Date result = BuildReferenceDateUtil.getBuildReferenceDate(buildDirectory.getAbsolutePath(), buildTimestampFile.getName());
+
+    // Then
+    assertTrue(fileCreated);
+    assertNotNull(result);
+    assertEquals(Long.parseLong(timestamp), result.getTime());
+  }
+
+  @Test
+  public void testGetBuildTimestampFile() {
+    // Given
+    String projectBuildDirectory = "target/docker";
+    String dockerBuildTimestampFile = "build.timestamp";
+
+    // When
+    File result = BuildReferenceDateUtil.getBuildTimestampFile(projectBuildDirectory, dockerBuildTimestampFile);
+
+    // Then
+    assertNotNull(result);
+    assertEquals("target/docker/build.timestamp", result.getPath());
+  }
+
+  @Test
+  public void testGetBuildTimestampFromPluginContext() throws IOException {
+    // Given
+    File buildDirectory = temporaryFolder.newFolder("testGetBuildTimestampFromPluginContext");
+    File buildTimestampFile = new File(buildDirectory, "build.timestamp");
+    String timestamp = "1605029866235";
+    Map<String, Object> pluginContext = new HashMap<>();
+    String buildTimestampContextKey = "buildTimestampContextKey";
+    pluginContext.put(buildTimestampContextKey, Date.from(Instant.ofEpochMilli(Long.parseLong(timestamp))));
+
+    // When
+    Date result = BuildReferenceDateUtil.getBuildTimestamp(pluginContext, buildTimestampContextKey, buildDirectory.getPath(),
+        buildTimestampFile.getName());
+
+    // Then
+    assertNotNull(result);
+    assertEquals(Long.parseLong(timestamp), result.getTime());
+  }
+
+  @Test
+  public void testGetBuildTimestampFromFile() throws IOException {
+    // Given
+    File buildDirectory = temporaryFolder.newFolder("testGetBuildTimestampFromFile");
+    File buildTimestampFile = new File(buildDirectory, "build.timestamp");
+    String timestamp = "1605029866235";
+    boolean fileCreated = buildTimestampFile.createNewFile();
+    try (FileWriter fileWriter = new FileWriter(buildTimestampFile)) {
+      fileWriter.write(timestamp);
+    }
+    Map<String, Object> pluginContext = new HashMap<>();
+    String buildTimestampContextKey = "buildTimestampContextKey";
+
+    // When
+    Date result = BuildReferenceDateUtil.getBuildTimestamp(pluginContext, buildTimestampContextKey, buildDirectory.getPath(),
+        buildTimestampFile.getName());
+
+    // Then
+    assertTrue(fileCreated);
+    assertNotNull(result);
+    assertEquals(Long.parseLong(timestamp), result.getTime());
+  }
+}

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/RegistryAuthConfiguration.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/RegistryAuthConfiguration.java
@@ -13,10 +13,15 @@
  */
 package org.eclipse.jkube.kit.config.image.build;
 
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.io.Serializable;
 import java.util.Map;
 import java.util.TreeMap;
 
+@NoArgsConstructor
+@Setter
 public class RegistryAuthConfiguration implements Serializable {
 
     private Map<String, String> push;

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
@@ -49,6 +49,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestamp;
 import static org.eclipse.jkube.maven.plugin.mojo.build.ApplyMojo.DEFAULT_KUBERNETES_MANIFEST;
 
 
@@ -125,10 +126,10 @@ public class WatchMojo extends AbstractDockerMojo implements ManifestProvider {
                     .useProjectClasspath(useProjectClasspath)
                     .jKubeServiceHub(jkubeServiceHub)
                     .build();
-        } catch (IOException exception) {
-            throw new MojoExecutionException(exception.getMessage());
         } catch (DependencyResolutionRequiredException dependencyException) {
             throw new MojoExecutionException("Instructed to use project classpath, but cannot. Continuing build if we can: " + dependencyException.getMessage());
+        } catch (IOException ioException) {
+            throw new MojoExecutionException(ioException.getMessage());
         }
     }
 
@@ -157,7 +158,7 @@ public class WatchMojo extends AbstractDockerMojo implements ManifestProvider {
         return new AnsiLogger(getLog(), useColor, verbose, !settings.getInteractiveMode(), getLogPrefix() + prefix);
     }
 
-    protected WatchContext getWatchContext() throws IOException, DependencyResolutionRequiredException {
+    protected WatchContext getWatchContext() throws DependencyResolutionRequiredException, IOException {
         final ServiceHub hub = jkubeServiceHub.getDockerServiceHub();
         return WatchContext.builder()
                 .watchInterval(watchInterval)
@@ -168,7 +169,7 @@ public class WatchMojo extends AbstractDockerMojo implements ManifestProvider {
                 .keepRunning(keepRunning)
                 .removeVolumes(removeVolumes)
                 .containerNamePattern(containerNamePattern)
-                .buildTimestamp(getBuildTimestamp())
+                .buildTimestamp(getBuildTimestamp(getPluginContext(), CONTEXT_KEY_BUILD_TIMESTAMP, project.getBuild().getDirectory(), DOCKER_BUILD_TIMESTAMP))
                 .gavLabel(getGavLabel())
                 .buildContext(initJKubeConfiguration())
                 .follow(watchFollow)


### PR DESCRIPTION
## Description

Some code related to initialization of ImageConfiguration,
BuildTimestamps etc seems to be common in both gradle and maven plugins.
Moving this common code to JKube Kit in order to avoid duplication

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->