### PR TITLE
Chore: Update Spring Boot Quickstarts to use OpenShift Gradle Plugin & Don't set Offline to true

### DIFF
--- a/quickstarts/gradle/spring-boot-camel-complete/build.gradle
+++ b/quickstarts/gradle/spring-boot-camel-complete/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.5.4'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'org.eclipse.jkube.kubernetes' version '1.5.0-SNAPSHOT'
+    id 'org.eclipse.jkube.openshift' version '1.5.0-SNAPSHOT'
     id 'java'
 }
 

--- a/quickstarts/gradle/spring-boot/build.gradle
+++ b/quickstarts/gradle/spring-boot/build.gradle
@@ -48,5 +48,4 @@ kubernetes {
 
 openshift {
     useColor = true
-    offline = true
 }


### PR DESCRIPTION


## Description

Related to #903 

+ Add OpenShift Gradle Plugin to Spring Boot Camel Complete Quickstart
+ Remove offline: true statement from openshift gradle plugin
  configuration in spring boot quickstart

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->