### PR TITLE
Fix #934: Add KubernetesPushTask related configuration options to KubernetesExtension

### DIFF
--- a/gradle-plugin/it/src/it/extension-configuration/build.gradle
+++ b/gradle-plugin/it/src/it/extension-configuration/build.gradle
@@ -44,6 +44,10 @@ kubernetes {
     deletePodsOnReplicationControllerUpdate = false
     jsonLogDir = file("${project.getBuildDir()}/jkube/applyJson")
     serviceUrlWaitTimeSeconds = 10
+    skipPush = true
+    skipTag = true
+    pushRegistry = 'quay.io'
+    pushRetries = 5
     access {
         namespace = 'default'
     }

--- a/gradle-plugin/it/src/it/extension-configuration/expected/expected-config.yml
+++ b/gradle-plugin/it/src/it/extension-configuration/expected/expected-config.yml
@@ -24,6 +24,10 @@ ignoreservices: false
 deletepodsonreplicationcontrollerupdate: false
 jsonlogdir: "@endsWith('extension-configuration/build/jkube/applyJson')@"
 serviceurlwaittimeseconds: 10
+skippush: true
+skiptag: true
+pushregistry: quay.io
+pushretries: 5
 access:
   namespace: "default"
 enricher:

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesExtension.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesExtension.java
@@ -193,6 +193,14 @@ public abstract class KubernetesExtension {
 
   public abstract Property<Integer> getServiceUrlWaitTimeSeconds();
 
+  public abstract Property<Boolean> getSkipPush();
+
+  public abstract Property<String> getPushRegistry();
+
+  public abstract Property<Boolean> getSkipTag();
+
+  public abstract Property<Integer> getPushRetries();
+
   public JKubeBuildStrategy buildStrategy;
 
   public abstract Property<String> getSourceDirectory();
@@ -442,5 +450,21 @@ public abstract class KubernetesExtension {
 
   public boolean getRollingUpgradePreserveScaleOrDefault() {
     return getRollingUpgradePreserveScale().getOrElse(false);
+  }
+
+  public boolean getSkipPushOrDefault() {
+    return getSkipPush().getOrElse(false);
+  }
+
+  public boolean getSkipTagOrDefault() {
+    return getSkipTag().getOrElse(false);
+  }
+
+  public Integer getPushRetriesOrDefault() {
+    return getPushRetries().getOrElse(0);
+  }
+
+  public boolean getSkipExtendedAuthOrDefault() {
+    return getSkipExtendedAuth().getOrElse(false);
   }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
@@ -272,4 +272,24 @@ public class TestKubernetesExtension extends KubernetesExtension {
   public Property<Integer> getServiceUrlWaitTimeSeconds() {
     return new DefaultProperty<>(Integer.class);
   }
+
+  @Override
+  public Property<Boolean> getSkipPush() {
+    return new DefaultProperty<>(Boolean.class);
+  }
+
+  @Override
+  public Property<String> getPushRegistry() {
+    return new DefaultProperty<>(String.class);
+  }
+
+  @Override
+  public Property<Boolean> getSkipTag() {
+    return new DefaultProperty<>(Boolean.class);
+  }
+
+  @Override
+  public Property<Integer> getPushRetries() {
+    return new DefaultProperty<>(Integer.class);
+  }
 }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/TestOpenShiftExtension.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/TestOpenShiftExtension.java
@@ -246,6 +246,26 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
   }
 
   @Override
+  public Property<Boolean> getSkipPush() {
+    return new DefaultProperty<>(Boolean.class);
+  }
+
+  @Override
+  public Property<String> getPushRegistry() {
+    return new DefaultProperty<>(String.class);
+  }
+
+  @Override
+  public Property<Boolean> getSkipTag() {
+    return new DefaultProperty<>(Boolean.class);
+  }
+
+  @Override
+  public Property<Integer> getPushRetries() {
+    return new DefaultProperty<>(Integer.class);
+  }
+
+  @Override
   public Property<String> getSourceDirectory() {
     return new DefaultProperty<>(String.class);
   }


### PR DESCRIPTION
## Description
Fix #934

Add Configuration fields required by KubernetesPushTask to KubernetesExtension

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->