### PR TITLE
Fix #935: Implement `k8s:push` equivalent functionality `k8sPush` for Kubernetes Gradle Plugin

### DIFF
--- a/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
@@ -272,6 +272,11 @@ Defaults to `false`.
 | `jkube.deploy.processTemplatesLocally`
 endif::[]
 
+| *pushRegistry*
+| The registry to use when pushing the image. See <<registry,Registry Handling>> for
+more details.
+| `jkube.docker.push.registry`
+
 | *recreate*
 | Update resources by deleting them first and then creating them again.
 
@@ -281,6 +286,12 @@ Defaults to `false`.
 | *registry*
 | Specify globally a registry to use for pulling and pushing images. See <<registry,Registry handling>> for details.
 | `jkube.docker.registry`
+
+| *pushRetries*
+| How often should a push be retried before giving up. This useful for flaky registries which tend to return 500 error codes from time to time.
+
+Defaults to 0.
+| `jkube.docker.push.retries`
 
 | *resourceEnvironment*
 | Environment name where resources are placed. For example, if you set this property to dev and resourceDir is the
@@ -353,12 +364,24 @@ Defaults to `false`.
 | Skip using docker machine in any case
 | `jkube.docker.skip.machine`
 
+| *skipPush*
+| If set to true the plugin won’t push any images that have been built.
+
+Defaults to `false`.
+| `jkube.skip.push`
+
 | *skipResourceValidation*
 | If value is set to `true` then resource validation is skipped. This may be useful if resource validation is failing
 for some reason but you still want to continue the deployment.
 
   Default is `false`.
 | `jkube.skipResourceValidation`
+
+| *skipTag*
+| If set to true this plugin won’t push any tags
+
+Defaults to `false`.
+| `jkube.skip.tag`
 
 | *useProjectClassPath*
 | Should we use the project's compile time classpath to scan for additional enrichers/generators.

--- a/gradle-plugin/doc/src/main/asciidoc/inc/tasks/build/_jkube-push.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/tasks/build/_jkube-push.adoc
@@ -1,0 +1,8 @@
+[[jkube:push]]
+=== *{task-prefix}Push*
+
+This task uploads images to the registry which have a `build` configuration section. The images to push can be restricted with
+the global option `filter` (see <<build-configuration,Build Goal Configuration>> for details). The registry to push is by
+default `docker.io` but can be specified as part of the images's `name` the Docker way.
+E.g. `docker.test.org:5000/data:1.5` will push the image `data` with tag `1.5` to the registry `docker.test.org` at port
+`5000`. Registry credentials (i.e. username and password) can be specified in multiple ways as described in section <<authentication,Authentication>>.

--- a/gradle-plugin/doc/src/main/asciidoc/inc/tasks/build/_tasks.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/tasks/build/_tasks.adoc
@@ -6,3 +6,5 @@ include::_jkube-build.adoc[]
 include::_jkube-resource.adoc[]
 
 include::_jkube-apply.adoc[]
+
+include::_jkube-push.adoc[]

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SimpleIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SimpleIT.java
@@ -37,6 +37,7 @@ public class SimpleIT {
         .contains("k8sBuild - ")
         .contains("k8sLog - ")
         .contains("k8sResource - ")
+        .contains("k8sPush")
         .contains("k8sUndeploy - ")
         .contains("Openshift tasks")
         .contains("ocApply - ")

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesPlugin.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesPlugin.java
@@ -22,6 +22,7 @@ import org.eclipse.jkube.gradle.plugin.task.KubernetesApplyTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesBuildTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesConfigViewTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesLogTask;
+import org.eclipse.jkube.gradle.plugin.task.KubernetesPushTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesResourceTask;
 
 import org.eclipse.jkube.gradle.plugin.task.KubernetesUndeployTask;
@@ -38,6 +39,7 @@ public class KubernetesPlugin extends AbstractJKubePlugin<KubernetesExtension> {
   public Map<String, Collection<Class<? extends Task>>> getTaskPrecedence() {
     final Map<String, Collection<Class<? extends Task>>> ret = new HashMap<>();
     ret.put("k8sApply", Collections.singletonList(KubernetesResourceTask.class));
+    ret.put("k8sPush", Collections.singletonList(KubernetesBuildTask.class));
     return ret;
   }
 
@@ -45,6 +47,7 @@ public class KubernetesPlugin extends AbstractJKubePlugin<KubernetesExtension> {
   protected void jKubeApply(Project project) {
     register(project, "k8sConfigView", KubernetesConfigViewTask.class);
     register(project, "k8sBuild", KubernetesBuildTask.class);
+    register(project, "k8sPush", KubernetesPushTask.class);
     register(project, "k8sResource", KubernetesResourceTask.class);
     register(project, "k8sApply", KubernetesApplyTask.class);
     register(project, "k8sLog", KubernetesLogTask.class);

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
+import org.eclipse.jkube.kit.common.RegistryConfig;
+import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
+import org.eclipse.jkube.kit.config.service.JKubeServiceException;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+
+import javax.inject.Inject;
+import java.util.Collections;
+
+public class KubernetesPushTask extends AbstractJKubeTask {
+  @Inject
+  public KubernetesPushTask(Class<? extends KubernetesExtension> extensionClass) {
+    super(extensionClass);
+    setDescription("Uploads the built Docker images to a Docker registry");
+  }
+
+
+  @Override
+  protected JKubeServiceHub.JKubeServiceHubBuilder initJKubeServiceHubBuilder() {
+    return TaskUtil.addDockerServiceHubToJKubeServiceHubBuilder(super.initJKubeServiceHubBuilder(), kubernetesExtension, javaProject, kitLogger)
+      .buildServiceConfig(buildServiceConfigBuilder().build());
+  }
+
+  @Override
+  public void run() {
+    if (kubernetesExtension.getSkipPushOrDefault()) {
+      return;
+    }
+
+    try {
+      jKubeServiceHub.getBuildService().push(resolvedImages, kubernetesExtension.getPushRetriesOrDefault(), initRegistryConfig(kubernetesExtension.getPushRegistry().getOrNull()), kubernetesExtension.getSkipTagOrDefault());
+    } catch (JKubeServiceException e) {
+      throw new IllegalStateException("Error in pushing image: " + e.getMessage(), e);
+    }
+  }
+
+  private RegistryConfig initRegistryConfig(String specificRegistry) {
+    return RegistryConfig.builder()
+      .settings(Collections.emptyList())
+      .authConfig(kubernetesExtension.authConfig != null ? kubernetesExtension.authConfig.toMap() : null)
+      .skipExtendedAuth(kubernetesExtension.getSkipExtendedAuthOrDefault())
+      .registry(specificRegistry != null ? specificRegistry : kubernetesExtension.getRegistry().getOrNull())
+      .passwordDecryptionMethod(password -> password).build();
+  }
+
+  protected BuildServiceConfig.BuildServiceConfigBuilder buildServiceConfigBuilder() {
+    return TaskUtil.buildServiceConfigBuilder(kubernetesExtension, javaProject);
+  }
+}

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesPluginTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesPluginTest.java
@@ -93,7 +93,8 @@ public class KubernetesPluginTest {
     final Map<String, Collection<Class<? extends Task>>> result = new KubernetesPlugin().getTaskPrecedence();
     // Then
     assertThat(result)
-        .hasSize(1)
-        .containsEntry("k8sApply", Collections.singletonList(KubernetesResourceTask.class));
+        .hasSize(2)
+        .containsEntry("k8sApply", Collections.singletonList(KubernetesResourceTask.class))
+        .containsEntry("k8sPush", Collections.singletonList(KubernetesBuildTask.class));
   }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTaskTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
+import org.eclipse.jkube.gradle.plugin.TestKubernetesExtension;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.eclipse.jkube.kit.config.service.JKubeServiceException;
+import org.eclipse.jkube.kit.config.service.kubernetes.DockerBuildService;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class KubernetesPushTaskTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private MockedConstruction<DefaultTask> defaultTaskMockedConstruction;
+  private MockedConstruction<DockerBuildService> dockerBuildServiceMockedConstruction;
+  private List<ImageConfiguration> images;
+  private Project project;
+  private Logger logger;
+
+  @Before
+  public void setUp() throws IOException {
+    project = mock(Project.class, Mockito.RETURNS_DEEP_STUBS);
+    logger = mock(Logger.class);
+
+    defaultTaskMockedConstruction = mockConstruction(DefaultTask.class, (mock, ctx) -> {
+      when(mock.getProject()).thenReturn(project);
+      when(mock.getLogger()).thenReturn(logger);
+    });
+    dockerBuildServiceMockedConstruction = mockConstruction(DockerBuildService.class, (mock, ctx) -> {
+      when(mock.isApplicable()).thenReturn(true);
+    });
+    when(project.getConfigurations().stream()).thenAnswer(i -> Stream.empty());
+    when(project.getBuildscript().getConfigurations().stream()).thenAnswer(i -> Stream.empty());
+    when(project.getProjectDir()).thenReturn(temporaryFolder.getRoot());
+    when(project.getBuildDir()).thenReturn(temporaryFolder.newFolder("build"));
+    KubernetesExtension extension = new TestKubernetesExtension() {
+      @Override
+      public boolean isDockerAccessRequired() { return false; }
+    };
+    images = Collections.singletonList(ImageConfiguration.builder()
+      .name("foo/bar:latest")
+      .build(BuildConfiguration.builder()
+        .dockerFile("Dockerfile")
+        .build())
+      .build());
+    extension.images = images;
+    when(project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
+    when(project.getConvention().getPlugin(JavaPluginConvention.class)).thenReturn(mock(JavaPluginConvention.class));
+  }
+
+  @Test
+  public void run_withImageConfiguration_shouldPushImage() throws JKubeServiceException {
+    // Given
+    final KubernetesPushTask kubernetesPushTask = new KubernetesPushTask(KubernetesExtension.class);
+
+    // When
+    kubernetesPushTask.runTask();
+
+    // Then
+    assertThat(dockerBuildServiceMockedConstruction.constructed()).hasSize(1);
+    verify(dockerBuildServiceMockedConstruction.constructed().iterator().next(), times(1))
+      .push(eq(images), eq(0), any(), eq(false));
+  }
+
+  @After
+  public void tearDown() {
+    defaultTaskMockedConstruction.close();
+    dockerBuildServiceMockedConstruction.close();
+  }
+}


### PR DESCRIPTION
## Description

Fix #935

Kubernetes Push Task ported to gradle

~Should be ready once #941 gets merged.~

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->