### PR TITLE
feat: KubernetesExtension#images can be configured leniently

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
@@ -49,7 +49,7 @@ public class GradleUtil {
 //        .compileClassPathElements(gradleProject.)
 //        .packaging(gradleProject)
         .dependencies(extractDependencies(gradleProject))
-//        .dependenciesWithTransitive(gradleProject.getDependencies().)
+        .dependenciesWithTransitive(extractDependencies(gradleProject))
 //        .localRepositoryBaseDirectory(gradleProject.)
         .plugins(extractPlugins(gradleProject))
 //

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/GroovyUtilTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/GroovyUtilTest.java
@@ -18,15 +18,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import groovy.lang.Closure;
+import org.codehaus.groovy.runtime.GStringImpl;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.eclipse.jkube.gradle.plugin.GroovyUtil.closureTo;
-import static org.eclipse.jkube.gradle.plugin.GroovyUtil.namedListClosureTo;
+import static org.eclipse.jkube.gradle.plugin.GroovyUtil.invokeOrParseClosureList;
 
+@SuppressWarnings({ "unused", "serial" })
 public class GroovyUtilTest {
 
   /**
@@ -45,7 +48,7 @@ public class GroovyUtilTest {
   public void closureTo_withNestedClosure_shouldReturnStructuredClass() {
     // Given
     final Closure<?> closure = closure(this,
-        "property", "value",
+        "property", new GStringImpl(new Object[] { "lue" }, new String[] { "va" }),
         "nested", closure(this, "nestedProperty", "nestedValue"));
     // When
     final StructuredClass result = closureTo(closure, StructuredClass.class);
@@ -92,7 +95,7 @@ public class GroovyUtilTest {
    * </pre>
    */
   @Test
-  public void namedListClosureTo_withNamedListNestedClosure_shouldReturnOrderedList() {
+  public void invokeOrParseClosureList_namedClosureListTo_withNamedListNestedClosure_shouldReturnOrderedList() {
     // Given
     final Closure<?> element1 = closure(this, "property", "value",
         "nested", closure(this, "nestedProperty", "nestedValue"));
@@ -100,9 +103,10 @@ public class GroovyUtilTest {
         "nested", closure(this, "nestedProperty", "nestedValue2"));
     final Closure<?> closure = closure(this, "element1", element1, "element2", element2);
     // When
-    final List<StructuredClass> result = namedListClosureTo(closure, StructuredClass.class);
+    final Optional<List<StructuredClass>> result = invokeOrParseClosureList(closure, StructuredClass.class);
     // Then
-    assertThat(result).hasSize(2)
+    assertThat(result).isPresent().get().asList()
+        .hasSize(2)
         .extracting("property", "nested.nestedProperty")
         .containsExactly(
             tuple("value", "nestedValue"),

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionTest.java
@@ -13,14 +13,19 @@
  */
 package org.eclipse.jkube.gradle.plugin;
 
+import java.util.Collections;
+
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 
+import groovy.lang.Closure;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings({ "serial", "unused" })
 public class KubernetesExtensionTest {
 
   @Test
@@ -32,5 +37,70 @@ public class KubernetesExtensionTest {
     final RuntimeMode result = partial.getRuntimeMode();
     // Then
     assertThat(result).isEqualTo(RuntimeMode.KUBERNETES);
+  }
+
+  @Test
+  public void images_withCallableClosure_shouldSetImagesInClosureExecution() {
+    // Given
+    final KubernetesExtension extension = new TestKubernetesExtension();
+    // When
+    extension.images(new Closure<Void>(extension) {
+      public Void doCall(Object... args) {
+        extension.image(new Closure<Void>(new ImageConfiguration()) {
+          public Void doCall(Object... args) {
+            setProperty("name", "closure/image:name");
+            return null;
+          }
+        });
+        return null;
+      }
+    });
+    // Then
+    assertThat(extension.images).singleElement()
+        .hasFieldOrPropertyWithValue("name", "closure/image:name");
+  }
+
+  @Test
+  public void images_withMapListClosure_shouldSetImagesUsingConfigObjectParsing() {
+    // Given
+    final KubernetesExtension extension = new TestKubernetesExtension();
+    // When
+    extension.images(new Closure<Void>(extension) {
+      public Void doCall(Object... args) {
+        setProperty("image1", new Closure<Void>(new ImageConfiguration()) {
+          public Void doCall(Object... args) {
+            setProperty("name", "closure/image1:name");
+            return null;
+          }
+        });
+        setProperty("image2", new Closure<Void>(new ImageConfiguration()) {
+          public Void doCall(Object... args) {
+            setProperty("name", "closure/image2:name");
+            return null;
+          }
+        });
+        return null;
+      }
+    });
+    // Then
+    assertThat(extension.images).hasSize(2)
+        .extracting(ImageConfiguration::getName)
+        .containsExactly("closure/image1:name", "closure/image2:name");
+  }
+
+  @Test
+  public void images_withListOfClosures_shouldSetImages() {
+    // Given
+    final KubernetesExtension extension = new TestKubernetesExtension();
+    // When
+    extension.images(Collections.singletonList(new Closure<Void>(extension) {
+      public Void doCall(Object... args) {
+        setProperty("name", "closure/image:name");
+        return null;
+      }
+    }));
+    // Then
+    assertThat(extension.images).singleElement()
+        .hasFieldOrPropertyWithValue("name", "closure/image:name");
   }
 }

--- a/quickstarts/gradle/micronaut-customized-image/gradle/wrapper/gradle-wrapper.properties
+++ b/quickstarts/gradle/micronaut-customized-image/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quickstarts/gradle/spring-boot/build.gradle
+++ b/quickstarts/gradle/spring-boot/build.gradle
@@ -29,17 +29,20 @@ kubernetes {
         excludes = ['jkube-expose']
     }
     resources {
-        controllerName ='test'
+        controllerName = 'test'
         configMap {
             name = 'configMap-name'
             entries = [
-                [name: 'test', value: 'value']
+                    [name: 'test', value: 'value']
             ]
         }
     }
     images {
-        image2 { name = 'registry/image2:tag' }
-        image1 {
+        image {
+            name = 'registry/image2:tag'
+            build.from = 'busybox'
+        }
+        image {
             name = 'registry/image:tag'
             build {
                 from = 'busybox'


### PR DESCRIPTION
## Description
feat: KubernetesExtension#images can be configured leniently

Images can now be configured with the following syntax options:
```groovy
// The most groovy compliant way
images {
  image {
    name = 'image1'
  }
  image {
    name = 'image2'
  }
}
// As a map of image entries
images {
  image1 {
    name = 'image1'
  }
  image2 {
    name = 'image2'
  }
}
// As a list of image entries
images ([
  {
    name = 'image1'
  },
  {
    name = 'image2'
  }
])
```

