### PR TITLE
fix: FileUtil#createDirectory works for files with trailing separator (`/`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Usage:
 * Fix #904: `%g` should be resolved to namespace in OpenShift Maven Plugin
 * Fix #908: OpenShift-Maven-Plugin doesn't remove periods from container name
 * Fix #923: QuakusGenerator not applicable when using `io.quarkus.platform` groupId
+* Fix #895: FileUtil#createDirectory works for files with trailing separator (`/`)
 
 ### 1.4.0 (2021-07-27)
 * Fix #253: Refactor JKubeServiceHub's BuildService election mechanism via ServiceLoader

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/FileUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/FileUtil.java
@@ -247,11 +247,9 @@ public class FileUtil {
     }
 
     public static void createDirectory(File directory) throws IOException {
+      FileUtils.forceMkdir(directory);
         if (!directory.exists()) {
-            boolean isCreated = directory.mkdirs();
-            if (!isCreated) {
-                throw new IOException("Failed to create directory: " + directory.getAbsolutePath());
-            }
+          throw new IOException("Failed to create directory: " + directory.getAbsolutePath());
         }
     }
 }

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/FileUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/FileUtilTest.java
@@ -89,6 +89,15 @@ public class FileUtilTest {
     assertTrue(newDirectory.exists());
   }
 
+  // https://github.com/eclipse/jkube/issues/895
+  @Test
+  public void createDirectory_withTrailingSlash_shouldNotFail() throws IOException {
+    final File toCreate = new File(folder.getRoot().toPath().resolve("first").resolve("second").toFile(),
+        File.separator);
+    FileUtil.createDirectory(toCreate);
+    assertTrue(toCreate.exists());
+  }
+
   @Test
   public void testListFilesRecursively() throws IOException {
     prepareDirectory();


### PR DESCRIPTION
## Description

Fix #895

FileUtil#createDirectory works for files with trailing separator (`/`)

Provided test was failing before the fix was implemented.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->