### PR TITLE
Fix #921: Implement `oc:apply` equivalent functionality for OpenShift Gradle Plugin

### DIFF
--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
@@ -18,14 +18,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.jkube.gradle.plugin.task.KubernetesApplyTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesConfigViewTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesLogTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesResourceTask;
-
 import org.eclipse.jkube.gradle.plugin.task.KubernetesUndeployTask;
+import org.eclipse.jkube.gradle.plugin.task.OpenShiftApplyTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftBuildTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftResourceTask;
+
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 
@@ -47,7 +47,7 @@ public class OpenShiftPlugin extends AbstractJKubePlugin<OpenShiftExtension> {
     register(project, "ocConfigView", KubernetesConfigViewTask.class);
     register(project, "ocBuild", OpenShiftBuildTask.class);
     register(project, "ocResource", OpenShiftResourceTask.class);
-    register(project, "ocApply", KubernetesApplyTask.class);
+    register(project, "ocApply", OpenShiftApplyTask.class);
     register(project, "ocLog", KubernetesLogTask.class);
     register(project, "ocUndeploy", KubernetesUndeployTask.class);
   }

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftApplyTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftApplyTask.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+
+import javax.inject.Inject;
+
+public class OpenShiftApplyTask extends KubernetesApplyTask implements OpenShiftJKubeTask {
+
+  @Inject
+  public OpenShiftApplyTask(Class<? extends OpenShiftExtension> extensionClass) {
+    super(extensionClass);
+    setDescription(
+      "Task which deploys the generated artifacts into the OpenShift cluster");
+  }
+}

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginTest.java
@@ -17,9 +17,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
-import org.eclipse.jkube.gradle.plugin.task.KubernetesApplyTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesResourceTask;
 
+import org.eclipse.jkube.gradle.plugin.task.OpenShiftApplyTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftBuildTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftResourceTask;
 import org.gradle.api.Project;
@@ -54,7 +54,7 @@ public class OpenShiftPluginTest {
     verify(project.getTasks(), times(1))
         .register("ocResource", OpenShiftResourceTask.class, OpenShiftExtension.class);
     verify(project.getTasks(), times(1))
-        .register("ocApply", KubernetesApplyTask.class, OpenShiftExtension.class);
+        .register("ocApply", OpenShiftApplyTask.class, OpenShiftExtension.class);
   }
 
   @Test

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftApplyTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftApplyTaskTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.eclipse.jgit.util.FileUtils;
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+import org.eclipse.jkube.gradle.plugin.TestOpenShiftExtension;
+import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.eclipse.jkube.kit.config.service.ApplyService;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Property;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedConstruction;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OpenShiftApplyTaskTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private MockedConstruction<DefaultTask> defaultTaskMockedConstruction;
+  private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
+  private MockedConstruction<ApplyService> applyServiceMockedConstruction;
+  private Project project;
+  private boolean isOffline;
+  private boolean isFailOnUnknownKubernetesJson;
+
+  @Before
+  public void setUp() throws IOException {
+    project = mock(Project.class, RETURNS_DEEP_STUBS);
+    defaultTaskMockedConstruction = mockConstruction(DefaultTask.class, (mock, ctx) -> {
+      when(mock.getProject()).thenReturn(project);
+      when(mock.getLogger()).thenReturn(mock(Logger.class));
+    });
+    clusterAccessMockedConstruction = mockConstruction(ClusterAccess.class, (mock, ctx) -> {
+      final OpenShiftClient openShiftClient = mock(OpenShiftClient.class);
+      when(openShiftClient.getMasterUrl()).thenReturn(new URL("http://openshiftapps-com-cluster:6443"));
+      when(openShiftClient.isAdaptable(OpenShiftClient.class)).thenReturn(true);
+      when(mock.createDefaultClient()).thenReturn(openShiftClient);
+    });
+    applyServiceMockedConstruction = mockConstruction(ApplyService.class);
+    isOffline = false;
+    isFailOnUnknownKubernetesJson = false;
+    final OpenShiftExtension extension = new TestOpenShiftExtension() {
+      @Override
+      public Property<Boolean> getOffline() {
+        return new DefaultProperty<>(Boolean.class).value(isOffline);
+      }
+
+      @Override
+      public Property<Boolean> getFailOnNoKubernetesJson() {
+        return new DefaultProperty<>(Boolean.class).value(isFailOnUnknownKubernetesJson);
+      }
+    };
+    when(project.getProjectDir()).thenReturn(temporaryFolder.getRoot());
+    when(project.getBuildDir()).thenReturn(temporaryFolder.newFolder("build"));
+    when(project.getConfigurations().stream()).thenAnswer(i -> Stream.empty());
+    when(project.getBuildscript().getConfigurations().stream()).thenAnswer(i -> Stream.empty());
+    when(project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(extension);
+    when(project.getConvention().getPlugin(JavaPluginConvention.class)).thenReturn(mock(JavaPluginConvention.class));
+  }
+
+  @After
+  public void tearDown() {
+    applyServiceMockedConstruction.close();
+    clusterAccessMockedConstruction.close();
+    defaultTaskMockedConstruction.close();
+  }
+
+  @Test
+  public void runTask_withOffline_shouldThrowException() {
+    // Given
+    isOffline = true;
+    final OpenShiftApplyTask ocApplyTask = new OpenShiftApplyTask(OpenShiftExtension.class);
+
+    // When
+    final IllegalArgumentException result = assertThrows(IllegalArgumentException.class, ocApplyTask::runTask);
+
+    // Then
+    assertThat(result)
+      .hasMessage("Connection to Cluster required. Please check if offline mode is set to false");
+  }
+
+  @Test
+  public void runTask_withNoManifest_shouldThrowException() {
+    // Given
+    isFailOnUnknownKubernetesJson = true;
+    final OpenShiftApplyTask ocApplyTask = new OpenShiftApplyTask(OpenShiftExtension.class);
+    // When
+    final IllegalStateException result = assertThrows(IllegalStateException.class, ocApplyTask::runTask);
+    // Then
+    assertThat(result)
+      .hasMessageMatching("No such generated manifest file: .+openshift\\.yml");
+  }
+
+  @Test
+  public void configureApplyService_withManifest_shouldSetDefaults() throws Exception {
+    // Given
+    withOpenShiftManifest();
+    final OpenShiftApplyTask ocApplyTask = new OpenShiftApplyTask(OpenShiftExtension.class);
+    // When
+    ocApplyTask.runTask();
+    // Then
+    final ApplyService as = applyServiceMockedConstruction.constructed().iterator().next();
+    verify(as, times(1)).setAllowCreate(true);
+    verify(as, times(1)).setServicesOnlyMode(false);
+    verify(as, times(1)).setIgnoreServiceMode(false);
+    verify(as, times(1)).setLogJsonDir(any());
+    verify(as, times(1)).setBasedir(temporaryFolder.getRoot());
+    verify(as, times(1)).setSupportOAuthClients(true);
+    verify(as, times(1)).setIgnoreRunningOAuthClients(true);
+    verify(as, times(1)).setProcessTemplatesLocally(false);
+    verify(as, times(1)).setDeletePodsOnReplicationControllerUpdate(true);
+    verify(as, times(1)).setRollingUpgrade(false);
+    verify(as, times(1)).setRollingUpgradePreserveScale(false);
+    verify(as, times(1)).setRecreateMode(false);
+    verify(as, times(1)).setNamespace(null);
+    verify(as, times(1)).setFallbackNamespace(null);
+  }
+
+  @Test
+  public void runTask_withManifest_shouldApplyEntities() throws Exception {
+    // Given
+    withOpenShiftManifest();
+    final OpenShiftApplyTask ocApplyTask = new OpenShiftApplyTask(OpenShiftExtension.class);
+    // When
+    ocApplyTask.runTask();
+    // Then
+    assertThat(applyServiceMockedConstruction.constructed()).hasSize(1);
+    verify(applyServiceMockedConstruction.constructed().iterator().next(), times(1))
+      .applyEntities(any(), eq(Collections.emptyList()), any(), eq(5L));
+  }
+
+  private void withOpenShiftManifest() throws IOException {
+    final File manifestsDir = temporaryFolder.newFolder("build", "classes", "java", "main", "META-INF", "jkube");
+    FileUtils.touch(new File(manifestsDir, "openshift.yml").toPath());
+  }
+}


### PR DESCRIPTION


## Description
Fix #921
Add OpenShiftApplyTask to OpenShift Gradle Plugin which just extends
KubernetesApplyTask. There was no need to override any behavior from
KubernetesApplyTask since all configuration options are overridden in
case of OpenShiftExtension.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->