### PR TITLE
Fix #815: ClassCastException during oc:build when OpenShift not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.5.0-SNAPSHOT
+* Fix #815: `java.lang.ClassCastException` during `oc:build` when OpenShift not present
 
 ### 1.4.0 (2021-07-27)
 * Fix #253: Refactor JKubeServiceHub's BuildService election mechanism via ServiceLoader

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.eclipse.jkube.kit.build.api.auth.AuthConfig;
 import org.eclipse.jkube.kit.build.service.docker.auth.AuthConfigFactory;
 import org.eclipse.jkube.kit.common.KitLogger;
@@ -231,10 +232,11 @@ public class OpenshiftBuildService implements BuildService {
             clusterAccess = new ClusterAccess(log,
                 ClusterConfiguration.from(System.getProperties(), jKubeServiceHub.getConfiguration().getProject().getProperties()).build());
         }
-        client = clusterAccess.createDefaultClient();
-        if (!isOpenShift(client)) {
+        KubernetesClient k8sClient = clusterAccess.createDefaultClient();
+        if (!isOpenShift(k8sClient)) {
             throw new IllegalStateException("OpenShift platform has been specified but OpenShift has not been detected!");
         }
+        client = (OpenShiftClient) k8sClient;
     }
 
     private void validateSourceType(String buildName, BuildConfigSpec spec) {

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceTest.java
@@ -16,11 +16,16 @@ package org.eclipse.jkube.kit.config.service.openshift;
 import mockit.Mocked;
 import mockit.Verifications;
 import org.eclipse.jkube.kit.common.RegistryConfig;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.service.JKubeServiceException;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 import org.junit.Test;
 
 import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("unused")
 public class OpenShiftBuildServiceTest {
@@ -38,5 +43,24 @@ public class OpenShiftBuildServiceTest {
       jKubeServiceHub.getLog().warn("Image is pushed to OpenShift's internal registry during oc:build goal. Skipping..."); times = 1;
     }};
     // @formatter:on
+  }
+
+  @Test
+  public void initClient_withNoOpenShift_shouldThrowException() {
+    // Given
+    //  @formatter:off
+    ImageConfiguration imageConfiguration = ImageConfiguration.builder()
+      .name("foo/bar:latest")
+      .build(BuildConfiguration.builder()
+        .from("baseimage:latest")
+        .build())
+      .build();
+    // @formatter:on
+    OpenshiftBuildService openshiftBuildService = new OpenshiftBuildService(jKubeServiceHub);
+
+    // When + Then
+    IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, () -> openshiftBuildService.build(imageConfiguration));
+    assertThat(illegalStateException.getMessage())
+        .isEqualTo("OpenShift platform has been specified but OpenShift has not been detected!");
   }
 }


### PR DESCRIPTION

## Description
Fix #815 
Using OpenShiftClient to store result of `clusterAccess.createDefaultClient()` seems to
cause ClassCastException when return value is of type DefaultKubernetesClient.

Instead, Use a temporaty KubernetesClient variable for `clusterAccess.createDefaultClient()`
and type cast it to OpenShiftClient in case it's adaptable to OpenShiftClient interface.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

This would be the behavior after this change:
1. On OpenShift Cluster: Regular OpenShift S2I build as usual
2. On Kubernetes Cluster: `[ERROR] oc: Failed to execute the build [OpenShift platform has been specified but OpenShift has not been detected!]`
3. No Cluster: `Unknown host kubernetes.default.svc` 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->