### PR TITLE
Fix #904: DeploymentConfig ImageChange trigger seems to be wrong for custom images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ### 1.5.0-SNAPSHOT
 * Fix #815: `java.lang.ClassCastException` during `oc:build` when OpenShift not present
 * Fix #716: Update Spring Boot Quickstarts to latest version
+* Fix #904: DeploymentConfig ImageChange trigger seems to be wrong for custom images
 * Fix #907: Bump JKube base images to 0.0.10
 
 ### 1.4.0 (2021-07-27)

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ImageChangeTriggerEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ImageChangeTriggerEnricher.java
@@ -95,7 +95,6 @@ public class ImageChangeTriggerEnricher extends BaseEnricher {
                                     .withNewFrom()
                                     .withKind("ImageStreamTag")
                                     .withName(image.getSimpleName() + ":" + tag)
-                                    .withNamespace(image.getUser())
                                     .endFrom()
                                     .withContainerNames(containerName)
                                     .endImageChangeParams()

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/ImageChangeTriggerEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/ImageChangeTriggerEnricherTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.enricher.generic.openshift;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.eclipse.jkube.kit.config.resource.PlatformMode;
+import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+public class ImageChangeTriggerEnricherTest {
+  @Mocked
+  private JKubeEnricherContext context;
+
+  @Test
+  public void create_shouldAddImageChangeTriggers_whenDeploymentConfigPresent() {
+    // Given
+    Properties properties = new Properties();
+    properties.put("jkube.internal.effective.platform.mode", "OPENSHIFT");
+    new Expectations() {{
+      context.getProperties();
+      result = properties;
+      context.getProcessingInstructions();
+      result = Collections.singletonMap("IMAGECHANGE_TRIGGER", "test-container");
+    }};
+    ImageChangeTriggerEnricher imageChangeTriggerEnricher = new ImageChangeTriggerEnricher(context);
+    KubernetesListBuilder kubernetesListBuilder = new KubernetesListBuilder();
+    kubernetesListBuilder.addToItems(new DeploymentConfigBuilder()
+      .withNewMetadata().withName("test-dc").endMetadata()
+      .withNewSpec()
+      .withNewTemplate()
+        .withNewSpec()
+        .addNewContainer()
+        .withName("test-container")
+        .withImage("test-user/test-container:latest")
+        .endContainer()
+        .endSpec()
+      .endTemplate()
+      .endSpec());
+
+    // When
+    imageChangeTriggerEnricher.create(PlatformMode.openshift, kubernetesListBuilder);
+
+    // Then
+    List<HasMetadata> items = kubernetesListBuilder.buildItems();
+    assertThat(items)
+      .hasSize(1)
+      .asList().element(0)
+      .extracting("spec.triggers")
+      .asList()
+      .hasSize(1)
+      .element(0)
+      .extracting("imageChangeParams")
+      .hasFieldOrPropertyWithValue("automatic", true)
+      .extracting("from")
+      .hasFieldOrPropertyWithValue("kind", "ImageStreamTag")
+      .hasFieldOrPropertyWithValue("name", "test-container:latest")
+      .hasFieldOrPropertyWithValue("namespace", null);
+
+  }
+}


### PR DESCRIPTION
## Description

Fix #904

Setting from.namespace field from image.getUser() can be problematic if
it's not equal to the namespace. If it's set to `%g`, it will work since
JKube will evaluate to current configured namespace but if user defines
image name to have a different user then ImageChangeTrigger would be
configured with a non-existent namespace.

Don't set from.namespace field for ImageChangeTrigger while adding
ImageChangeTrigger to DeploymentConfig

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->