### PR TITLE
Fix #923: QuakusGenerator not applicable when using `io.quarkus.platform` groupId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Usage:
 * Fix #904: DeploymentConfig ImageChange trigger seems to be wrong for custom images
 * Fix #904: `%g` should be resolved to namespace in OpenShift Maven Plugin
 * Fix #908: OpenShift-Maven-Plugin doesn't remove periods from container name
+* Fix #923: QuakusGenerator not applicable when using `io.quarkus.platform` groupId
 
 ### 1.4.0 (2021-07-27)
 * Fix #253: Refactor JKubeServiceHub's BuildService election mechanism via ServiceLoader

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
@@ -35,6 +35,7 @@ import static org.eclipse.jkube.kit.common.util.YamlUtil.getPropertiesFromYamlRe
 public class QuarkusUtils {
 
   public static final String QUARKUS_GROUP_ID = "io.quarkus";
+  public static final String QUARKUS_PLATFORM_GROUP_ID = "io.quarkus.platform";
   private static final String QUARKUS_HTTP_PORT = "quarkus.http.port";
   private static final String QUARKUS_PACKAGE_RUNNER_SUFFIX = "quarkus.package.runner-suffix";
   private static final String QUARKUS_HTTP_ROOT_PATH = "quarkus.http.root-path";
@@ -137,6 +138,11 @@ public class QuarkusUtils {
   public static String resolveQuarkusLivenessPath(JavaProject javaProject) {
     return getQuarkusConfiguration(javaProject)
         .getProperty(QUARKUS_SMALLRYE_HEALTH_LIVENESS_PATH, DEFAULT_LIVENESS_SUBPATH);
+  }
+
+  public static boolean hasQuarkusPlugin(JavaProject javaProject) {
+    return JKubeProjectUtil.hasPlugin(javaProject, QUARKUS_GROUP_ID, "quarkus-maven-plugin") ||
+           JKubeProjectUtil.hasPlugin(javaProject, QUARKUS_PLATFORM_GROUP_ID, "quarkus-maven-plugin");
   }
 
   /**

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusGenerator.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/generator/QuarkusGenerator.java
@@ -34,10 +34,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
-import static org.eclipse.jkube.quarkus.QuarkusUtils.QUARKUS_GROUP_ID;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.extractPort;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.findSingleFileThatEndsWith;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusConfiguration;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.hasQuarkusPlugin;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.runnerSuffix;
 
 public class QuarkusGenerator extends JavaExecGenerator {
@@ -66,8 +66,7 @@ public class QuarkusGenerator extends JavaExecGenerator {
 
   @Override
   public boolean isApplicable(List<ImageConfiguration> configs) {
-    return shouldAddGeneratedImageConfiguration(configs)
-        && JKubeProjectUtil.hasPlugin(getProject(), QUARKUS_GROUP_ID, "quarkus-maven-plugin");
+    return shouldAddGeneratedImageConfiguration(configs) && hasQuarkusPlugin(getProject());
   }
 
   @Override

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
@@ -102,7 +102,7 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
-  public void isApplicable_withDependency_shouldReturnTrue() {
+  public void isApplicable_withQuarkusGroupIdPlugin_shouldReturnTrue() {
     // Given
     // @formatter:off
     new Expectations() {{
@@ -110,6 +110,23 @@ public class QuarkusGeneratorTest {
           .groupId("io.quarkus")
           .artifactId("quarkus-maven-plugin")
           .build());
+    }};
+    // @formatter:on
+    // When
+    final boolean result = new QuarkusGenerator(ctx).isApplicable(new ArrayList<>());
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void isApplicable_withQuarkusPlatformGroupIdPlugin_shouldReturnTrue() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      project.getPlugins(); result = Collections.singletonList(Plugin.builder()
+        .groupId("io.quarkus.platform")
+        .artifactId("quarkus-maven-plugin")
+        .build());
     }};
     // @formatter:on
     // When


### PR DESCRIPTION

## Description
Fix #923

QuarkusGenerator's isApplicable method should also work for
io.quarkus.platform groupId

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->