### PR TITLE
Fix errors related to JIB mode

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTask.java
@@ -49,6 +49,7 @@ public class KubernetesBuildTask extends AbstractJKubeTask {
   @Override
   protected JKubeServiceHub.JKubeServiceHubBuilder initJKubeServiceHubBuilder() {
     JKubeServiceHub.JKubeServiceHubBuilder builder = super.initJKubeServiceHubBuilder();
+    DockerAccess access = null;
     if (isDockerAccessRequired()) {
       DockerAccessFactory.DockerAccessContext dockerAccessContext = DockerAccessFactory.DockerAccessContext.builder()
           .log(kitLogger)
@@ -61,22 +62,22 @@ public class KubernetesBuildTask extends AbstractJKubeTask {
           .skipMachine(kubernetesExtension.getSkipMachine().getOrElse(false))
           .build();
       DockerAccessFactory dockerAccessFactory = new DockerAccessFactory();
-      ImagePullManager imagePullManager = createImagePullManager(
-          kubernetesExtension.getImagePullPolicy().getOrElse("Always"),
-          kubernetesExtension.getAutoPull().getOrElse("true"),
-          javaProject.getProperties());
-      DockerAccess access = dockerAccessFactory.createDockerAccess(dockerAccessContext);
-      ServiceHubFactory serviceHubFactory = new ServiceHubFactory();
-      LogOutputSpecFactory logSpecFactory = new LogOutputSpecFactory(true, true, null);
-      builder.dockerServiceHub(serviceHubFactory.createServiceHub(access, kitLogger, logSpecFactory));
-      builder.buildServiceConfig(BuildServiceConfig.builder()
-          .buildRecreateMode(BuildRecreateMode.fromParameter(kubernetesExtension.getBuildRecreate().getOrElse("none")))
-          .jKubeBuildStrategy(kubernetesExtension.getBuildStrategy())
-          .forcePull(kubernetesExtension.getForcePull().getOrElse(false))
-          .buildDirectory(javaProject.getBuildDirectory().getAbsolutePath())
-          .imagePullManager(imagePullManager)
-          .build());
+      access = dockerAccessFactory.createDockerAccess(dockerAccessContext);
     }
+    ServiceHubFactory serviceHubFactory = new ServiceHubFactory();
+    LogOutputSpecFactory logSpecFactory = new LogOutputSpecFactory(true, true, null);
+    builder.dockerServiceHub(serviceHubFactory.createServiceHub(access, kitLogger, logSpecFactory));
+    ImagePullManager imagePullManager = createImagePullManager(
+      kubernetesExtension.getImagePullPolicy().getOrElse("Always"),
+      kubernetesExtension.getAutoPull().getOrElse("true"),
+      javaProject.getProperties());
+    builder.buildServiceConfig(BuildServiceConfig.builder()
+      .buildRecreateMode(BuildRecreateMode.fromParameter(kubernetesExtension.getBuildRecreate().getOrElse("none")))
+      .jKubeBuildStrategy(kubernetesExtension.getBuildStrategy())
+      .forcePull(kubernetesExtension.getForcePull().getOrElse(false))
+      .buildDirectory(javaProject.getBuildDirectory().getAbsolutePath())
+      .imagePullManager(imagePullManager)
+      .build());
     return builder;
   }
 

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
@@ -13,7 +13,6 @@
  */
 package org.eclipse.jkube.gradle.plugin;
 
-import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
 import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.provider.Property;
 

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTaskTest.java
@@ -24,6 +24,7 @@ import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 
+import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
@@ -49,6 +50,7 @@ public class KubernetesBuildTaskTest {
   private MockedConstruction<DefaultTask> defaultTaskMockedConstruction;
   private MockedConstruction<DockerAccessFactory> dockerAccessFactoryMockedConstruction;
   private Project project;
+  private KubernetesExtension extension;
 
   @Before
   public void setUp() throws IOException {
@@ -60,7 +62,7 @@ public class KubernetesBuildTaskTest {
     dockerAccessFactoryMockedConstruction = mockConstruction(DockerAccessFactory.class, (mock, ctx) -> {
       when(mock.createDockerAccess(any())).thenReturn(mock(DockerAccess.class));
     });
-    final KubernetesExtension extension = new TestKubernetesExtension();
+    extension = new TestKubernetesExtension();
     when(project.getProjectDir()).thenReturn(temporaryFolder.getRoot());
     when(project.getBuildDir()).thenReturn(temporaryFolder.newFolder("build"));
     when(project.getConfigurations().stream()).thenAnswer(i -> Stream.empty());
@@ -94,5 +96,18 @@ public class KubernetesBuildTaskTest {
     assertThat(buildTask.resolvedImages)
         .singleElement()
         .hasFieldOrPropertyWithValue("name", "foo/bar:latest");
+  }
+
+  @Test
+  public void runTask_withImageConfigurationAndJibBuildStrategy_shouldGetBuildService() {
+    // Given
+    extension.buildStrategy = JKubeBuildStrategy.jib;
+    final KubernetesBuildTask buildTask = new KubernetesBuildTask(KubernetesExtension.class);
+    // When
+    buildTask.runTask();
+    // Then
+    assertThat(buildTask.resolvedImages)
+      .singleElement()
+      .hasFieldOrPropertyWithValue("name", "foo/bar:latest");
   }
 }


### PR DESCRIPTION
# Description
When JIB build strategy is picked, we were getting some
NullPointerExceptions due to BuildServiceConfig and
DockerServiceHub(required by OpenShiftBuildService) not
getting initialized.
    
Moving this initialization block out of `isDockerAccessRequired() { // .. }`
block.


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->