### PR TITLE
deps: Bump JKube base images to 0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Usage:
 ```
 ### 1.5.0-SNAPSHOT
 * Fix #815: `java.lang.ClassCastException` during `oc:build` when OpenShift not present
-* Fix #716: Update Spring Boot Quickstarts to latest version\
+* Fix #716: Update Spring Boot Quickstarts to latest version
+* Fix #907: Bump JKube base images to 0.0.10
 
 ### 1.4.0 (2021-07-27)
 * Fix #253: Refactor JKubeServiceHub's BuildService election mechanism via ServiceLoader

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.wagon-ssh-external>2.3</version.wagon-ssh-external>
 
     <!-- =======================================================  -->
-    <version.image.jkube-images>0.0.9</version.image.jkube-images>
+    <version.image.jkube-images>0.0.10</version.image.jkube-images>
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
     <!-- Upstream -->
     <version.image.java.upstream.docker>${version.image.jkube-images}</version.image.java.upstream.docker>


### PR DESCRIPTION
## Description
deps: Bump [JKube base images](https://quay.io/repository/jkube/jkube-java-binary-s2i?tab=tags) to [0.0.10](https://quay.io/repository/jkube/jkube-java-binary-s2i/manifest/sha256:b6a0e84440061ab27064534e342d99077aa4e8466913e74b16218c86baf74f00?tab=vulnerabilities).

New images don't have security warnings.

- [x] k8s:watch goal works on new image
- [x] k8s:debug goal works on new image
- [x] oc:build s2i goal works on new image
- [x] oc:build docker goal works on new image
- [x] ~~oc:watch goal works on new image~~ n/a (#422)
- [x] oc:debug goal works on new image

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] ~~I have implemented unit tests to cover my changes~~
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->