### PR TITLE
Expose `jkube.image.user` property in ImageNameFormatter for reuse in Mojos

### DIFF
--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/helper/ImageNameFormatter.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/helper/ImageNameFormatter.java
@@ -30,6 +30,12 @@ import java.util.Map;
  */
 public class ImageNameFormatter implements ConfigHelper.NameFormatter {
 
+    /**
+     * Property to lookup for image user which overwrites the calculated default (group).
+     * Used with format modifier %g
+     */
+    public static final String DOCKER_IMAGE_USER = "jkube.image.user";
+
 
     private final FormatParameterReplacer formatParamReplacer;
 
@@ -85,12 +91,6 @@ public class ImageNameFormatter implements ConfigHelper.NameFormatter {
 
 
     private static class DefaultUserLookup extends AbstractLookup {
-
-        /**
-         * Property to lookup for image user which overwrites the calculated default (group).
-         * Used with format modifier %g
-         */
-        private static final String DOCKER_IMAGE_USER = "jkube.image.user";
 
         private DefaultUserLookup(JavaProject project) {
             super(project);

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
@@ -60,6 +60,7 @@ import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 
+import static org.eclipse.jkube.kit.build.service.docker.helper.ImageNameFormatter.DOCKER_IMAGE_USER;
 import static org.eclipse.jkube.kit.common.ResourceFileType.yaml;
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestamp;
 import static org.eclipse.jkube.kit.common.util.DekorateUtil.DEFAULT_RESOURCE_LOCATION;
@@ -78,7 +79,6 @@ public class ResourceMojo extends AbstractJKubeMojo {
     // Filename for holding the build timestamp
     public static final String DOCKER_BUILD_TIMESTAMP = "docker/build.timestamp";
 
-    private static final String DOCKER_IMAGE_USER = "jkube.image.user";
     /**
      * The generated kubernetes and openshift manifests
      */


### PR DESCRIPTION

## Description

We have `jkube.image.user` property constant defined in both
ResourceMojo and ImageNameFormatter. In feat/gradle-plugin branch it's
also used by OpenShiftResourceTask.

Expose this constant in ImageNameFormatter so that it can be reused in
Mojos and Tasks.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->