### PR TITLE
`%g` should be resolved to namespace in OpenShift Maven Plugin

### DIFF
--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
@@ -78,7 +78,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
     // Filename for holding the build timestamp
     public static final String DOCKER_BUILD_TIMESTAMP = "docker/build.timestamp";
 
-    private static final String DOCKER_IMAGE_USER = "docker.image.user";
+    private static final String DOCKER_IMAGE_USER = "jkube.image.user";
     /**
      * The generated kubernetes and openshift manifests
      */
@@ -89,7 +89,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
     private MavenFileFilter mavenFileFilter;
 
     @Component
-    private ImageConfigResolver imageConfigResolver;
+    protected ImageConfigResolver imageConfigResolver;
 
     /**
      * Folder where to find project specific files
@@ -118,7 +118,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
 
     // Skip resource descriptors validation
     @Parameter(property = "jkube.skipResourceValidation", defaultValue = "false")
-    private Boolean skipResourceValidation;
+    protected Boolean skipResourceValidation;
 
     // Determine if the plugin should stop when a validation error is encountered
     @Parameter(property = "jkube.failOnValidationError", defaultValue = "false")
@@ -126,7 +126,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
 
     // Reusing image configuration from d-m-p
     @Parameter
-    private List<ImageConfiguration> images;
+    protected List<ImageConfiguration> images;
 
     /**
      * Profile to use. A profile contains the enrichers and generators to
@@ -158,7 +158,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
     private boolean useReplicaSet = true;
 
     // The image configuration after resolving and customization
-    private List<ImageConfiguration> resolvedImages;
+    protected List<ImageConfiguration> resolvedImages;
 
     // Mapping for kind filenames
     @Parameter
@@ -168,7 +168,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
      * Namespace to use when accessing Kubernetes or OpenShift
      */
     @Parameter(property = "jkube.namespace")
-    private String namespace;
+    protected String namespace;
 
     @Parameter(property = "jkube.skip.resource", defaultValue = "false")
     protected boolean skipResource;
@@ -188,7 +188,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
     private Boolean interpolateTemplateParameters;
 
     @Component
-    private MavenProjectHelper projectHelper;
+    protected MavenProjectHelper projectHelper;
 
     // resourceDir when environment has been applied
     private File realResourceDir;

--- a/openshift-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenShiftResourceMojoTest.java
+++ b/openshift-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenShiftResourceMojoTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.maven.plugin.mojo.build;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.settings.Settings;
+import org.eclipse.jkube.kit.build.service.docker.config.handler.ImageConfigResolver;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class OpenShiftResourceMojoTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Mocked
+  private MavenProject mockedMavenProject;
+
+  @Mocked
+  private MavenSession mockedMavenSession;
+
+  @Mocked
+  private Settings mockedSettings;
+
+  @Mocked
+  private JKubeServiceHub mockedJKubeServiceHub;
+
+  @Mocked
+  private ClusterAccess mockedClusterAccess;
+
+  @Mocked
+  private KitLogger mockedLogger;
+
+  @Mocked
+  private MavenProjectHelper mockedMavenProjectHelper;
+
+  @Mocked
+  private ImageConfigResolver mockedImageConfigResolver;
+
+  private OpenshiftResourceMojo openShiftResourceMojo;
+
+  @Before
+  public void setUp() throws IOException {
+    this.openShiftResourceMojo = new OpenshiftResourceMojo();
+    this.openShiftResourceMojo.jkubeServiceHub = mockedJKubeServiceHub;
+    this.openShiftResourceMojo.project = mockedMavenProject;
+    this.openShiftResourceMojo.session = mockedMavenSession;
+    this.openShiftResourceMojo.clusterAccess = mockedClusterAccess;
+    this.openShiftResourceMojo.settings = mockedSettings;
+    this.openShiftResourceMojo.log = mockedLogger;
+    this.openShiftResourceMojo.skipResourceValidation = true;
+    this.openShiftResourceMojo.projectHelper = mockedMavenProjectHelper;
+    this.openShiftResourceMojo.imageConfigResolver = mockedImageConfigResolver;
+    File buildDirectory = temporaryFolder.newFolder("target");
+    new Expectations() {{
+      mockedMavenProject.getArtifactId();
+      result = "test-project";
+
+      mockedMavenProject.getGroupId();
+      result = "org.eclipse.jkube";
+
+      mockedMavenProject.getProperties();
+      result = new Properties();
+
+      mockedMavenProject.getBuild().getOutputDirectory();
+      result = buildDirectory.getAbsolutePath();
+
+      mockedMavenProject.getBuild().getDirectory();
+      result = buildDirectory.getAbsolutePath();
+
+      mockedMavenProject.getBasedir();
+      result = temporaryFolder.getRoot();
+    }};
+  }
+
+  @Test
+  public void executeInternal_resolvesGroupInImageNameToClusterAccessNamespace_whenNamespaceDetected() throws MojoExecutionException, MojoFailureException {
+    // Given
+    ImageConfiguration imageConfiguration = ImageConfiguration.builder()
+      .name("%g/%a")
+      .build(BuildConfiguration.builder()
+        .from("test-base-image:latest")
+        .build())
+      .build();
+    new Expectations() {{
+      mockedClusterAccess.getNamespace();
+      result = "test-custom-namespace";
+
+      mockedImageConfigResolver.resolve(imageConfiguration, (JavaProject) any);
+      result = Collections.singletonList(imageConfiguration);
+    }};
+    this.openShiftResourceMojo.images = Collections.singletonList(imageConfiguration);
+
+    // When
+    openShiftResourceMojo.executeInternal();
+
+    // Then
+    assertEquals(1, openShiftResourceMojo.resolvedImages.size());
+    assertEquals("test-custom-namespace/test-project", openShiftResourceMojo.resolvedImages.get(0).getName());
+  }
+
+  @Test
+  public void executeInternal_resolvesGroupInImageNameToNamespaceSetViaConfiguration_whenNoNamespaceDetected() throws MojoExecutionException, MojoFailureException {
+    // Given
+    ImageConfiguration imageConfiguration = ImageConfiguration.builder()
+      .name("%g/%a")
+      .build(BuildConfiguration.builder()
+        .from("test-base-image:latest")
+        .build())
+      .build();
+    new Expectations() {{
+      mockedImageConfigResolver.resolve(imageConfiguration, (JavaProject) any);
+      result = Collections.singletonList(imageConfiguration);
+    }};
+    this.openShiftResourceMojo.images = Collections.singletonList(imageConfiguration);
+    this.openShiftResourceMojo.namespace = "namespace-configured-via-plugin";
+
+    // When
+    openShiftResourceMojo.executeInternal();
+
+    // Then
+    assertEquals(1, openShiftResourceMojo.resolvedImages.size());
+    assertEquals("namespace-configured-via-plugin/test-project", openShiftResourceMojo.resolvedImages.get(0).getName());
+  }
+}


### PR DESCRIPTION
## Description
Right now `%g` placeholder which corresponds to default image user picks
`jkube.image.user` property first, if not then project groupId.

Due to a typo in ResourceMojo for DOCKER_IMAGE_USER property, wrong
property was being set in mojo.

Changes regarding changing access modifiers of some fields in ResourceMojo are only done
in order to be able to have them available in OpenShiftResourceMojoTest

Relates to #904

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->