### PR TITLE
Fix #882: Add OpenShiftResourceTask to Kubernetes Gradle Plugin

### DIFF
--- a/gradle-plugin/it/src/it/dockerfile-simple/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/dockerfile-simple/expected/openshift.yml
@@ -1,0 +1,99 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      expose: "true"
+      app: dockerfile-simple
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: dockerfile-simple
+  spec:
+    ports:
+    - name: glrpc
+      port: 9080
+      protocol: TCP
+      targetPort: 9080
+    selector:
+      app: dockerfile-simple
+      provider: jkube
+      group: org.eclipse.jkube.integration.tests.gradle
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: dockerfile-simple
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: dockerfile-simple
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: dockerfile-simple
+      provider: jkube
+      group: org.eclipse.jkube.integration.tests.gradle
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: gradle/dockerfile-simple:latest
+          imagePullPolicy: IfNotPresent
+          name: gradle-dockerfile-simple
+          ports:
+          - containerPort: 9080
+            name: glrpc
+            protocol: TCP
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - gradle-dockerfile-simple
+        from:
+          kind: ImageStreamTag
+          name: dockerfile-simple:latest
+          namespace: gradle
+      type: ImageChange
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: dockerfile-simple
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: dockerfile-simple
+  spec:
+    port:
+      targetPort: 9080
+    to:
+      kind: Service
+      name: dockerfile-simple

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DockerfileSimpleIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DockerfileSimpleIT.java
@@ -42,4 +42,21 @@ public class DockerfileSimpleIT {
       .contains("Using first mentioned service port")
       .contains("validating");
   }
+
+  @Test
+  public void ocResource_whenRun_generatesOpenShiftManifests() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("dockerfile-simple").withArguments("ocResource").build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
+      gradleRunner.resolveFile("expected", "openshift.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+      .contains("Running in OpenShift mode")
+      .contains("Using resource templates from")
+      .contains("Adding a default Deployment")
+      .contains("Converting Deployment to DeploymentConfig")
+      .contains("Adding revision history limit to 2")
+      .contains("Using first mentioned service port")
+      .contains("validating");
+  }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ITGradleRunner.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ITGradleRunner.java
@@ -68,6 +68,10 @@ public class ITGradleRunner extends ExternalResource {
     return resolveFile("build", "classes", "java", "main", "META-INF", "jkube", "kubernetes.yml");
   }
 
+  public File resolveDefaultOpenShiftResourceFile() {
+    return resolveFile("build", "classes", "java", "main", "META-INF", "jkube", "openshift.yml");
+  }
+
   public BuildResult build() {
     return gradleRunner.build();
   }

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
@@ -23,6 +23,7 @@ import org.eclipse.jkube.gradle.plugin.task.KubernetesLogTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesResourceTask;
 
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftBuildTask;
+import org.eclipse.jkube.gradle.plugin.task.OpenShiftResourceTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 
@@ -42,7 +43,7 @@ public class OpenShiftPlugin extends AbstractJKubePlugin<OpenShiftExtension> {
   @Override
   protected void jKubeApply(Project project) {
     register(project, "ocBuild", OpenShiftBuildTask.class);
-    register(project, "ocResource", KubernetesResourceTask.class);
+    register(project, "ocResource", OpenShiftResourceTask.class);
     register(project, "ocApply", KubernetesApplyTask.class);
     register(project, "ocLog", KubernetesLogTask.class);
   }

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+import org.eclipse.jkube.kit.config.resource.RuntimeMode;
+
+import javax.inject.Inject;
+import java.util.Properties;
+
+public class OpenShiftResourceTask extends KubernetesResourceTask {
+  private static final String DOCKER_IMAGE_USER = "docker.image.user";
+
+  @Inject
+  public OpenShiftResourceTask(Class<? extends OpenShiftExtension> extensionClass) {
+    super(extensionClass);
+    setDescription(
+      "Generates or copies the OpenShift JSON file and attaches it to the build so its installed and released to maven repositories like other build artifacts.");
+  }
+
+  @Override
+  public void run() {
+    RuntimeMode runtimeMode = kubernetesExtension.getRuntimeMode();
+    Properties properties = javaProject.getProperties();
+    if (!properties.contains(DOCKER_IMAGE_USER)) {
+      String namespaceToBeUsed = kubernetesExtension.getNamespace().getOrElse(clusterAccess.getNamespace());
+      kitLogger.info("Using docker image name of namespace: " + namespaceToBeUsed);
+      properties.setProperty(DOCKER_IMAGE_USER, namespaceToBeUsed);
+    }
+    if (!properties.contains(RuntimeMode.JKUBE_EFFECTIVE_PLATFORM_MODE)) {
+      properties.setProperty(RuntimeMode.JKUBE_EFFECTIVE_PLATFORM_MODE, runtimeMode.toString());
+    }
+
+    super.run();
+  }
+}

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginTest.java
@@ -21,6 +21,7 @@ import org.eclipse.jkube.gradle.plugin.task.KubernetesApplyTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesResourceTask;
 
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftBuildTask;
+import org.eclipse.jkube.gradle.plugin.task.OpenShiftResourceTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.junit.Before;
@@ -51,7 +52,7 @@ public class OpenShiftPluginTest {
     verify(project.getTasks(), times(1))
         .register("ocBuild", OpenShiftBuildTask.class, OpenShiftExtension.class);
     verify(project.getTasks(), times(1))
-        .register("ocResource", KubernetesResourceTask.class, OpenShiftExtension.class);
+        .register("ocResource", OpenShiftResourceTask.class, OpenShiftExtension.class);
     verify(project.getTasks(), times(1))
         .register("ocApply", KubernetesApplyTask.class, OpenShiftExtension.class);
   }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTaskTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+import org.eclipse.jkube.gradle.plugin.TestOpenShiftExtension;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedConstruction;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+public class OpenShiftResourceTaskTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private MockedConstruction<DefaultTask> defaultTaskMockedConstruction;
+  private Project project;
+
+  @Before
+  public void setUp() throws IOException {
+    project = mock(Project.class, RETURNS_DEEP_STUBS);
+    defaultTaskMockedConstruction = mockConstruction(DefaultTask.class, (mock, ctx) -> {
+      when(mock.getProject()).thenReturn(project);
+      when(mock.getLogger()).thenReturn(mock(Logger.class));
+    });
+    when(project.getProjectDir()).thenReturn(temporaryFolder.getRoot());
+    when(project.getBuildDir()).thenReturn(temporaryFolder.newFolder("build"));
+    when(project.getConfigurations().stream()).thenAnswer(i -> Stream.empty());
+    when(project.getBuildscript().getConfigurations().stream()).thenAnswer(i -> Stream.empty());
+    when(project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(new TestOpenShiftExtension());
+    when(project.getConvention().getPlugin(JavaPluginConvention.class)).thenReturn(mock(JavaPluginConvention.class));
+  }
+
+  @After
+  public void tearDown() {
+    defaultTaskMockedConstruction.close();
+  }
+
+  @Test
+  public void runTask_withImageConfiguration_shouldGenerateResources() {
+    // Given
+    OpenShiftResourceTask resourceTask = new OpenShiftResourceTask(OpenShiftExtension.class);
+    // When
+    resourceTask.runTask();
+    // Then
+    assertThat(temporaryFolder.getRoot().toPath()
+      .resolve(Paths.get("build", "classes", "java", "main", "META-INF", "jkube", "openshift.yml")))
+      .exists()
+      .hasContent("---\n" +
+        "apiVersion: v1\n" +
+        "kind: List\n");
+  }
+}


### PR DESCRIPTION
## Description
Fix #882 
Provide `oc:resource` equivalent functionality to Kubernetes Gradle
Plugin.

Should be merged after #861

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->