### PR TITLE
 ISSUE#891 busybox image name is hardcoded in VolumePermissionEnrich…

### DIFF
--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricher.java
@@ -54,6 +54,7 @@ public class VolumePermissionEnricher extends BaseEnricher {
 
     @AllArgsConstructor
     enum Config implements Configs.Config {
+        IMAGE_NAME("imageName", "busybox"),
         PERMISSION("permission", "777"),
         DEFAULT_STORAGE_CLASS("defaultStorageClass", null);
 
@@ -112,7 +113,7 @@ public class VolumePermissionEnricher extends BaseEnricher {
                 Map<String, String> mountPoints = extractMountPoints(podSpec);
                 return new ContainerBuilder()
                         .withName(ENRICHER_NAME)
-                        .withImage("busybox")
+                        .withImage(getConfig(Config.IMAGE_NAME))
                         .withImagePullPolicy("IfNotPresent")
                         .withCommand(createChmodCommandArray(mountPoints))
                         .withVolumeMounts(createMounts(mountPoints))

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricherTest.java
@@ -54,8 +54,10 @@ public class VolumePermissionEnricherTest {
         private final String permission;
         private final String initContainerName;
         private final String[] volumeNames;
+        private final String imageName;
 
-        private TestConfig(String permission, String initContainerName, String... volumeNames) {
+        private TestConfig(String imageName,String permission, String initContainerName, String... volumeNames) {
+            this.imageName=imageName;
             this.permission = permission;
             this.initContainerName = initContainerName;
             this.volumeNames = volumeNames;
@@ -91,9 +93,10 @@ public class VolumePermissionEnricherTest {
     @Test
     public void testAdapt() {
         final TestConfig[] data = new TestConfig[]{
-            new TestConfig(null, null),
-            new TestConfig(null, VolumePermissionEnricher.ENRICHER_NAME, "volumeA"),
-            new TestConfig(null, VolumePermissionEnricher.ENRICHER_NAME, "volumeA", "volumeB")
+            new TestConfig("busybox",null, null),
+            new TestConfig("busybox1",null, null),
+            new TestConfig("busybox",null, VolumePermissionEnricher.ENRICHER_NAME, "volumeA"),
+            new TestConfig("busybox",null, VolumePermissionEnricher.ENRICHER_NAME, "volumeA", "volumeB")
         };
 
         for (final TestConfig tc : data) {
@@ -133,6 +136,7 @@ public class VolumePermissionEnricherTest {
 
             JsonObject jo = ja.get(0).getAsJsonObject();
             assertEquals(tc.initContainerName, jo.get("name").getAsString());
+            assertEquals(tc.imageName, jo.get("image").getAsString());
             String permission = StringUtils.isBlank(tc.permission) ? "777" : tc.permission;
             JsonArray chmodCmd = new JsonArray();
             chmodCmd.add("chmod");


### PR DESCRIPTION
## Description

Add Init Conatiner Image Name as configurable
 1. Added new ENUM for ImageName
 2. Used default value as busybox

It helps in avoiding ratelimiting from some  Image regsiteries and provide user custom images. 

Fix #891

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)


## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->