### PR TITLE
Fix #913 : make provider name configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Usage:
 * Fix #908: OpenShift-Maven-Plugin doesn't remove periods from container name
 * Fix #923: QuakusGenerator not applicable when using `io.quarkus.platform` groupId
 * Fix #895: FileUtil#createDirectory works for files with trailing separator (`/`)
+* Fix #913: Make provider name configurable
 
 ### 1.4.0 (2021-07-27)
 * Fix #253: Refactor JKubeServiceHub's BuildService election mechanism via ServiceLoader

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
@@ -66,7 +66,8 @@ public class ProjectLabelEnricher extends BaseEnricher {
     @AllArgsConstructor
     private enum Config implements Configs.Config {
       USE_PROJECT_LABEL("useProjectLabel", "false"),
-      APP("app", null);
+      APP("app", null),
+      PROVIDER("provider", "jkube");
 
         @Getter
         protected String key;
@@ -199,7 +200,7 @@ public class ProjectLabelEnricher extends BaseEnricher {
         }
 
         ret.put("group", groupArtifactVersion.getGroupId());
-        ret.put(LABEL_PROVIDER, "jkube");
+        ret.put(LABEL_PROVIDER, getConfig(Config.PROVIDER));
         if (!withoutVersion) {
             ret.put("version", groupArtifactVersion.getVersion());
         }

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_project_label.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_project_label.adoc
@@ -21,6 +21,11 @@ been replaced by the `app` label in newer versions of the plugin.
 
 Defaults to the Maven `project.artifactId` property.
 | `jkube.enricher.jkube-project-label.app`
+| *provider*
+| Makes it possible to define a custom `provider` label used in the generated resource files used for deployment.
+
+Defaults to `jkube`.
+| `jkube.enricher.jkube-project-label.provider`
 |===
 
 The project labels which are already specified in the input fragments are not overridden by the enricher.


### PR DESCRIPTION
## Description

Fix #913 : make provider name configurable


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->