### PR TITLE
Fix #908: OpenShift-Maven-Plugin doesn't remove periods from opinionated container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ Usage:
 ### 1.5.0-SNAPSHOT
 * Fix #815: `java.lang.ClassCastException` during `oc:build` when OpenShift not present
 * Fix #716: Update Spring Boot Quickstarts to latest version
-* Fix #904: DeploymentConfig ImageChange trigger seems to be wrong for custom images
 * Fix #907: Bump JKube base images to 0.0.10
 * Fix #832: Bump jib-core to 0.20.0
+* Fix #904: DeploymentConfig ImageChange trigger seems to be wrong for custom images
+* Fix #904: `%g` should be resolved to namespace in OpenShift Maven Plugin
+* Fix #908: OpenShift-Maven-Plugin doesn't remove periods from container name
 
 ### 1.4.0 (2021-07-27)
 * Fix #253: Refactor JKubeServiceHub's BuildService election mechanism via ServiceLoader

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtilTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtilTest.java
@@ -176,6 +176,21 @@ public class KubernetesResourceUtilTest {
     }
 
     @Test
+    public void containerName_withPeriodsInImageUser_shouldRemovePeriodsFromContainerName() {
+        // Given
+        ImageConfiguration imageConfiguration = ImageConfiguration.builder()
+          .name("org.eclipse.jkube.testing/test-image")
+          .build();
+        GroupArtifactVersion gav = new GroupArtifactVersion("org.eclipse.jkube.testing", "test-image", "1.0.0");
+
+        // When
+        String containerName = KubernetesResourceUtil.extractContainerName(gav, imageConfiguration);
+
+        // Then
+        assertEquals("orgeclipsejkubetesting-test-image", containerName);
+    }
+
+    @Test
     public void readWholeDir() throws IOException {
         ResourceVersioning v = new ResourceVersioning()
                 .withCoreVersion("v2")


### PR DESCRIPTION
## Description

Fix #908 
In quickstarts/maven/quarkus-customized-image,
KubernetesResourceUtil.extractContainerName tries to create an
opinionated container name from image name, but  in case image user also
contains periods, it doesn't sanitize it.

Add a replaceAll statement to sanitize returned imageUser.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->