### PR TITLE
Fix #945: Implement `oc:push` task equivalent OpenShiftPushTask in OpenShift Gradle Plugin

### DIFF
--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SimpleIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SimpleIT.java
@@ -44,6 +44,7 @@ public class SimpleIT {
         .contains("ocBuild - ")
         .contains("ocLog - ")
         .contains("ocResource - ")
+        .contains("ocPush")
         .contains("ocUndeploy - ");
   }
 

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
@@ -13,17 +13,19 @@
  */
 package org.eclipse.jkube.gradle.plugin;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jkube.gradle.plugin.task.KubernetesBuildTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesConfigViewTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesLogTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesResourceTask;
-import org.eclipse.jkube.gradle.plugin.task.KubernetesUndeployTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftApplyTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftBuildTask;
+import org.eclipse.jkube.gradle.plugin.task.OpenShiftPushTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftResourceTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftUndeployTask;
 
@@ -39,7 +41,8 @@ public class OpenShiftPlugin extends AbstractJKubePlugin<OpenShiftExtension> {
   @Override
   public Map<String, Collection<Class<? extends Task>>> getTaskPrecedence() {
     final Map<String, Collection<Class<? extends Task>>> ret = new HashMap<>();
-    ret.put("ocApply", Collections.singletonList(KubernetesResourceTask.class));
+    ret.put("ocApply", Arrays.asList(KubernetesResourceTask.class, OpenShiftResourceTask.class));
+    ret.put("ocPush", Arrays.asList(KubernetesBuildTask.class, OpenShiftBuildTask.class));
     return ret;
   }
 
@@ -47,6 +50,7 @@ public class OpenShiftPlugin extends AbstractJKubePlugin<OpenShiftExtension> {
   protected void jKubeApply(Project project) {
     register(project, "ocConfigView", KubernetesConfigViewTask.class);
     register(project, "ocBuild", OpenShiftBuildTask.class);
+    register(project, "ocPush", OpenShiftPushTask.class);
     register(project, "ocResource", OpenShiftResourceTask.class);
     register(project, "ocApply", OpenShiftApplyTask.class);
     register(project, "ocLog", KubernetesLogTask.class);

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftPushTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftPushTask.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+import org.gradle.api.tasks.Internal;
+
+import javax.inject.Inject;
+
+public class OpenShiftPushTask extends KubernetesPushTask {
+  @Inject
+  public OpenShiftPushTask(Class<? extends OpenShiftExtension> extensionClass) {
+    super(extensionClass);
+    setDescription(
+      "Uploads the built Docker images to a Docker registry");
+  }
+
+  @Override
+  @Internal
+  protected String getLogPrefix() {
+    return OpenShiftExtension.DEFAULT_LOG_PREFIX;
+  }
+}

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginTest.java
@@ -13,10 +13,11 @@
  */
 package org.eclipse.jkube.gradle.plugin;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
+import org.eclipse.jkube.gradle.plugin.task.KubernetesBuildTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesResourceTask;
 
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftApplyTask;
@@ -63,7 +64,8 @@ public class OpenShiftPluginTest {
     final Map<String, Collection<Class<? extends Task>>> result = new OpenShiftPlugin().getTaskPrecedence();
     // Then
     assertThat(result)
-        .hasSize(1)
-        .containsEntry("ocApply", Collections.singletonList(KubernetesResourceTask.class));
+        .hasSize(2)
+        .containsEntry("ocApply", Arrays.asList(KubernetesResourceTask.class, OpenShiftResourceTask.class))
+        .containsEntry("ocPush", Arrays.asList(KubernetesBuildTask.class, OpenShiftBuildTask.class));
   }
 }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftPushTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftPushTaskTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+import org.eclipse.jkube.gradle.plugin.TestOpenShiftExtension;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.eclipse.jkube.kit.config.service.JKubeServiceException;
+import org.eclipse.jkube.kit.config.service.kubernetes.JibBuildService;
+import org.eclipse.jkube.kit.config.service.openshift.OpenshiftBuildService;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.gradle.api.logging.Logger;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OpenShiftPushTaskTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private MockedConstruction<DefaultTask> defaultTaskMockedConstruction;
+  private List<ImageConfiguration> images;
+  private Project project;
+  private Logger logger;
+
+  @Before
+  public void setUp() throws IOException {
+    project = mock(Project.class, Mockito.RETURNS_DEEP_STUBS);
+    logger = mock(Logger.class);
+
+    defaultTaskMockedConstruction = mockConstruction(DefaultTask.class, (mock, ctx) -> {
+      when(mock.getProject()).thenReturn(project);
+      when(mock.getLogger()).thenReturn(logger);
+    });
+    when(project.getConfigurations().stream()).thenAnswer(i -> Stream.empty());
+    when(project.getBuildscript().getConfigurations().stream()).thenAnswer(i -> Stream.empty());
+    when(project.getProjectDir()).thenReturn(temporaryFolder.getRoot());
+    when(project.getBuildDir()).thenReturn(temporaryFolder.newFolder("build"));
+    OpenShiftExtension extension = new TestOpenShiftExtension();
+    images = Collections.singletonList(ImageConfiguration.builder()
+      .name("foo/bar:latest")
+      .build(BuildConfiguration.builder()
+        .dockerFile("Dockerfile")
+        .build())
+      .build());
+    extension.images = images;
+    when(project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(extension);
+    when(project.getConvention().getPlugin(JavaPluginConvention.class)).thenReturn(mock(JavaPluginConvention.class));
+  }
+
+  @Test
+  public void run_withImageConfigurationAndS2IBuildStrategy_shouldPushImage() {
+    try (MockedConstruction<OpenshiftBuildService> openshiftBuildServiceMockedConstruction = mockConstruction(OpenshiftBuildService.class,
+      (mock, ctx) -> when(mock.isApplicable()).thenReturn(true))) {
+      // Given
+      final OpenShiftPushTask openShiftPushTask = new OpenShiftPushTask(OpenShiftExtension.class);
+
+      // When
+      openShiftPushTask.runTask();
+
+      // Then
+      assertThat(openshiftBuildServiceMockedConstruction.constructed()).hasSize(1);
+    }
+  }
+
+  @Test
+  public void run_withImageConfigurationAndJIBBuildStrategy_shouldPushImage() throws JKubeServiceException {
+    try (MockedConstruction<JibBuildService> jibBuildServiceMockedConstruction = mockConstruction(JibBuildService.class,
+      (mock, ctx) -> when(mock.isApplicable()).thenReturn(true))) {
+      // Given
+      final OpenShiftPushTask openShiftPushTask = new OpenShiftPushTask(OpenShiftExtension.class);
+
+      // When
+      openShiftPushTask.runTask();
+
+      // Then
+      assertThat(jibBuildServiceMockedConstruction.constructed()).hasSize(1);
+      verify(jibBuildServiceMockedConstruction.constructed().iterator().next())
+        .push(eq(images), eq(0), any(), eq(false));
+    }
+  }
+
+  @After
+  public void tearDown() {
+    defaultTaskMockedConstruction.close();
+  }
+}


### PR DESCRIPTION
## Description

Fix #945

Port OpenShiftPushMojo to OpenShift Gradle Plugin

Requires #941 and #942 to get merged first.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->