### PR TITLE
JKubeProjectUtil.getFinalOutputArtifact : Pick finalArtifact file from JavaProject.artifact if present

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtil.java
@@ -115,17 +115,44 @@ public class JKubeProjectUtil {
         return properties;
     }
 
+  /**
+   * Returns the output artifact for the Project.
+   *
+   * <p> This method infers the Project's artifact from the provided project build directory, GAV coordinates,
+   *  packaging, and configured build name.
+   *
+   * <p> If the inferred artifact file exists it is returned.
+   *
+   * <p> If the inferred artifact file doesn't exist, but an existent artifact file is provided in the configuration, it is
+   * returned instead.
+
+   * <p> In case no artifacts are found or configured, this method returns null.
+   *
+   * <p> TODO: https://github.com/eclipse/jkube/issues/817
+   * <br> This method prioritizes artifact inference instead of configuration. This is done to handle case of maven
+   * where value of artifact varies depending upon the maven phase in which goal was executed.
+   *
+   * @see <a href="https://github.com/eclipse/jkube/issues/817">#817</a>
+   *
+   * @param jkubeProject project for which to retrieve the output artifact.
+   * @return the final output artifact file or null if it doesn't exist.
+   */
   public static File getFinalOutputArtifact(JavaProject jkubeProject) {
-    final String nameOfFinalArtifact;
+    final String inferredArtifactName;
     if (jkubeProject.getBuildFinalName() == null) {
-      nameOfFinalArtifact = String.format("%s-%s.%s",
+      inferredArtifactName = String.format("%s-%s.%s",
           jkubeProject.getArtifactId(), jkubeProject.getVersion(), jkubeProject.getPackaging());
     } else {
-      nameOfFinalArtifact = String.format("%s.%s",
+      inferredArtifactName = String.format("%s.%s",
           jkubeProject.getBuildFinalName(), jkubeProject.getPackaging());
     }
-    final File finalArtifact = new File(jkubeProject.getBuildDirectory(), nameOfFinalArtifact);
-    return finalArtifact.exists() ? finalArtifact : null;
+    final File inferredArtifact = new File(jkubeProject.getBuildDirectory(), inferredArtifactName);
+    if (inferredArtifact.exists()) {
+      return inferredArtifact;
+    } else if (jkubeProject.getArtifact() != null && jkubeProject.getArtifact().exists()) {
+      return jkubeProject.getArtifact();
+    }
+    return null;
   }
 
     public static String createDefaultResourceName(String artifactId, String ... suffixes) {


### PR DESCRIPTION
## Description
In case artifact is set in JavaProject, pick finalArtifact from
this field. Keeping this as a fallback to old method to not break
any backward compatibility

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->