### PR TITLE
Pre-requisite for #850: Add outputArtifactDir to JavaProject

### DIFF
--- a/jkube-kit/common-maven/src/main/java/org/eclipse/jkube/kit/common/util/MavenUtil.java
+++ b/jkube-kit/common-maven/src/main/java/org/eclipse/jkube/kit/common/util/MavenUtil.java
@@ -358,7 +358,8 @@ public class MavenUtil {
             .ifPresent(mavenBuild -> builder
                 .outputDirectory(new File(mavenBuild.getOutputDirectory()))
                 .buildFinalName(mavenBuild.getFinalName())
-                .buildDirectory(new File(mavenBuild.getDirectory())));
+                .buildDirectory(new File(mavenBuild.getDirectory()))
+                .buildPackageDirectory(new File(mavenBuild.getDirectory())));
 
         if (mavenProject.getIssueManagement() != null) {
             builder.issueManagementSystem(mavenProject.getIssueManagement().getSystem());

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/JavaProject.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/JavaProject.java
@@ -85,6 +85,24 @@ public class JavaProject implements Serializable {
    * @return The build directory for the project.
    */
   private File buildDirectory;
+
+  /**
+   * Directory where build packages or artifacts (jar/war/ear) are output.
+   * This can be <code>target</code> in case of Maven and <code>build/libs</code> in case of Gradle.
+   *
+   * <p>
+   * This directory is used by generators and other build related tools to locate the
+   * files and packages to be included in the Container Image.
+   *
+   * <p>
+   * Please note that it's different from buildDirectory or outputDirectory which may point to directory
+   * used by build tool or generated classes.
+   *
+   * @param buildPackageDirectory directory where the project artifacts and packages are output
+   * @return the directory where the project artifacts and packages are output
+   */
+  private File buildPackageDirectory;
+
   /**
    * Project configuration properties to be used in generators and enrichers
    *
@@ -212,7 +230,7 @@ public class JavaProject implements Serializable {
   @Builder
   public JavaProject(
       String name, String groupId, String artifactId, String version,
-      File outputDirectory, File baseDirectory, File buildDirectory,
+      File outputDirectory, File baseDirectory, File buildDirectory, File buildPackageDirectory,
       Properties properties, @Singular List<String> compileClassPathElements, @Singular List<Dependency> dependencies,
       List<Dependency> dependenciesWithTransitive, @Singular List<Plugin> plugins,
       String site, String description, String organizationName, String documentationUrl,
@@ -243,6 +261,7 @@ public class JavaProject implements Serializable {
     this.issueManagementUrl = issueManagementUrl;
     this.scmUrl = scmUrl;
     this.scmTag = scmTag;
+    this.buildPackageDirectory = buildPackageDirectory;
   }
 }
 

--- a/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
+++ b/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
@@ -62,7 +62,7 @@ public class JavaExecGenerator extends BaseGenerator {
 
     protected JavaExecGenerator(GeneratorContext context, String name) {
         super(context, name, new FromSelector.Default(context, "java"));
-        fatJarDetector = new FatJarDetector(getProject().getBuildDirectory());
+        fatJarDetector = new FatJarDetector(getProject().getBuildPackageDirectory());
         mainClassDetector = new MainClassDetector(getConfig(Config.MAIN_CLASS),
                 getProject().getOutputDirectory(), context.getLogger());
     }
@@ -200,7 +200,7 @@ public class JavaExecGenerator extends BaseGenerator {
     }
 
     private static AssemblyFileSet getOutputDirectoryFileSet(FatJarDetector.Result fatJar, JavaProject project) {
-        final File buildDirectory = project.getBuildDirectory();
+        final File buildDirectory = project.getBuildPackageDirectory();
         return AssemblyFileSet.builder()
                 .directory(getRelativePath(project.getBaseDirectory(), buildDirectory))
                 .include(getRelativePath(buildDirectory, fatJar.getArchiveFile()).getPath())

--- a/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorMainClassDeterminationTest.java
+++ b/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorMainClassDeterminationTest.java
@@ -63,7 +63,6 @@ public class JavaExecGeneratorMainClassDeterminationTest {
         // @formatter:off
         new Expectations() {{
             project.getVersion(); result = "1.33.7-SNAPSHOT";
-            project.getBuildDirectory(); result = "/the/directory";
             project.getOutputDirectory(); result = "/the/output/directory";
         }};
         // @formatter:on

--- a/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorTest.java
+++ b/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorTest.java
@@ -100,7 +100,7 @@ public class JavaExecGeneratorTest {
     // Given
     // @formatter:off
     new Expectations() {{
-      generatorContext.getProject().getBuildDirectory(); result = new File("");
+      generatorContext.getProject().getBuildPackageDirectory(); result = new File("");
       generatorContext.getProject().getBaseDirectory(); result = new File("");
       fjResult.getArchiveFile(); result = new File("fat.jar");
       fatJarDetector.scan(); result = fjResult;

--- a/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
+++ b/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
@@ -58,7 +58,6 @@ public class OpenLibertyGeneratorTest {
       project.getBaseDirectory(); result = "basedirectory"; minTimes = 0;
 
       String tempDir = Files.createTempDirectory("openliberty-test-project").toFile().getAbsolutePath();
-      project.getBuildDirectory(); result = tempDir;
       project.getOutputDirectory(); result = tempDir; minTimes = 0;
       project.getVersion(); result = "1.0.0"; minTimes = 0;
     }};

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
@@ -80,7 +80,7 @@ public class QuarkusGeneratorTest {
     new Expectations() {{
       project.getVersion(); result = "0.0.1-SNAPSHOT"; minTimes = 0;
       project.getBaseDirectory(); result = baseDir; minTimes = 0;
-      project.getBuildDirectory(); result = baseDir.getAbsolutePath();
+      project.getBuildDirectory(); result = baseDir.getAbsolutePath(); minTimes = 0;
       project.getProperties(); result = projectProps;
       project.getCompileClassPathElements(); result = Collections.emptyList(); minTimes = 0;
       project.getOutputDirectory(); result = baseDir;

--- a/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/generator/SpringBootGeneratorTest.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/generator/SpringBootGeneratorTest.java
@@ -68,7 +68,6 @@ public class SpringBootGeneratorTest {
             String tempDir = Files.createTempDirectory("springboot-test-project").toFile().getAbsolutePath();
 
             // TODO: Prepare more relastic test setup
-            project.getBuildDirectory(); result = tempDir;
             project.getOutputDirectory(); result = tempDir;
             project.getPlugins(); result = Collections.EMPTY_LIST; minTimes = 0;
             project.getVersion(); result = "1.0.0"; minTimes = 0;

--- a/jkube-kit/jkube-kit-vertx/src/test/java/org/eclipse/jkube/vertx/generator/VertxGeneratorTest.java
+++ b/jkube-kit/jkube-kit-vertx/src/test/java/org/eclipse/jkube/vertx/generator/VertxGeneratorTest.java
@@ -113,7 +113,6 @@ public class VertxGeneratorTest {
     // Given
     // @formatter:off
     new Expectations() {{
-      project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
       project.getOutputDirectory(); result = new File("target/tmp/target").getAbsolutePath();
     }};
     // @formatter:on
@@ -128,8 +127,6 @@ public class VertxGeneratorTest {
     // Given
     // @formatter:off
     new Expectations() {{
-      project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
-      project.getOutputDirectory(); result = new File("target/tmp/target").getAbsolutePath();
       project.getDependencies(); result = Arrays.asList(dropwizard, core);
     }};
     // @formatter:on
@@ -148,7 +145,6 @@ public class VertxGeneratorTest {
       // Given
       // @formatter:off
       new Expectations() {{
-        project.getBuildDirectory(); result = new File("target/tmp").getAbsolutePath();
         project.getOutputDirectory(); result = new File("target/tmp/target").getAbsolutePath();
         project.getDependencies(); result = Arrays.asList(infinispan, core);
       }};

--- a/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGeneratorTest.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/test/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGeneratorTest.java
@@ -266,7 +266,6 @@ public class WildflyJARGeneratorTest {
         new Expectations() {{
             context.getProject(); result = project;
             String tempDir = Files.createTempDirectory("wildfly-jar-test-project").toFile().getAbsolutePath();
-            project.getBuildDirectory(); result = tempDir;
             project.getOutputDirectory(); result = tempDir;
             project.getPlugins(); result = Collections.EMPTY_LIST; minTimes = 0;
             project.getVersion(); result = "1.0.0"; minTimes = 0;


### PR DESCRIPTION
## Description

Gradle's build directory doesn't contain jar files unlike maven.
Adding an additional field outputArtifactDir which will store parent
directory of artifact file.

JavaExecGenerator would make use of outputArtifactDir field in order to
look for fat jars and creating AssemblyFileSets

Related to #850

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->