### PR TITLE
Fixed #858, FromConfigRegistryAuthHandlerTest: Use assertThrows instead of deprecated ExpectedException.none() @Rule

### DIFF
--- a/jkube-kit/build/api/pom.xml
+++ b/jkube-kit/build/api/pom.xml
@@ -31,6 +31,14 @@
 
   <dependencies>
 
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.7.0</version>
+        <scope>test</scope>
+    </dependency>
+      
+      
     <dependency>
       <groupId>org.eclipse.jkube</groupId>
       <artifactId>jkube-kit-config-image</artifactId>

--- a/jkube-kit/build/api/pom.xml
+++ b/jkube-kit/build/api/pom.xml
@@ -31,8 +31,6 @@
 
   <dependencies>
 
-   
-      
     <dependency>
       <groupId>org.eclipse.jkube</groupId>
       <artifactId>jkube-kit-config-image</artifactId>

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -88,9 +88,7 @@ public class FromConfigRegistryAuthHandlerTest {
             RegistryAuthConfig.builder().putDefaultConfig(RegistryAuth.USERNAME, "admin").build(), log);
 
         //expectedException.expect(IllegalArgumentException.class);
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,() -> throws IllegalArgumentException("bad password"),"not thrown bad password exception");
-        
-        //() -> throw IllegalArgumentException("Throw an Illegal Argument Exception"));          
+        IllegalArgumentException exception= assertThrows(IllegalArgumentException.class,() -> { throw new IllegalArgumentException("throw illegal arg exception"); });      
         //expectedexception implementation substituted with assertThrows #task1
       
         

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -89,7 +89,7 @@ public class FromConfigRegistryAuthHandlerTest {
 
         //expectedException.expect(IllegalArgumentException.class);
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, 
-        () -> throwsIllegalArgumentException("Throw an Illegal Argument Exception"));          //expectedexception implementation substituted with assertThrows #task1
+        () -> throw new IllegalArgumentException("Throw an Illegal Argument Exception"));          //expectedexception implementation substituted with assertThrows #task1
       
         
         //expectedException.expectMessage(containsString("password"));

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -88,8 +88,8 @@ public class FromConfigRegistryAuthHandlerTest {
             RegistryAuthConfig.builder().putDefaultConfig(RegistryAuth.USERNAME, "admin").build(), log);
 
         //expectedException.expect(IllegalArgumentException.class);
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, 
-        () -> throw new IllegalArgumentException("Throw an Illegal Argument Exception"));          //expectedexception implementation substituted with assertThrows #task1
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> throw IllegalArgumentException("Throw an Illegal Argument Exception"));          
+        //expectedexception implementation substituted with assertThrows #task1
       
         
         //expectedException.expectMessage(containsString("password"));

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 
 
 import static org.assertj.core.api.Assertions.assertThat;  /*assertj assertThat import*/
-import static org.junit.jupiter.api.Assertions.assertThrows;   /*assertThrows import*/
+import static org.junit.Assert.assertThrows;   /*assertThrows import*/
 
 /**
  * @author roland
@@ -44,8 +44,6 @@ public class FromConfigRegistryAuthHandlerTest {
     @Mocked
     private KitLogger log;
 
-    /*@Rule
-    public ExpectedException expectedException = ExpectedException.none();*/      //removed expectedException @Rule
 
     @Test
     public void testFromPluginConfiguration() throws IOException {
@@ -86,15 +84,9 @@ public class FromConfigRegistryAuthHandlerTest {
     public void testFromPluginConfigurationFailed() {
         FromConfigRegistryAuthHandler handler = new FromConfigRegistryAuthHandler(
             RegistryAuthConfig.builder().putDefaultConfig(RegistryAuth.USERNAME, "admin").build(), log);
-
-        //expectedException.expect(IllegalArgumentException.class);
-        IllegalArgumentException exception= assertThrows(IllegalArgumentException.class,() -> { throw new IllegalArgumentException("throw illegal arg exception"); });      
-        //expectedexception implementation substituted with assertThrows #task1
-      
         
-        //expectedException.expectMessage(containsString("password"));
-        assertThat(exception.getMessage()).contains("password");    //assertThat from assertJ used for in place of containsString of hamcrest #task2
-       
+        IllegalArgumentException exception= assertThrows(IllegalArgumentException.class,() -> {handler.create(RegistryAuthConfig.Kind.PUSH, null, null, s -> s); });             
+        assertThat(exception.getMessage()).contains("password");   
         
         handler.create(RegistryAuthConfig.Kind.PUSH, null, null, s -> s);
     }

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -93,7 +93,7 @@ public class FromConfigRegistryAuthHandlerTest {
       
         
         //expectedException.expectMessage(containsString("password"));
-        assertThat(exception.getMessage()).contains("password"));    //assertThat from assertJ used for in place of containsString of hamcrest #task2
+        assertThat(exception.getMessage()).contains("password");    //assertThat from assertJ used for in place of containsString of hamcrest #task2
        
         
         handler.create(RegistryAuthConfig.Kind.PUSH, null, null, s -> s);

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -30,6 +30,11 @@ import org.junit.rules.ExpectedException;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 
+
+
+import static org.assertj.core.api.Assertions.assertThat;  /*assertj assertThat import*/
+import static org.junit.jupiter.api.Assertions.assertThrows;   /*assertThrows import*/
+
 /**
  * @author roland
  * @since 23.10.18
@@ -39,8 +44,8 @@ public class FromConfigRegistryAuthHandlerTest {
     @Mocked
     private KitLogger log;
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    /*@Rule
+    public ExpectedException expectedException = ExpectedException.none();*/      //removed expectedException @Rule
 
     @Test
     public void testFromPluginConfiguration() throws IOException {
@@ -82,8 +87,15 @@ public class FromConfigRegistryAuthHandlerTest {
         FromConfigRegistryAuthHandler handler = new FromConfigRegistryAuthHandler(
             RegistryAuthConfig.builder().putDefaultConfig(RegistryAuth.USERNAME, "admin").build(), log);
 
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(containsString("password"));
+        //expectedException.expect(IllegalArgumentException.class);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, 
+        () -> throwsIllegalArgumentException("Throw an Illegal Argument Exception"));          //expectedexception implementation substituted with assertThrows #task1
+      
+        
+        //expectedException.expectMessage(containsString("password"));
+        assertThat(exception.getMessage(),containsString("password"));    //assertThat from assertJ used for in place of containsString of hamcrest #task2
+       
+        
         handler.create(RegistryAuthConfig.Kind.PUSH, null, null, s -> s);
     }
 

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -23,17 +23,13 @@ import org.eclipse.jkube.kit.build.api.auth.RegistryAuth;
 import org.eclipse.jkube.kit.build.api.auth.RegistryAuthConfig;
 import org.eclipse.jkube.kit.common.KitLogger;
 import mockit.Mocked;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import static org.hamcrest.CoreMatchers.containsString;
+
 import static org.junit.Assert.assertEquals;
 
-
-
-import static org.assertj.core.api.Assertions.assertThat;  /*assertj assertThat import*/
-import static org.junit.Assert.assertThrows;   /*assertThrows import*/
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 /**
  * @author roland
@@ -85,7 +81,7 @@ public class FromConfigRegistryAuthHandlerTest {
         FromConfigRegistryAuthHandler handler = new FromConfigRegistryAuthHandler(
             RegistryAuthConfig.builder().putDefaultConfig(RegistryAuth.USERNAME, "admin").build(), log);
         
-        IllegalArgumentException exception= assertThrows(IllegalArgumentException.class,() -> {handler.create(RegistryAuthConfig.Kind.PUSH, null, null, s -> s); });             
+        IllegalArgumentException exception= assertThrows(IllegalArgumentException.class, () -> handler.create(RegistryAuthConfig.Kind.PUSH, null, null, s -> s));             
         assertThat(exception.getMessage()).contains("password");   
         
         handler.create(RegistryAuthConfig.Kind.PUSH, null, null, s -> s);

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -88,7 +88,9 @@ public class FromConfigRegistryAuthHandlerTest {
             RegistryAuthConfig.builder().putDefaultConfig(RegistryAuth.USERNAME, "admin").build(), log);
 
         //expectedException.expect(IllegalArgumentException.class);
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> throw IllegalArgumentException("Throw an Illegal Argument Exception"));          
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class);
+        
+        //() -> throw IllegalArgumentException("Throw an Illegal Argument Exception"));          
         //expectedexception implementation substituted with assertThrows #task1
       
         

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -93,7 +93,7 @@ public class FromConfigRegistryAuthHandlerTest {
       
         
         //expectedException.expectMessage(containsString("password"));
-        assertThat(exception.getMessage(),containsString("password"));    //assertThat from assertJ used for in place of containsString of hamcrest #task2
+        assertThat(exception.getMessage()).contains("password"));    //assertThat from assertJ used for in place of containsString of hamcrest #task2
        
         
         handler.create(RegistryAuthConfig.Kind.PUSH, null, null, s -> s);

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -88,7 +88,7 @@ public class FromConfigRegistryAuthHandlerTest {
             RegistryAuthConfig.builder().putDefaultConfig(RegistryAuth.USERNAME, "admin").build(), log);
 
         //expectedException.expect(IllegalArgumentException.class);
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,() -> throwsIllegalArgumentException("bad password"),"not thrown bad password exception");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,() -> throws IllegalArgumentException("bad password"),"not thrown bad password exception");
         
         //() -> throw IllegalArgumentException("Throw an Illegal Argument Exception"));          
         //expectedexception implementation substituted with assertThrows #task1

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/handler/FromConfigRegistryAuthHandlerTest.java
@@ -88,7 +88,7 @@ public class FromConfigRegistryAuthHandlerTest {
             RegistryAuthConfig.builder().putDefaultConfig(RegistryAuth.USERNAME, "admin").build(), log);
 
         //expectedException.expect(IllegalArgumentException.class);
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,() -> throwsIllegalArgumentException("bad password"),"not thrown bad password exception");
         
         //() -> throw IllegalArgumentException("Throw an Illegal Argument Exception"));          
         //expectedexception implementation substituted with assertThrows #task1


### PR DESCRIPTION
# Fixed [ issue #858](https://github.com/eclipse/jkube/issues/858)

## Refactored testFromPluginConfigurationFailed() function as stated in the issue [#858 ](https://github.com/eclipse/jkube/issues/858)

## Tasks Completed:
- 1.  Remove ExpectedException.none() @Rule and use assertThrows    : Completed
- 2. Use AssertJ's assertThat instead of Hamcrest assertion for asserting exception message org.hamcrest.CoreMatchers.containsString     : Completed

## Overall changes
- imports for assertJ assertThat() and Junit assertThrows()
- commented out deprecated usage rules for expectedException
- refactored testFromPluginConfigurationFailed() function with assertThat and assertThrows




