### PR TITLE
Fix #939: Move KubernetesBuildTask's common initialization logic to a helper class

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/TaskUtil.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/TaskUtil.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
+import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
+import org.eclipse.jkube.kit.build.service.docker.ImagePullManager;
+import org.eclipse.jkube.kit.build.service.docker.ServiceHubFactory;
+import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
+import org.eclipse.jkube.kit.build.service.docker.access.log.LogOutputSpecFactory;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.resource.BuildRecreateMode;
+import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+
+import static org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory.DockerAccessContext.DEFAULT_MAX_CONNECTIONS;
+import static org.eclipse.jkube.kit.build.service.docker.ImagePullManager.createImagePullManager;
+
+public class TaskUtil {
+  private TaskUtil() { }
+
+  public static BuildServiceConfig.BuildServiceConfigBuilder buildServiceConfigBuilder(KubernetesExtension kubernetesExtension, JavaProject javaProject) {
+    ImagePullManager imagePullManager = createImagePullManager(
+      kubernetesExtension.getImagePullPolicy().getOrElse("Always"),
+      kubernetesExtension.getAutoPull().getOrElse("true"),
+      javaProject.getProperties());
+
+    return BuildServiceConfig.builder()
+      .imagePullManager(imagePullManager)
+      .buildRecreateMode(BuildRecreateMode.fromParameter(kubernetesExtension.getBuildRecreate().getOrElse("none")))
+      .jKubeBuildStrategy(kubernetesExtension.getBuildStrategy())
+      .forcePull(kubernetesExtension.getForcePull().getOrElse(false))
+      .buildDirectory(javaProject.getBuildDirectory().getAbsolutePath());
+  }
+
+  public static JKubeServiceHub.JKubeServiceHubBuilder addDockerServiceHubToJKubeServiceHubBuilder(JKubeServiceHub.JKubeServiceHubBuilder builder, KubernetesExtension kubernetesExtension, JavaProject javaProject, KitLogger kitLogger) {
+    DockerAccess access = null;
+    if (kubernetesExtension.isDockerAccessRequired()) {
+      DockerAccessFactory.DockerAccessContext dockerAccessContext = DockerAccessFactory.DockerAccessContext.builder()
+        .log(kitLogger)
+        .projectProperties(javaProject.getProperties())
+        .maxConnections(kubernetesExtension.getMaxConnections().getOrElse(DEFAULT_MAX_CONNECTIONS))
+        .dockerHost(kubernetesExtension.getDockerHost().getOrNull())
+        .certPath(kubernetesExtension.getCertPath().getOrNull())
+        .machine(kubernetesExtension.machine)
+        .minimalApiVersion(kubernetesExtension.getMinimalApiVersion().getOrNull())
+        .skipMachine(kubernetesExtension.getSkipMachine().getOrElse(false))
+        .build();
+      DockerAccessFactory dockerAccessFactory = new DockerAccessFactory();
+      access = dockerAccessFactory.createDockerAccess(dockerAccessContext);
+    }
+    ServiceHubFactory serviceHubFactory = new ServiceHubFactory();
+    LogOutputSpecFactory logSpecFactory = new LogOutputSpecFactory(true, true, null);
+    builder.dockerServiceHub(serviceHubFactory.createServiceHub(access, kitLogger, logSpecFactory));
+    return builder;
+  }
+}

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskUtilTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskUtilTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
+import org.eclipse.jkube.gradle.plugin.TestKubernetesExtension;
+import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
+import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
+import org.eclipse.jkube.kit.config.resource.BuildRecreateMode;
+import org.eclipse.jkube.kit.config.resource.RuntimeMode;
+import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.provider.Property;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+public class TaskUtilTest {
+  private JavaProject javaProject;
+  private KubernetesExtension extension;
+  private KitLogger kitLogger;
+
+  @Before
+  public void setUp() {
+    javaProject = mock(JavaProject.class, RETURNS_DEEP_STUBS);
+    extension = new TestKubernetesExtension();
+    kitLogger = mock(KitLogger.class, RETURNS_DEEP_STUBS);
+  }
+
+  @Test
+  public void buildServiceConfigBuilder_shouldInitializeBuildServiceConfigWithDefaults() {
+    // When
+    BuildServiceConfig buildServiceConfig = TaskUtil.buildServiceConfigBuilder(extension, javaProject).build();
+
+    // Then
+    assertThat(buildServiceConfig)
+      .hasFieldOrPropertyWithValue("buildRecreateMode", BuildRecreateMode.none)
+      .hasFieldOrPropertyWithValue("jKubeBuildStrategy", JKubeBuildStrategy.docker)
+      .hasFieldOrPropertyWithValue("forcePull", false)
+      .hasFieldOrPropertyWithValue("buildDirectory", null);
+  }
+
+  @Test
+  public void buildServiceConfigBuilder_shouldInitializeBuildServiceConfigWithConfiguredValues() {
+    // Given
+    extension = new TestKubernetesExtension() {
+      @Override
+      public Property<String> getBuildRecreate() { return new DefaultProperty<>(String.class).value("true"); }
+
+      @Override
+      public JKubeBuildStrategy getBuildStrategy() { return JKubeBuildStrategy.jib; }
+
+      @Override
+      public Property<Boolean> getForcePull() { return new DefaultProperty<>(Boolean.class).value(true); }
+    };
+    when(javaProject.getBuildDirectory().getAbsolutePath()).thenReturn("/tmp/foo");
+
+    // When
+    BuildServiceConfig buildServiceConfig = TaskUtil.buildServiceConfigBuilder(extension, javaProject).build();
+
+    // Then
+    assertThat(buildServiceConfig)
+      .hasFieldOrPropertyWithValue("buildRecreateMode", BuildRecreateMode.all)
+      .hasFieldOrPropertyWithValue("jKubeBuildStrategy", JKubeBuildStrategy.jib)
+      .hasFieldOrPropertyWithValue("forcePull", true)
+      .hasFieldOrPropertyWithValue("buildDirectory", "/tmp/foo");
+  }
+
+  @Test
+  public void addDockerServiceHubToJKubeServiceHubBuilder_shouldInitializeJKubeServiceHubWithDefaults() {
+    try (MockedConstruction<DockerAccessFactory> dockerAccessFactory = mockConstruction(DockerAccessFactory.class)) {
+      // Given
+      JKubeConfiguration jKubeConfiguration = mock(JKubeConfiguration.class, RETURNS_DEEP_STUBS);
+      JKubeServiceHub.JKubeServiceHubBuilder builder = JKubeServiceHub.builder()
+        .configuration(jKubeConfiguration)
+        .log(kitLogger)
+        .platformMode(RuntimeMode.KUBERNETES);
+
+      // When
+      JKubeServiceHub jKubeServiceHub = TaskUtil.addDockerServiceHubToJKubeServiceHubBuilder(builder, extension, javaProject, kitLogger).build();
+
+      // Then
+      assertThat(jKubeServiceHub)
+        .hasFieldOrProperty("buildServiceConfig")
+        .hasFieldOrProperty("dockerServiceHub");
+    }
+  }
+}

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftBuildTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftBuildTask.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
 import org.gradle.api.tasks.Internal;
 
@@ -42,6 +43,10 @@ public class OpenShiftBuildTask extends KubernetesBuildTask implements OpenShift
         .s2iImageStreamLookupPolicyLocal(getOpenShiftExtension().getS2iImageStreamLookupPolicyLocalOrDefault())
         .openshiftPushSecret(getOpenShiftExtension().getOpenshiftPushSecret().getOrNull())
         .resourceConfig(getOpenShiftExtension().resources)
-        .buildOutputKind(getOpenShiftExtension().getBuildOutputKindOrDefault());
+        .buildOutputKind(getOpenShiftExtension().getBuildOutputKindOrDefault())
+        .enricherTask(e -> {
+          enricherManager.enrich(PlatformMode.kubernetes, e);
+          enricherManager.enrich(PlatformMode.openshift, e);
+        });
   }
 }


### PR DESCRIPTION

## Description

Fix #939
KubernetesBuildTask's initJKubeServiceHubBuilder() and
buildServiceConfigBuilder() are same as implementation for
KubernetesPushTask.

Moving them to a helper class BuildTaskHelper in order to reuse them.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->