### PR TITLE
GradleUtil.extractProperty should also extract System Properties

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jkube.kit.common.Dependency;
 import org.eclipse.jkube.kit.common.JavaProject;
@@ -82,11 +83,12 @@ public class GradleUtil {
   }
 
   private static Properties extractProperties(Project gradleProject) {
-    return gradleProject.getProperties().entrySet().stream().filter(e -> Objects.nonNull(e.getValue()))
-        .reduce(new Properties(), (acc, e) -> {
-          acc.put(e.getKey(), e.getValue());
-          return acc;
-        }, (acc, e) -> acc);
+    return Stream.concat(gradleProject.getProperties().entrySet().stream(), System.getProperties().entrySet().stream())
+      .filter(e -> Objects.nonNull(e.getValue()))
+      .reduce(new Properties(), (acc, e) -> {
+        acc.put(e.getKey(), e.getValue());
+        return acc;
+      }, (acc, e) -> acc);
   }
 
   private static List<Dependency> extractDependencies(Project gradleProject) {
@@ -132,5 +134,4 @@ public class GradleUtil {
         .filter(File::exists)
         .findFirst().orElse(null);
   }
-
 }


### PR DESCRIPTION
## Description
While testing #944, I noticed that Gradle project.getProperties() don't
contain System Properties which are passed to JVM. So some property
passed like like won't work:
```
gradle -Djkube.offline=true ocApply
```

Modify GradleUtil.extractProperty to include System.getProperties() as
well while converting Gradle Project to JavaProject

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->