### PR TITLE
followup #910: Correct DOCKER_IMAGE_USER property in OpenShiftResourceTask

### DIFF
--- a/gradle-plugin/it/src/it/dockerfile-simple/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/dockerfile-simple/expected/openshift.yml
@@ -58,9 +58,9 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: gradle/dockerfile-simple:latest
+          image: "@endsWith('dockerfile-simple:latest')@"
           imagePullPolicy: IfNotPresent
-          name: gradle-dockerfile-simple
+          name: "@endsWith('dockerfile-simple')@"
           ports:
           - containerPort: 9080
             name: glrpc
@@ -71,8 +71,6 @@ items:
     - type: ConfigChange
     - imageChangeParams:
         automatic: true
-        containerNames:
-        - gradle-dockerfile-simple
         from:
           kind: ImageStreamTag
           name: dockerfile-simple:latest

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -75,12 +75,8 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
     jKubeServiceHub = initJKubeServiceHubBuilder().build();
     ImageConfigResolver imageConfigResolver = new ImageConfigResolver();
     try {
-      resolvedImages = initImageConfiguration(
-          kubernetesExtension.getApiVersion().getOrNull(),
-          getBuildTimestamp(null, null, javaProject.getBuildDirectory().getAbsolutePath(), DOCKER_BUILD_TIMESTAMP),
-          javaProject, kubernetesExtension.images, imageConfigResolver, kitLogger,
-          kubernetesExtension.getFilter().getOrNull(),
-          this::customizeConfig);
+      resolvedImages = resolveImages(imageConfigResolver);
+
       enricherManager = new DefaultEnricherManager(JKubeEnricherContext.builder()
         .project(javaProject)
           .processorConfig(ProfileUtil.blendProfileWithConfiguration(ProfileUtil.ENRICHER_CONFIG,
@@ -173,5 +169,14 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
     } catch (IOException e) {
       throw new IllegalArgumentException("Cannot extract generator config: " + e, e);
     }
+  }
+
+  protected List<ImageConfiguration> resolveImages(ImageConfigResolver imageConfigResolver) throws IOException {
+    return initImageConfiguration(
+      kubernetesExtension.getApiVersion().getOrNull(),
+      getBuildTimestamp(null, null, javaProject.getBuildDirectory().getAbsolutePath(), DOCKER_BUILD_TIMESTAMP),
+      javaProject, kubernetesExtension.images, imageConfigResolver, kitLogger,
+      kubernetesExtension.getFilter().getOrNull(),
+      this::customizeConfig);
   }
 }

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
@@ -14,14 +14,18 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+import org.eclipse.jkube.kit.build.service.docker.config.handler.ImageConfigResolver;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 
 import javax.inject.Inject;
+import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
 
-public class OpenShiftResourceTask extends KubernetesResourceTask {
-  private static final String DOCKER_IMAGE_USER = "docker.image.user";
+import static org.eclipse.jkube.kit.build.service.docker.helper.ImageNameFormatter.DOCKER_IMAGE_USER;
 
+public class OpenShiftResourceTask extends KubernetesResourceTask {
   @Inject
   public OpenShiftResourceTask(Class<? extends OpenShiftExtension> extensionClass) {
     super(extensionClass);
@@ -30,7 +34,7 @@ public class OpenShiftResourceTask extends KubernetesResourceTask {
   }
 
   @Override
-  public void run() {
+  public List<ImageConfiguration> resolveImages(ImageConfigResolver imageConfigResolver) throws IOException {
     RuntimeMode runtimeMode = kubernetesExtension.getRuntimeMode();
     Properties properties = javaProject.getProperties();
     if (!properties.contains(DOCKER_IMAGE_USER)) {
@@ -41,7 +45,6 @@ public class OpenShiftResourceTask extends KubernetesResourceTask {
     if (!properties.contains(RuntimeMode.JKUBE_EFFECTIVE_PLATFORM_MODE)) {
       properties.setProperty(RuntimeMode.JKUBE_EFFECTIVE_PLATFORM_MODE, runtimeMode.toString());
     }
-
-    super.run();
+    return super.resolveImages(imageConfigResolver);
   }
 }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTaskTest.java
@@ -13,8 +13,12 @@
  */
 package org.eclipse.jkube.gradle.plugin.task;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
 import org.eclipse.jkube.gradle.plugin.TestOpenShiftExtension;
+import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
@@ -25,12 +29,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -43,6 +51,7 @@ public class OpenShiftResourceTaskTest {
 
   private MockedConstruction<DefaultTask> defaultTaskMockedConstruction;
   private Project project;
+  private TestOpenShiftExtension testOpenShiftExtension;
 
   @Before
   public void setUp() throws IOException {
@@ -51,11 +60,14 @@ public class OpenShiftResourceTaskTest {
       when(mock.getProject()).thenReturn(project);
       when(mock.getLogger()).thenReturn(mock(Logger.class));
     });
+    testOpenShiftExtension = new TestOpenShiftExtension();
+    when(project.getGroup()).thenReturn("org.eclipse.jkube.testing");
+    when(project.getName()).thenReturn("test-project");
     when(project.getProjectDir()).thenReturn(temporaryFolder.getRoot());
     when(project.getBuildDir()).thenReturn(temporaryFolder.newFolder("build"));
     when(project.getConfigurations().stream()).thenAnswer(i -> Stream.empty());
     when(project.getBuildscript().getConfigurations().stream()).thenAnswer(i -> Stream.empty());
-    when(project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(new TestOpenShiftExtension());
+    when(project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(testOpenShiftExtension);
     when(project.getConvention().getPlugin(JavaPluginConvention.class)).thenReturn(mock(JavaPluginConvention.class));
   }
 
@@ -77,5 +89,32 @@ public class OpenShiftResourceTaskTest {
       .hasContent("---\n" +
         "apiVersion: v1\n" +
         "kind: List\n");
+  }
+
+  @Test
+  public void runTask_resolvesGroupInImageNameToNamespaceSetViaConfiguration_whenNoNamespaceDetected() {
+    try (MockedStatic<KubernetesHelper> kubernetesHelper = Mockito.mockStatic(KubernetesHelper.class)) {
+      // Given
+      kubernetesHelper.when(KubernetesHelper::getDefaultNamespace).thenReturn("test-custom-namespace");
+      kubernetesHelper.when(() -> KubernetesHelper.getKind(any())).thenReturn("DeploymentConfig");
+      kubernetesHelper.when(() -> KubernetesHelper.getName((HasMetadata) any())).thenReturn("test-project");
+      ImageConfiguration imageConfiguration = ImageConfiguration.builder()
+        .name("%g/%a")
+        .build(BuildConfiguration.builder()
+          .from("test-base-image:latest")
+          .build())
+        .build();
+      testOpenShiftExtension.images = Collections.singletonList(imageConfiguration);
+      OpenShiftResourceTask resourceTask = new OpenShiftResourceTask(OpenShiftExtension.class);
+
+      // When
+      resourceTask.runTask();
+
+      // Then
+      assertThat(resourceTask.resolvedImages)
+        .hasSize(1)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "test-custom-namespace/test-project");
+    }
   }
 }


### PR DESCRIPTION
## Description
This property was wrongly named in ResourceMojo, for maven plugins
this got fixed in #910.

Fix property name in OpenShiftResourceTask as well

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->