### PR TITLE
Fix #854: %n should be used in place of \n to produce the platform-specific line separator. 

### DIFF
--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -266,9 +266,9 @@ public class ImageName {
         }
         if (!errors.isEmpty()) {
             StringBuilder buf = new StringBuilder();
-            buf.append(String.format("Given Docker name '%s' is invalid:\n", getFullName()));
+            buf.append(String.format("Given Docker name '%s' is invalid:%n", getFullName()));
             for (String error : errors) {
-                buf.append(String.format("   * %s\n",error));
+                buf.append(String.format("   * %s%n",error));
             }
             buf.append("See http://bit.ly/docker_image_fmt for more details");
             throw new IllegalArgumentException(buf.toString());


### PR DESCRIPTION
Fix #854 
 - [x] Bug fix (non-breaking change which fixes an issue) #854 
