### PR TITLE
Fix #868: Rename variables 'followLog' and 'podName' in order to alig…

### DIFF
--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/LogMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/LogMojo.java
@@ -34,11 +34,11 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 public class LogMojo extends ApplyMojo {
 
   @Parameter(property = "jkube.log.follow", defaultValue = "true")
-  private boolean followLog;
+  private boolean logFollow;
   @Parameter(property = "jkube.log.container")
   private String logContainerName;
   @Parameter(property = "jkube.log.pod")
-  private String podName;
+  private String logPodName;
 
   @Override
   protected void applyEntities(final KubernetesClient kubernetes, String fileName, final Collection<HasMetadata> entities) {
@@ -48,7 +48,7 @@ public class LogMojo extends ApplyMojo {
         entities,
         false,
         null,
-        followLog,
+        logFollow,
         null,
         true
     );
@@ -58,7 +58,7 @@ public class LogMojo extends ApplyMojo {
     return PodLogService.PodLogServiceContext.builder()
         .log(log)
         .logContainerName(logContainerName)
-        .podName(podName)
+        .podName(logPodName)
         .newPodLog(createLogger("[[C]][NEW][[C]] "))
         .oldPodLog(createLogger("[[R]][OLD][[R]] "));
   }


### PR DESCRIPTION
## Description
Fix #868: Rename variables in order to align with documentation
- [x] Rename `followLog` -> `logFollow`
- [x] Rename `podName` -> `logPodName`

Signed-off-by: Izael <jv.izael@hotmail.com>
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->