### PR TITLE
[GRADLE PLUGINS] GradleUtil  pick finalArtifact of largest size

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
@@ -47,7 +47,7 @@ public class GradleUtil {
         .baseDirectory(gradleProject.getProjectDir())
 //        .documentationUrl(gradleProject.)
 //        .compileClassPathElements(gradleProject.)
-//        .packaging(gradleProject.)
+//        .packaging(gradleProject)
         .dependencies(extractDependencies(gradleProject))
 //        .dependenciesWithTransitive(gradleProject.getDependencies().)
 //        .localRepositoryBaseDirectory(gradleProject.)
@@ -101,9 +101,10 @@ public class GradleUtil {
         .map(PublishArtifactSet::getFiles)
         .map(FileCollection::getFiles)
         .flatMap(Set::stream)
+        .sorted((o1, o2) -> (int)(o2.length() - o1.length()))
         .distinct()
         .filter(File::exists)
-        .findAny().orElse(null);
+        .findFirst().orElse(null);
   }
 
 }


### PR DESCRIPTION
## Description
I noticed GradleUtil.findArtifact was picking the plain jar instead of
fat jar. We can sort all artifacts files by size so that fat jar with
larger size gets picked.

~Once we have the artifact, we can check it's name to find out whether
project has war or jar packaging~

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->