### PR TITLE
Fix #952: KubernetesExtension and OpenShiftExtension field values can be configured with properties

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -15,8 +15,6 @@ package org.eclipse.jkube.gradle.plugin.task;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +76,7 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
       enricherManager = new DefaultEnricherManager(JKubeEnricherContext.builder()
           .project(kubernetesExtension.javaProject)
           .processorConfig(ProfileUtil.blendProfileWithConfiguration(ProfileUtil.ENRICHER_CONFIG,
-              kubernetesExtension.getProfileOrDefault(),
+              kubernetesExtension.getProfileOrNull(),
               resolveResourceSourceDirectory(),
               kubernetesExtension.enricher))
         .images(resolvedImages)
@@ -155,13 +153,13 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
 
   protected final File resolveResourceSourceDirectory() {
     return ResourceUtil.getFinalResourceDir(kubernetesExtension.getResourceSourceDirectoryOrDefault(),
-        kubernetesExtension.getResourceEnvironmentOrDefault());
+        kubernetesExtension.getResourceEnvironmentOrNull());
   }
 
 
   protected ProcessorConfig extractGeneratorConfig() {
     try {
-      return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.GENERATOR_CONFIG, kubernetesExtension.getProfileOrDefault(), kubernetesExtension.getResourceTargetDirectoryOrDefault(), kubernetesExtension.generator);
+      return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.GENERATOR_CONFIG, kubernetesExtension.getProfileOrNull(), kubernetesExtension.getResourceTargetDirectoryOrDefault(), kubernetesExtension.generator);
     } catch (IOException e) {
       throw new IllegalArgumentException("Cannot extract generator config: " + e, e);
     }
@@ -169,7 +167,7 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
 
   protected List<ImageConfiguration> resolveImages(ImageConfigResolver imageConfigResolver) throws IOException {
     return initImageConfiguration(
-      kubernetesExtension.getApiVersionOrDefault(),
+        kubernetesExtension.getApiVersionOrNull(),
         getBuildTimestamp(null, null, kubernetesExtension.javaProject.getBuildDirectory().getAbsolutePath(),
             DOCKER_BUILD_TIMESTAMP),
         kubernetesExtension.javaProject, kubernetesExtension.images, imageConfigResolver, kitLogger,

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
@@ -97,7 +97,7 @@ public class KubernetesApplyTask extends AbstractJKubeTask {
     applyService.setRollingUpgrade(kubernetesExtension.getRollingUpgradesOrDefault());
     applyService.setRollingUpgradePreserveScale(kubernetesExtension.getRollingUpgradePreserveScaleOrDefault());
     applyService.setRecreateMode(kubernetesExtension.getRecreateOrDefault());
-    applyService.setNamespace(kubernetesExtension.getNamespace().getOrNull());
+    applyService.setNamespace(kubernetesExtension.getNamespaceOrDefault());
     applyService.setFallbackNamespace(
       Optional.ofNullable(kubernetesExtension.resources)
         .map(ResourceConfig::getNamespace).orElse(clusterAccess.getNamespace()));

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
@@ -97,7 +97,7 @@ public class KubernetesApplyTask extends AbstractJKubeTask {
     applyService.setRollingUpgrade(kubernetesExtension.getRollingUpgradesOrDefault());
     applyService.setRollingUpgradePreserveScale(kubernetesExtension.getRollingUpgradePreserveScaleOrDefault());
     applyService.setRecreateMode(kubernetesExtension.getRecreateOrDefault());
-    applyService.setNamespace(kubernetesExtension.getNamespaceOrDefault());
+    applyService.setNamespace(kubernetesExtension.getNamespaceOrNull());
     applyService.setFallbackNamespace(
       Optional.ofNullable(kubernetesExtension.resources)
         .map(ResourceConfig::getNamespace).orElse(clusterAccess.getNamespace()));

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTask.java
@@ -41,7 +41,7 @@ public class KubernetesLogTask extends AbstractJKubeTask {
 
       new PodLogService(podLogServiceContextBuilder().build()).tailAppPodsLogs(
         kubernetes,
-        kubernetesExtension.getNamespaceOrDefault(),
+          kubernetesExtension.getNamespaceOrNull(),
         entities,
         false,
         null,
@@ -56,10 +56,10 @@ public class KubernetesLogTask extends AbstractJKubeTask {
 
   protected PodLogService.PodLogServiceContext.PodLogServiceContextBuilder podLogServiceContextBuilder() {
     return PodLogService.PodLogServiceContext.builder()
-      .log(kitLogger)
-      .logContainerName(kubernetesExtension.getLogContainerNameOrDefault())
-      .podName(kubernetesExtension.getLogPodNameOrDefault())
-      .newPodLog(createLogger("[NEW]"))
-      .oldPodLog(createLogger("[OLD]"));
+        .log(kitLogger)
+        .logContainerName(kubernetesExtension.getLogContainerNameOrNull())
+        .podName(kubernetesExtension.getLogPodNameOrNull())
+        .newPodLog(createLogger("[NEW]"))
+        .oldPodLog(createLogger("[OLD]"));
   }
 }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTask.java
@@ -41,7 +41,7 @@ public class KubernetesLogTask extends AbstractJKubeTask {
 
       new PodLogService(podLogServiceContextBuilder().build()).tailAppPodsLogs(
         kubernetes,
-        kubernetesExtension.getNamespace().getOrNull(),
+        kubernetesExtension.getNamespaceOrDefault(),
         entities,
         false,
         null,
@@ -57,8 +57,8 @@ public class KubernetesLogTask extends AbstractJKubeTask {
   protected PodLogService.PodLogServiceContext.PodLogServiceContextBuilder podLogServiceContextBuilder() {
     return PodLogService.PodLogServiceContext.builder()
       .log(kitLogger)
-      .logContainerName(kubernetesExtension.getLogContainerName().getOrNull())
-      .podName(kubernetesExtension.getLogPodName().getOrNull())
+      .logContainerName(kubernetesExtension.getLogContainerNameOrDefault())
+      .podName(kubernetesExtension.getLogPodNameOrDefault())
       .newPodLog(createLogger("[NEW]"))
       .oldPodLog(createLogger("[OLD]"));
   }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTask.java
@@ -48,8 +48,8 @@ public class KubernetesResourceTask extends AbstractJKubeTask {
   protected JKubeServiceHub.JKubeServiceHubBuilder initJKubeServiceHubBuilder() {
     JKubeServiceHub.JKubeServiceHubBuilder builder = super.initJKubeServiceHubBuilder();
     ResourceConfig resourceConfig = kubernetesExtension.resources;
-    if (kubernetesExtension.getNamespaceOrDefault() != null) {
-      resourceConfig = ResourceConfig.toBuilder(resourceConfig).namespace(kubernetesExtension.getNamespaceOrDefault()).build();
+    if (kubernetesExtension.getNamespaceOrNull() != null) {
+      resourceConfig = ResourceConfig.toBuilder(resourceConfig).namespace(kubernetesExtension.getNamespaceOrNull()).build();
     }
     final ResourceServiceConfig resourceServiceConfig = ResourceServiceConfig.builder()
         .project(kubernetesExtension.javaProject)

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
@@ -36,12 +36,13 @@ public class KubernetesUndeployTask extends AbstractJKubeTask {
   public void run() {
     try {
       ResourceConfig resources = ResourceConfig.toBuilder(kubernetesExtension.resources)
-        .namespace(Optional.ofNullable(kubernetesExtension.getNamespaceOrDefault())
+          .namespace(Optional.ofNullable(kubernetesExtension.getNamespaceOrNull())
           .map(String::trim)
           .filter(s -> !s.isEmpty())
           .orElse(null))
         .build();
-      final File environmentResourceDir = ResourceUtil.getFinalResourceDir(resolveResourceSourceDirectory(), kubernetesExtension.getResourceEnvironmentOrDefault());
+      final File environmentResourceDir = ResourceUtil.getFinalResourceDir(resolveResourceSourceDirectory(),
+          kubernetesExtension.getResourceEnvironmentOrNull());
       final String fallbackNamespace = Optional.ofNullable(kubernetesExtension.resources)
         .map(ResourceConfig::getNamespace).orElse(clusterAccess.getNamespace());
       jKubeServiceHub.getUndeployService()

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
@@ -36,12 +36,12 @@ public class KubernetesUndeployTask extends AbstractJKubeTask {
   public void run() {
     try {
       ResourceConfig resources = ResourceConfig.toBuilder(kubernetesExtension.resources)
-        .namespace(Optional.ofNullable(kubernetesExtension.getNamespace().getOrNull())
+        .namespace(Optional.ofNullable(kubernetesExtension.getNamespaceOrDefault())
           .map(String::trim)
           .filter(s -> !s.isEmpty())
           .orElse(null))
         .build();
-      final File environmentResourceDir = ResourceUtil.getFinalResourceDir(resolveResourceSourceDirectory(), kubernetesExtension.getResourceEnvironment().getOrNull());
+      final File environmentResourceDir = ResourceUtil.getFinalResourceDir(resolveResourceSourceDirectory(), kubernetesExtension.getResourceEnvironmentOrDefault());
       final String fallbackNamespace = Optional.ofNullable(kubernetesExtension.resources)
         .map(ResourceConfig::getNamespace).orElse(clusterAccess.getNamespace());
       jKubeServiceHub.getUndeployService()

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/TaskUtil.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/TaskUtil.java
@@ -34,8 +34,8 @@ public class TaskUtil {
       KubernetesExtension kubernetesExtension) {
 
     final ImagePullManager imagePullManager = createImagePullManager(
-        kubernetesExtension.getImagePullPolicyOrDefault(),
-        kubernetesExtension.getAutoPullOrDefault(),
+        kubernetesExtension.getImagePullPolicyOrNull(),
+        kubernetesExtension.getAutoPullOrNull(),
         kubernetesExtension.javaProject.getProperties());
     return BuildServiceConfig.builder()
         .imagePullManager(imagePullManager)
@@ -53,8 +53,8 @@ public class TaskUtil {
           .log(kitLogger)
           .projectProperties(kubernetesExtension.javaProject.getProperties())
           .maxConnections(kubernetesExtension.getMaxConnectionsOrDefault())
-          .dockerHost(kubernetesExtension.getDockerHostOrDefault())
-          .certPath(kubernetesExtension.getCertPathOrDefault())
+          .dockerHost(kubernetesExtension.getDockerHostOrNull())
+          .certPath(kubernetesExtension.getCertPathOrNull())
           .machine(kubernetesExtension.machine)
           .minimalApiVersion(kubernetesExtension.getMinimalApiVersion().getOrNull())
           .skipMachine(kubernetesExtension.getSkipMachineOrDefault())

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/TaskUtil.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/TaskUtil.java
@@ -24,7 +24,6 @@ import org.eclipse.jkube.kit.config.resource.BuildRecreateMode;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 
-import static org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory.DockerAccessContext.DEFAULT_MAX_CONNECTIONS;
 import static org.eclipse.jkube.kit.build.service.docker.ImagePullManager.createImagePullManager;
 
 public class TaskUtil {
@@ -35,14 +34,14 @@ public class TaskUtil {
       KubernetesExtension kubernetesExtension) {
 
     final ImagePullManager imagePullManager = createImagePullManager(
-        kubernetesExtension.getImagePullPolicy().getOrElse("Always"),
-        kubernetesExtension.getAutoPull().getOrElse("true"),
+        kubernetesExtension.getImagePullPolicyOrDefault(),
+        kubernetesExtension.getAutoPullOrDefault(),
         kubernetesExtension.javaProject.getProperties());
     return BuildServiceConfig.builder()
         .imagePullManager(imagePullManager)
-        .buildRecreateMode(BuildRecreateMode.fromParameter(kubernetesExtension.getBuildRecreate().getOrElse("none")))
-        .jKubeBuildStrategy(kubernetesExtension.getBuildStrategy())
-        .forcePull(kubernetesExtension.getForcePull().getOrElse(false))
+        .buildRecreateMode(BuildRecreateMode.fromParameter(kubernetesExtension.getBuildRecreateOrDefault()))
+        .jKubeBuildStrategy(kubernetesExtension.getBuildStrategyOrDefault())
+        .forcePull(kubernetesExtension.getForcePullOrDefault())
         .buildDirectory(kubernetesExtension.javaProject.getBuildDirectory().getAbsolutePath());
   }
 
@@ -53,12 +52,12 @@ public class TaskUtil {
       DockerAccessFactory.DockerAccessContext dockerAccessContext = DockerAccessFactory.DockerAccessContext.builder()
           .log(kitLogger)
           .projectProperties(kubernetesExtension.javaProject.getProperties())
-          .maxConnections(kubernetesExtension.getMaxConnections().getOrElse(DEFAULT_MAX_CONNECTIONS))
-          .dockerHost(kubernetesExtension.getDockerHost().getOrNull())
-          .certPath(kubernetesExtension.getCertPath().getOrNull())
+          .maxConnections(kubernetesExtension.getMaxConnectionsOrDefault())
+          .dockerHost(kubernetesExtension.getDockerHostOrDefault())
+          .certPath(kubernetesExtension.getCertPathOrDefault())
           .machine(kubernetesExtension.machine)
           .minimalApiVersion(kubernetesExtension.getMinimalApiVersion().getOrNull())
-          .skipMachine(kubernetesExtension.getSkipMachine().getOrElse(false))
+          .skipMachine(kubernetesExtension.getSkipMachineOrDefault())
           .build();
       DockerAccessFactory dockerAccessFactory = new DockerAccessFactory();
       access = dockerAccessFactory.createDockerAccess(dockerAccessContext);

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionPropertyTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionPropertyTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jkube.kit.common.JavaProject;
 
 import org.eclipse.jkube.kit.common.ResourceFileType;
 import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,63 +32,91 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Parameterized.class)
 public class KubernetesExtensionPropertyTest {
 
-  @Parameterized.Parameters(name = "{index} {0}, with {1}={2}, returns {3}")
+  public static File BASE = new File("");
+
+  @Parameterized.Parameters(name = "{index} {0}, returns {4}, or with property {1}={2} returns {3}")
   public static Collection<Object[]> data() {
     return Arrays.asList(
-      new Object[] { "getOfflineOrDefault", "jkube.offline", "false", false },
-      new Object[] { "getUseProjectClassPathOrDefault", "jkube.useProjectClasspath", "true", true },
-      new Object[] { "getFailOnValidationErrorOrDefault", "jkube.failOnValidationError", "false", false},
-      new Object[] { "getMergeWithDekorateOrDefault", "jkube.mergeWithDekorate", "false", false},
-      new Object[] { "getInterpolateTemplateParametersOrDefault", "jkube.interpolateTemplateParameters", "true", true},
-      new Object[] { "getSkipResourceValidationOrDefault", "jkube.skipResourceValidation", "false", false},
-      new Object[] { "getLogFollowOrDefault", "jkube.log.follow", "true", true},
-      new Object[] { "getRecreateOrDefault", "jkube.recreate", "false", false},
-      new Object[] { "getSkipApplyOrDefault", "jkube.skip.apply", "false", false},
-      new Object[] { "getFailOnNoKubernetesJsonOrDefault", "jkube.deploy.failOnNoKubernetesJson", "false",false},
-      new Object[] { "getCreateNewResourcesOrDefault", "jkube.deploy.create", "true", true},
-      new Object[] { "getServicesOnlyOrDefault", "jkube.deploy.servicesOnly", "false", false},
-      new Object[] { "getIgnoreServicesOrDefault", "jkube.deploy.ignoreServices", "false", false},
-      new Object[] { "getJsonLogDirOrDefault", "jkube.deploy.jsonLogDir", Paths.get("build", "jkube", "applyJson").toString(), Paths.get("build", "jkube", "applyJson").toFile()},
-      new Object[] { "getDeletePodsOnReplicationControllerUpdateOrDefault", "jkube.deploy.deletePods", "true", true},
-      new Object[] { "getRollingUpgradesOrDefault", "jkube.rolling", "false", false},
-      new Object[] { "getServiceUrlWaitTimeSecondsOrDefault", "jkube.serviceUrl.waitSeconds", "5", 5},
-      new Object[] { "getKubernetesManifestOrDefault", "jkube.kubernetesManifest", Paths.get("META-INF", "jkube", "kubernetes.yml").toString(), Paths.get("META-INF", "jkube", "kubernetes.yml").toFile()},
-      new Object[] { "getSkipOrDefault", "jkube.skip", "false", false},
-      new Object[] { "getIgnoreRunningOAuthClientsOrDefault", "jkube.deploy.ignoreRunningOAuthClients", "true", true},
-      new Object[] { "getProcessTemplatesLocallyOrDefault", "jkube.deploy.processTemplatesLocally", "true", true},
-      new Object[] { "getRollingUpgradePreserveScaleOrDefault", "jkube.rolling.preserveScale", "false", false},
-      new Object[] { "getSkipPushOrDefault", "jkube.skip.push", "false", false},
-      new Object[] { "getSkipTagOrDefault", "jkube.skip.tag", "false", false},
-      new Object[] { "getPushRetriesOrDefault", "jkube.docker.push.retries", "0", 0},
-      new Object[] { "getSkipExtendedAuthOrDefault", "jkube.docker.skip.extendedAuth", "false", false},
-      new Object[] { "getUseColorOrDefault", "jkube.useColor", "true", true},
-      new Object[] { "getMaxConnectionsOrDefault", "jkube.docker.maxConnections", "100", 100},
-      new Object[] { "getFilterOrDefault", "jkube.image.filter", "foo", "foo"},
-      new Object[] { "getApiVersionOrDefault", "jkube.docker.apiVersion", "1.24", "1.24"},
-      new Object[] { "getImagePullPolicyOrDefault", "jkube.docker.imagePullPolicy", "Always", "Always"},
-      new Object[] { "getAutoPullOrDefault", "jkube.docker.autoPull", "true", "true"},
-      new Object[] { "getDockerHostOrDefault", "jkube.docker.host", "unix:///var/run/docker.sock", "unix:///var/run/docker.sock"},
-      new Object[] { "getCertPathOrDefault", "jkube.docker.certPath", "~/.docker", "~/.docker"},
-      new Object[] { "getSkipMachineOrDefault", "jkube.docker.skip.machine", "false", false},
-      new Object[] { "getForcePullOrDefault", "jkube.build.forcePull", "false", false},
-      new Object[] { "getRegistryOrDefault", "jkube.docker.registry", "docker.io", "docker.io"},
-      new Object[] { "getPullRegistryOrDefault", "jkube.docker.pull.registry", "quay.io", "quay.io"},
-      new Object[] { "getBuildSourceDirectoryOrDefault", "jkube.build.source.dir", "src/main/docker", "src/main/docker"},
-      new Object[] { "getBuildOutputDirectoryOrDefault", "jkube.build.target.dir", "build/docker", "build/docker"},
-      new Object[] { "getResourceSourceDirectoryOrDefault", "jkube.resourceDir", Paths.get("src", "main", "jkube").toString(), Paths.get("src", "main", "jkube").toFile()},
-      new Object[] { "getResourceTargetDirectoryOrDefault", "jkube.targetDir", Paths.get("META-INF", "jkube").toString(), Paths.get("META-INF", "jkube").toFile()},
-      new Object[] { "getResourceEnvironmentOrDefault", "jkube.environment", "dev", "dev"},
-      new Object[] { "getWorkDirectoryOrDefault", "jkube.workDir", Paths.get("jkube").toString(), Paths.get("jkube").toFile()},
-      new Object[] { "getProfileOrDefault", "jkube.profile", "default", "default"},
-      new Object[] { "getNamespaceOrDefault", "jkube.namespace", "test", "test"},
-      new Object[] { "getBuildStrategyOrDefault", "jkube.build.strategy", "docker", JKubeBuildStrategy.docker},
-      new Object[] { "getBuildStrategyOrDefault", "jkube.build.strategy", "jib", JKubeBuildStrategy.jib},
-      new Object[] { "getResourceFileTypeOrDefault", "jkube.resourceType", "yaml", ResourceFileType.yaml},
-      new Object[] { "getResourceFileTypeOrDefault", "jkube.resourceType", "json", ResourceFileType.json},
-      new Object[] { "getBuildRecreateOrDefault", "jkube.build.recreate", "none", "none"},
-      new Object[] { "getLogPodNameOrDefault", "jkube.log.pod", "test", "test"},
-      new Object[] { "getLogContainerNameOrDefault", "jkube.log.container", "test", "test"}
-    );
+        new Object[] { "getOfflineOrDefault", "jkube.offline", "true", true, false },
+        new Object[] { "getFailOnValidationErrorOrDefault", "jkube.failOnValidationError", "true", true, false },
+        new Object[] { "getMergeWithDekorateOrDefault", "jkube.mergeWithDekorate", "true", true, false },
+        new Object[] { "getInterpolateTemplateParametersOrDefault", "jkube.interpolateTemplateParameters", "false", false,
+            true },
+        new Object[] { "getSkipResourceValidationOrDefault", "jkube.skipResourceValidation", "true", true, false },
+        new Object[] { "getLogFollowOrDefault", "jkube.log.follow", "false", false, true },
+        new Object[] { "getRecreateOrDefault", "jkube.recreate", "true", true, false },
+        new Object[] { "getSkipApplyOrDefault", "jkube.skip.apply", "true", true, false },
+        new Object[] { "getFailOnNoKubernetesJsonOrDefault", "jkube.deploy.failOnNoKubernetesJson", "true", true, false
+        },
+        new Object[] { "getCreateNewResourcesOrDefault", "jkube.deploy.create", "false", false, true },
+        new Object[] { "getServicesOnlyOrDefault", "jkube.deploy.servicesOnly", "true", true, false },
+        new Object[] { "getIgnoreServicesOrDefault", "jkube.deploy.ignoreServices", "true", true, false },
+        new Object[] { "getJsonLogDirOrDefault", "jkube.deploy.jsonLogDir",
+            Paths.get("build", "jkube", "other").toString(),
+            Paths.get("build", "jkube", "other").toFile(),
+            new File(BASE, "build").toPath().resolve(Paths.get("jkube", "applyJson")).toFile() },
+        new Object[] { "getDeletePodsOnReplicationControllerUpdateOrDefault", "jkube.deploy.deletePods", "false", false,
+            true },
+        new Object[] { "getRollingUpgradesOrDefault", "jkube.rolling", "true", true, false },
+        new Object[] { "getServiceUrlWaitTimeSecondsOrDefault", "jkube.serviceUrl.waitSeconds", "1337", 1337, 5 },
+        new Object[] { "getKubernetesManifestOrDefault", "jkube.kubernetesManifest",
+            Paths.get("META-INF", "jkube", "other.yml").toString(),
+            Paths.get("META-INF", "jkube", "other.yml").toFile(),
+            new File(BASE, "build").toPath().resolve(Paths.get("META-INF", "jkube", "kubernetes.yml")).toFile() },
+        new Object[] { "getSkipOrDefault", "jkube.skip", "true", true, false },
+        new Object[] { "getIgnoreRunningOAuthClientsOrDefault", "jkube.deploy.ignoreRunningOAuthClients", "false", false,
+            true },
+        new Object[] { "getProcessTemplatesLocallyOrDefault", "jkube.deploy.processTemplatesLocally", "false", false,
+            true },
+        new Object[] { "getRollingUpgradePreserveScaleOrDefault", "jkube.rolling.preserveScale", "true", true, false },
+        new Object[] { "getSkipPushOrDefault", "jkube.skip.push", "true", true, false },
+        new Object[] { "getSkipTagOrDefault", "jkube.skip.tag", "true", true, false },
+        new Object[] { "getPushRetriesOrDefault", "jkube.docker.push.retries", "1337", 1337, 0 },
+        new Object[] { "getSkipExtendedAuthOrDefault", "jkube.docker.skip.extendedAuth", "true", true, false },
+        new Object[] { "getBuildRecreateOrDefault", "jkube.build.recreate", "changed", "changed", "none" },
+        new Object[] { "getUseColorOrDefault", "jkube.useColor", "false", false, true },
+        new Object[] { "getMaxConnectionsOrDefault", "jkube.docker.maxConnections", "1337", 1337, 100 },
+        new Object[] { "getFilterOrNull", "jkube.image.filter", "foo", "foo", null },
+        new Object[] { "getApiVersionOrNull", "jkube.docker.apiVersion", "1.24", "1.24", null },
+        new Object[] { "getImagePullPolicyOrNull", "jkube.docker.imagePullPolicy", "Always", "Always", null },
+        new Object[] { "getAutoPullOrNull", "jkube.docker.autoPull", "true", "true", null },
+        new Object[] { "getDockerHostOrNull", "jkube.docker.host", "unix:///var/run/docker.sock",
+            "unix:///var/run/docker.sock", null },
+        new Object[] { "getCertPathOrNull", "jkube.docker.certPath", "~/.docker", "~/.docker", null },
+        new Object[] { "getSkipMachineOrDefault", "jkube.docker.skip.machine", "true", true, false },
+        new Object[] { "getForcePullOrDefault", "jkube.build.forcePull", "true", true, false },
+        new Object[] { "getRegistryOrDefault", "jkube.docker.registry", "quay.io", "quay.io", "docker.io" },
+        new Object[] { "getPullRegistryOrDefault", "jkube.docker.pull.registry", "quay.io", "quay.io", "docker.io" },
+        new Object[] { "getBuildSourceDirectoryOrDefault", "jkube.build.source.dir", "src/main/other", "src/main/other",
+            "src/main/docker" },
+        new Object[] { "getBuildOutputDirectoryOrDefault", "jkube.build.target.dir", "build/other", "build/other",
+            "build/docker" },
+        new Object[] { "getResourceSourceDirectoryOrDefault", "jkube.resourceDir",
+            Paths.get("src", "main", "other").toString(),
+            Paths.get("src", "main", "other").toFile(),
+            BASE.toPath().resolve(Paths.get("src", "main", "jkube")).toFile()
+        },
+        new Object[] { "getResourceTargetDirectoryOrDefault", "jkube.targetDir",
+            Paths.get("META-INF", "jkube", "other").toString(),
+            Paths.get("META-INF", "jkube", "other").toFile(),
+            new File(BASE, "build").toPath().resolve(Paths.get("META-INF", "jkube")).toFile()
+        },
+        new Object[] { "getResourceEnvironmentOrNull", "jkube.environment", "dev", "dev", null },
+        new Object[] { "getWorkDirectoryOrDefault", "jkube.workDir",
+            Paths.get("jkube-work-other").toString(),
+            Paths.get("jkube-work-other").toFile(),
+            new File(BASE, "build").toPath().resolve(Paths.get("jkube")).toFile() },
+        new Object[] { "getProfileOrNull", "jkube.profile", "default", "default", null },
+        new Object[] { "getNamespaceOrNull", "jkube.namespace", "test", "test", null },
+        new Object[] { "getBuildStrategyOrDefault", "jkube.build.strategy", "s2i", JKubeBuildStrategy.s2i,
+            JKubeBuildStrategy.docker },
+        new Object[] { "getBuildStrategyOrDefault", "jkube.build.strategy", "jib", JKubeBuildStrategy.jib,
+            JKubeBuildStrategy.docker },
+        new Object[] { "getResourceFileTypeOrDefault", "jkube.resourceType", "json", ResourceFileType.json,
+            ResourceFileType.yaml },
+        new Object[] { "getLogPodNameOrNull", "jkube.log.pod", "test", "test", null },
+        new Object[] { "getLogContainerNameOrNull", "jkube.log.container", "test", "test", null },
+        new Object[] { "getUseProjectClassPathOrDefault", "jkube.useProjectClasspath", "true", true, false });
   }
 
   @Parameterized.Parameter
@@ -102,15 +131,33 @@ public class KubernetesExtensionPropertyTest {
   @Parameterized.Parameter(3)
   public Object expectedValue;
 
-  @Test
-  public void test() throws Exception {
-    // Given
-    final KubernetesExtension extension = new TestKubernetesExtension();
+  @Parameterized.Parameter(4)
+  public Object expectedDefault;
+
+  private TestKubernetesExtension extension;
+
+  @Before
+  public void setUp() throws Exception {
+    extension = new TestKubernetesExtension();
     extension.javaProject = JavaProject.builder()
-      .baseDirectory(Paths.get("").toFile())
-      .buildDirectory(new File(Paths.get("").toFile(), "build"))
-      .outputDirectory(new File(Paths.get("").toFile(), "build"))
-      .build();
+        .artifactId("artifact-id")
+        .baseDirectory(BASE)
+        .buildDirectory(new File(BASE, "build"))
+        .outputDirectory(new File(BASE, "build"))
+        .build();
+  }
+
+  @Test
+  public void getValue_withDefaults_shouldReturnDefaultValue() throws Exception {
+    // When
+    final Object result = extension.getClass().getMethod(method).invoke(extension);
+    // Then
+    assertThat(result).isEqualTo(expectedDefault);
+  }
+
+  @Test
+  public void getValue_withProperty_shouldReturnFromPropertyValue() throws Exception {
+    // Given
     extension.javaProject.getProperties().setProperty(property, propertyValue);
     // When
     final Object result = extension.getClass().getMethod(method).invoke(extension);

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionPropertyTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionPropertyTest.java
@@ -13,11 +13,15 @@
  */
 package org.eclipse.jkube.gradle.plugin;
 
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.jkube.kit.common.JavaProject;
 
+import org.eclipse.jkube.kit.common.ResourceFileType;
+import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -30,8 +34,60 @@ public class KubernetesExtensionPropertyTest {
   @Parameterized.Parameters(name = "{index} {0}, with {1}={2}, returns {3}")
   public static Collection<Object[]> data() {
     return Arrays.asList(
-        new Object[] { "getOfflineOrDefault", "jkube.offline", "false", false },
-        new Object[] { "getUseProjectClassPathOrDefault", "jkube.useProjectClasspath", "true", true });
+      new Object[] { "getOfflineOrDefault", "jkube.offline", "false", false },
+      new Object[] { "getUseProjectClassPathOrDefault", "jkube.useProjectClasspath", "true", true },
+      new Object[] { "getFailOnValidationErrorOrDefault", "jkube.failOnValidationError", "false", false},
+      new Object[] { "getMergeWithDekorateOrDefault", "jkube.mergeWithDekorate", "false", false},
+      new Object[] { "getInterpolateTemplateParametersOrDefault", "jkube.interpolateTemplateParameters", "true", true},
+      new Object[] { "getSkipResourceValidationOrDefault", "jkube.skipResourceValidation", "false", false},
+      new Object[] { "getLogFollowOrDefault", "jkube.log.follow", "true", true},
+      new Object[] { "getRecreateOrDefault", "jkube.recreate", "false", false},
+      new Object[] { "getSkipApplyOrDefault", "jkube.skip.apply", "false", false},
+      new Object[] { "getFailOnNoKubernetesJsonOrDefault", "jkube.deploy.failOnNoKubernetesJson", "false",false},
+      new Object[] { "getCreateNewResourcesOrDefault", "jkube.deploy.create", "true", true},
+      new Object[] { "getServicesOnlyOrDefault", "jkube.deploy.servicesOnly", "false", false},
+      new Object[] { "getIgnoreServicesOrDefault", "jkube.deploy.ignoreServices", "false", false},
+      new Object[] { "getJsonLogDirOrDefault", "jkube.deploy.jsonLogDir", Paths.get("build", "jkube", "applyJson").toString(), Paths.get("build", "jkube", "applyJson").toFile()},
+      new Object[] { "getDeletePodsOnReplicationControllerUpdateOrDefault", "jkube.deploy.deletePods", "true", true},
+      new Object[] { "getRollingUpgradesOrDefault", "jkube.rolling", "false", false},
+      new Object[] { "getServiceUrlWaitTimeSecondsOrDefault", "jkube.serviceUrl.waitSeconds", "5", 5},
+      new Object[] { "getKubernetesManifestOrDefault", "jkube.kubernetesManifest", Paths.get("META-INF", "jkube", "kubernetes.yml").toString(), Paths.get("META-INF", "jkube", "kubernetes.yml").toFile()},
+      new Object[] { "getSkipOrDefault", "jkube.skip", "false", false},
+      new Object[] { "getIgnoreRunningOAuthClientsOrDefault", "jkube.deploy.ignoreRunningOAuthClients", "true", true},
+      new Object[] { "getProcessTemplatesLocallyOrDefault", "jkube.deploy.processTemplatesLocally", "true", true},
+      new Object[] { "getRollingUpgradePreserveScaleOrDefault", "jkube.rolling.preserveScale", "false", false},
+      new Object[] { "getSkipPushOrDefault", "jkube.skip.push", "false", false},
+      new Object[] { "getSkipTagOrDefault", "jkube.skip.tag", "false", false},
+      new Object[] { "getPushRetriesOrDefault", "jkube.docker.push.retries", "0", 0},
+      new Object[] { "getSkipExtendedAuthOrDefault", "jkube.docker.skip.extendedAuth", "false", false},
+      new Object[] { "getUseColorOrDefault", "jkube.useColor", "true", true},
+      new Object[] { "getMaxConnectionsOrDefault", "jkube.docker.maxConnections", "100", 100},
+      new Object[] { "getFilterOrDefault", "jkube.image.filter", "foo", "foo"},
+      new Object[] { "getApiVersionOrDefault", "jkube.docker.apiVersion", "1.24", "1.24"},
+      new Object[] { "getImagePullPolicyOrDefault", "jkube.docker.imagePullPolicy", "Always", "Always"},
+      new Object[] { "getAutoPullOrDefault", "jkube.docker.autoPull", "true", "true"},
+      new Object[] { "getDockerHostOrDefault", "jkube.docker.host", "unix:///var/run/docker.sock", "unix:///var/run/docker.sock"},
+      new Object[] { "getCertPathOrDefault", "jkube.docker.certPath", "~/.docker", "~/.docker"},
+      new Object[] { "getSkipMachineOrDefault", "jkube.docker.skip.machine", "false", false},
+      new Object[] { "getForcePullOrDefault", "jkube.build.forcePull", "false", false},
+      new Object[] { "getRegistryOrDefault", "jkube.docker.registry", "docker.io", "docker.io"},
+      new Object[] { "getPullRegistryOrDefault", "jkube.docker.pull.registry", "quay.io", "quay.io"},
+      new Object[] { "getBuildSourceDirectoryOrDefault", "jkube.build.source.dir", "src/main/docker", "src/main/docker"},
+      new Object[] { "getBuildOutputDirectoryOrDefault", "jkube.build.target.dir", "build/docker", "build/docker"},
+      new Object[] { "getResourceSourceDirectoryOrDefault", "jkube.resourceDir", Paths.get("src", "main", "jkube").toString(), Paths.get("src", "main", "jkube").toFile()},
+      new Object[] { "getResourceTargetDirectoryOrDefault", "jkube.targetDir", Paths.get("META-INF", "jkube").toString(), Paths.get("META-INF", "jkube").toFile()},
+      new Object[] { "getResourceEnvironmentOrDefault", "jkube.environment", "dev", "dev"},
+      new Object[] { "getWorkDirectoryOrDefault", "jkube.workDir", Paths.get("jkube").toString(), Paths.get("jkube").toFile()},
+      new Object[] { "getProfileOrDefault", "jkube.profile", "default", "default"},
+      new Object[] { "getNamespaceOrDefault", "jkube.namespace", "test", "test"},
+      new Object[] { "getBuildStrategyOrDefault", "jkube.build.strategy", "docker", JKubeBuildStrategy.docker},
+      new Object[] { "getBuildStrategyOrDefault", "jkube.build.strategy", "jib", JKubeBuildStrategy.jib},
+      new Object[] { "getResourceFileTypeOrDefault", "jkube.resourceType", "yaml", ResourceFileType.yaml},
+      new Object[] { "getResourceFileTypeOrDefault", "jkube.resourceType", "json", ResourceFileType.json},
+      new Object[] { "getBuildRecreateOrDefault", "jkube.build.recreate", "none", "none"},
+      new Object[] { "getLogPodNameOrDefault", "jkube.log.pod", "test", "test"},
+      new Object[] { "getLogContainerNameOrDefault", "jkube.log.container", "test", "test"}
+    );
   }
 
   @Parameterized.Parameter
@@ -50,7 +106,11 @@ public class KubernetesExtensionPropertyTest {
   public void test() throws Exception {
     // Given
     final KubernetesExtension extension = new TestKubernetesExtension();
-    extension.javaProject = JavaProject.builder().build();
+    extension.javaProject = JavaProject.builder()
+      .baseDirectory(Paths.get("").toFile())
+      .buildDirectory(new File(Paths.get("").toFile(), "build"))
+      .outputDirectory(new File(Paths.get("").toFile(), "build"))
+      .build();
     extension.javaProject.getProperties().setProperty(property, propertyValue);
     // When
     final Object result = extension.getClass().getMethod(method).invoke(extension);

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.gradle.plugin;
 import java.util.Collections;
 
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 
 import groovy.lang.Closure;
@@ -37,6 +38,13 @@ public class KubernetesExtensionTest {
     final RuntimeMode result = partial.getRuntimeMode();
     // Then
     assertThat(result).isEqualTo(RuntimeMode.KUBERNETES);
+  }
+
+  @Test
+  public void getBuildStrategy_withDefaults_shouldReturnDocker() {
+    assertThat(new TestKubernetesExtension())
+        .extracting(TestKubernetesExtension::getBuildStrategyOrDefault)
+        .isEqualTo(JKubeBuildStrategy.docker);
   }
 
   @Test

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
@@ -15,17 +15,30 @@ package org.eclipse.jkube.gradle.plugin;
 
 import java.io.File;
 
+import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.provider.Property;
 
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
 public class TestKubernetesExtension extends KubernetesExtension {
+
+  public Boolean isOffline;
+  public String buildRecreate;
+  public Boolean isForcePull;
+  public Boolean isFailOnNoKubernetesJson;
+
+  public TestKubernetesExtension() {
+    javaProject = mock(JavaProject.class, RETURNS_DEEP_STUBS);
+  }
 
   @Override
   public Property<Boolean> getOffline() {
-    return new DefaultProperty<>(Boolean.class).value(true);
+    return new DefaultProperty<>(Boolean.class).value(isOffline);
   }
 
   @Override
@@ -50,7 +63,7 @@ public class TestKubernetesExtension extends KubernetesExtension {
 
   @Override
   public Property<String> getBuildRecreate() {
-    return new DefaultProperty<>(String.class);
+    return new DefaultProperty<>(String.class).value(buildRecreate);
   }
 
   @Override
@@ -85,7 +98,7 @@ public class TestKubernetesExtension extends KubernetesExtension {
 
   @Override
   public Property<Boolean> getForcePull() {
-    return new DefaultProperty<>(Boolean.class);
+    return new DefaultProperty<>(Boolean.class).value(isForcePull);
   }
 
   @Override
@@ -245,7 +258,7 @@ public class TestKubernetesExtension extends KubernetesExtension {
 
   @Override
   public Property<Boolean> getFailOnNoKubernetesJson() {
-    return new DefaultProperty<>(Boolean.class);
+    return new DefaultProperty<>(Boolean.class).value(isFailOnNoKubernetesJson);
   }
 
   @Override

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesConfigViewTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesConfigViewTaskTest.java
@@ -33,7 +33,7 @@ public class KubernetesConfigViewTaskTest {
   @Rule
   public TaskEnvironment taskEnvironment = new TaskEnvironment();
 
-  private KubernetesExtension extension;
+  private TestKubernetesExtension extension;
 
   @Before
   public void setUp() throws IOException {
@@ -42,10 +42,10 @@ public class KubernetesConfigViewTaskTest {
   }
 
   @Test
-  public void runTask_withImplementationPending_shouldThrowException() {
+  public void runTask_withManualSettings_shouldLogThem() {
     // Given
     extension.buildStrategy = JKubeBuildStrategy.s2i;
-    extension.getOffline().set(true);
+    extension.isOffline = true;
     final KubernetesConfigViewTask configViewTask = new KubernetesConfigViewTask(KubernetesExtension.class);
     // When
     configViewTask.runTask();

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTaskTest.java
@@ -24,8 +24,6 @@ import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.kubernetes.KubernetesUndeployService;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.gradle.api.internal.provider.DefaultProperty;
-import org.gradle.api.provider.Property;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,7 +47,7 @@ public class KubernetesUndeployTaskTest {
 
   private MockedConstruction<KubernetesUndeployService> kubernetesUndeployServiceMockedConstruction;
   private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
-  private boolean isOffline;
+  private TestKubernetesExtension extension;
 
   @Before
   public void setUp() throws IOException {
@@ -59,13 +57,7 @@ public class KubernetesUndeployTaskTest {
       when(kubernetesClient.getMasterUrl()).thenReturn(new URL("http://kubernetes-cluster"));
     });
     kubernetesUndeployServiceMockedConstruction = mockConstruction(KubernetesUndeployService.class);
-    isOffline = false;
-    final KubernetesExtension extension = new TestKubernetesExtension() {
-      @Override
-      public Property<Boolean> getOffline() {
-        return new DefaultProperty<>(Boolean.class).value(isOffline);
-      }
-    };
+    extension = new TestKubernetesExtension();
     when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
   }
 
@@ -78,7 +70,7 @@ public class KubernetesUndeployTaskTest {
   @Test
   public void runTask_withOffline_shouldThrowException() {
     // Given
-    isOffline = true;
+    extension.isOffline = true;
     final KubernetesUndeployTask undeployTask = new KubernetesUndeployTask(KubernetesExtension.class);
 
     // When

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskUtilTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskUtilTest.java
@@ -37,13 +37,12 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
 public class TaskUtilTest {
-  private KubernetesExtension extension;
+  private TestKubernetesExtension extension;
   private KitLogger kitLogger;
 
   @Before
   public void setUp() {
     extension = new TestKubernetesExtension();
-    extension.javaProject = mock(JavaProject.class, RETURNS_DEEP_STUBS);
     kitLogger = mock(KitLogger.class, RETURNS_DEEP_STUBS);
   }
 
@@ -63,17 +62,10 @@ public class TaskUtilTest {
   @Test
   public void buildServiceConfigBuilder_shouldInitializeBuildServiceConfigWithConfiguredValues() {
     // Given
-    extension = new TestKubernetesExtension() {
-      @Override
-      public Property<String> getBuildRecreate() { return new DefaultProperty<>(String.class).value("true"); }
-
-      @Override
-      public JKubeBuildStrategy getBuildStrategy() { return JKubeBuildStrategy.jib; }
-
-      @Override
-      public Property<Boolean> getForcePull() { return new DefaultProperty<>(Boolean.class).value(true); }
-    };
-    extension.javaProject = mock(JavaProject.class, RETURNS_DEEP_STUBS);
+    extension = new TestKubernetesExtension();
+    extension.buildRecreate = "true";
+    extension.isForcePull = true;
+    extension.buildStrategy = JKubeBuildStrategy.jib;
     when(extension.javaProject.getBuildDirectory().getAbsolutePath()).thenReturn("/tmp/foo");
 
     // When

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftExtension.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftExtension.java
@@ -55,6 +55,11 @@ public abstract class OpenShiftExtension extends KubernetesExtension {
   }
 
   @Override
+  public boolean isDockerAccessRequired() {
+    return false;
+  }
+
+  @Override
   public PlatformMode getPlatformMode() {
     return PlatformMode.openshift;
   }
@@ -73,13 +78,9 @@ public abstract class OpenShiftExtension extends KubernetesExtension {
   }
 
   @Override
-  public JKubeBuildStrategy getBuildStrategy() {
-    return buildStrategy != null ? buildStrategy : JKubeBuildStrategy.s2i;
-  }
-
-  @Override
-  public boolean isDockerAccessRequired() {
-    return false;
+  public JKubeBuildStrategy getBuildStrategyOrDefault() {
+    return getProperty("jkube.build.strategy", JKubeBuildStrategy::valueOf)
+        .orElse(buildStrategy != null ? buildStrategy : JKubeBuildStrategy.s2i);
   }
 
   public String getOpenshiftPullSecretOrDefault() {

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftExtension.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftExtension.java
@@ -83,24 +83,24 @@ public abstract class OpenShiftExtension extends KubernetesExtension {
   }
 
   public String getOpenshiftPullSecretOrDefault() {
-    return getOpenshiftPullSecret().getOrElse(DEFAULT_OPENSHIFT_PULLSECRET);
+    return getOrDefaultString("jkube.build.pullSecret", this::getOpenshiftPullSecret, DEFAULT_OPENSHIFT_PULLSECRET);
   }
 
   public String getS2iBuildNameSuffixOrDefault() {
-    return getS2iBuildNameSuffix().getOrElse(DEFAULT_S2I_BUILDNAME_SUFFIX);
+    return getOrDefaultString("jkube.s2i.buildNameSuffix", this::getS2iBuildNameSuffix, DEFAULT_S2I_BUILDNAME_SUFFIX);
   }
 
   public boolean getS2iImageStreamLookupPolicyLocalOrDefault() {
-    return getS2iImageStreamLookupPolicyLocal().getOrElse(true);
+    return getOrDefaultBoolean("jkube.s2i.imageStreamLookupPolicyLocal", this::getS2iImageStreamLookupPolicyLocal, true);
   }
 
   public String getBuildOutputKindOrDefault() {
-    return getBuildOutputKind().getOrElse(DEFAULT_BUILD_OUTPUT_KIND);
+    return getOrDefaultString("jkube.build.buildOutput.kind", this::getBuildOutputKind, DEFAULT_BUILD_OUTPUT_KIND);
   }
 
   @Override
   public boolean getProcessTemplatesLocallyOrDefault() {
-    return getProcessTemplatesLocally().getOrElse(false);
+    return getOrDefaultBoolean("jkube.deploy.processTemplatesLocally", this::getProcessTemplatesLocally, false);
   }
 
   @Override
@@ -109,12 +109,10 @@ public abstract class OpenShiftExtension extends KubernetesExtension {
   }
 
   public File getOpenShiftManifestOrDefault() {
-    return getOpenShiftManifest()
-        .getOrElse(javaProject.getOutputDirectory().toPath().resolve(DEFAULT_OPENSHIFT_MANIFEST).toFile());
+    return getOrDefaultFile("jkube.openshiftManifest", this::getOpenShiftManifest, javaProject.getOutputDirectory().toPath().resolve(DEFAULT_OPENSHIFT_MANIFEST).toFile());
   }
 
   public File getImageStreamManifestOrDefault() {
-    return getImageStreamManifest().getOrElse(
-        javaProject.getBuildDirectory().toPath().resolve(Paths.get(javaProject.getArtifactId() + "-is.yml")).toFile());
+    return getOrDefaultFile("jkube.openshiftImageStreamManifest", this::getImageStreamManifest, javaProject.getBuildDirectory().toPath().resolve(Paths.get(javaProject.getArtifactId() + "-is.yml")).toFile());
   }
 }

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
@@ -39,7 +39,7 @@ public class OpenShiftResourceTask extends KubernetesResourceTask {
     RuntimeMode runtimeMode = kubernetesExtension.getRuntimeMode();
     final Properties properties = kubernetesExtension.javaProject.getProperties();
     if (!properties.contains(DOCKER_IMAGE_USER)) {
-      String namespaceToBeUsed = Optional.ofNullable(kubernetesExtension.getNamespaceOrDefault()).orElse(clusterAccess.getNamespace());
+      String namespaceToBeUsed = Optional.ofNullable(kubernetesExtension.getNamespaceOrNull()).orElse(clusterAccess.getNamespace());
       kitLogger.info("Using docker image name of namespace: " + namespaceToBeUsed);
       properties.setProperty(DOCKER_IMAGE_USER, namespaceToBeUsed);
     }

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
@@ -21,6 +21,7 @@ import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.eclipse.jkube.kit.build.service.docker.helper.ImageNameFormatter.DOCKER_IMAGE_USER;
@@ -38,7 +39,7 @@ public class OpenShiftResourceTask extends KubernetesResourceTask {
     RuntimeMode runtimeMode = kubernetesExtension.getRuntimeMode();
     final Properties properties = kubernetesExtension.javaProject.getProperties();
     if (!properties.contains(DOCKER_IMAGE_USER)) {
-      String namespaceToBeUsed = kubernetesExtension.getNamespace().getOrElse(clusterAccess.getNamespace());
+      String namespaceToBeUsed = Optional.ofNullable(kubernetesExtension.getNamespaceOrDefault()).orElse(clusterAccess.getNamespace());
       kitLogger.info("Using docker image name of namespace: " + namespaceToBeUsed);
       properties.setProperty(DOCKER_IMAGE_USER, namespaceToBeUsed);
     }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftExtensionPropertyTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftExtensionPropertyTest.java
@@ -14,7 +14,12 @@
 package org.eclipse.jkube.gradle.plugin;
 
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -27,15 +32,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class OpenShiftExtensionPropertyTest {
-  @Parameterized.Parameters(name = "{index} {0}, with {1}={2}, returns {3}")
+
+  public static File BASE = new File("");
+
+  @Parameterized.Parameters(name = "{index} {0}, returns {4}, or with property {1}={2} returns {3}")
   public static Collection<Object[]> data() {
     return Arrays.asList(
-      new Object[] { "getOpenshiftPullSecretOrDefault", "jkube.build.pullSecret", "pullsecret-jkube", "pullsecret-jkube" },
-      new Object[] { "getS2iBuildNameSuffixOrDefault", "jkube.s2i.buildNameSuffix", "-s2i", "-s2i"},
-      new Object[] { "getS2iImageStreamLookupPolicyLocalOrDefault", "jkube.s2i.imageStreamLookupPolicyLocal", "true", true},
-      new Object[] { "getProcessTemplatesLocallyOrDefault", "jkube.deploy.processTemplatesLocally", "false", false},
-      new Object[] { "getOpenShiftManifestOrDefault", "jkube.openshiftManifest", Paths.get("META-INF", "jkube", "openshift.yml").toString(), Paths.get("META-INF", "jkube", "openshift.yml").toFile()},
-      new Object[] { "getImageStreamManifestOrDefault", "jkube.openshiftImageStreamManifest", Paths.get("test-project-is.yml").toString(), Paths.get("test-project-is.yml").toFile()}
+        new Object[] { "getBuildStrategyOrDefault", "jkube.build.strategy", "jib", JKubeBuildStrategy.jib,
+            JKubeBuildStrategy.s2i },
+        new Object[] { "getBuildStrategyOrDefault", "jkube.build.strategy", "docker", JKubeBuildStrategy.docker,
+            JKubeBuildStrategy.s2i },
+        new Object[] { "getOpenshiftPullSecretOrDefault", "jkube.build.pullSecret", "pullsecret-other", "pullsecret-other",
+            "pullsecret-jkube" },
+        new Object[] { "getS2iBuildNameSuffixOrDefault", "jkube.s2i.buildNameSuffix", "-other", "-other", "-s2i" },
+        new Object[] { "getS2iImageStreamLookupPolicyLocalOrDefault", "jkube.s2i.imageStreamLookupPolicyLocal", "false",
+            false, true },
+        new Object[] { "getBuildOutputKindOrDefault", "jkube.build.buildOutput.kind", "DockerImage", "DockerImage",
+            "ImageStreamTag" },
+        new Object[] { "getProcessTemplatesLocallyOrDefault", "jkube.deploy.processTemplatesLocally", "true", true, false },
+        new Object[] { "getOpenShiftManifestOrDefault", "jkube.openshiftManifest",
+            Paths.get("META-INF", "jkube", "other.yml").toString(),
+            Paths.get("META-INF", "jkube", "other.yml").toFile(),
+            new File(BASE, "build").toPath().resolve(Paths.get("META-INF", "jkube", "openshift.yml")).toFile() },
+        new Object[] { "getImageStreamManifestOrDefault", "jkube.openshiftImageStreamManifest",
+            Paths.get("test-project-is.yml").toString(),
+            Paths.get("test-project-is.yml").toFile(),
+            new File(BASE, "build").toPath().resolve("artifact-id-is.yml").toFile()
+        }
     );
   }
 
@@ -51,16 +74,33 @@ public class OpenShiftExtensionPropertyTest {
   @Parameterized.Parameter(3)
   public Object expectedValue;
 
-  @Test
-  public void test() throws Exception {
-    // Given
-    final OpenShiftExtension extension = new TestOpenShiftExtension();
+  @Parameterized.Parameter(4)
+  public Object expectedDefault;
+
+  private TestOpenShiftExtension extension;
+
+  @Before
+  public void setUp() {
+    extension = new TestOpenShiftExtension();
     extension.javaProject = JavaProject.builder()
-      .artifactId("test-project")
-      .baseDirectory(Paths.get("").toFile())
-      .buildDirectory(new File(Paths.get("").toFile(), "build"))
-      .outputDirectory(new File(Paths.get("").toFile(), "build"))
-      .build();
+        .artifactId("artifact-id")
+        .baseDirectory(BASE)
+        .buildDirectory(new File(BASE, "build"))
+        .outputDirectory(new File(BASE, "build"))
+        .build();
+  }
+
+  @Test
+  public void getValue_withDefaults_shouldReturnDefaultValue() throws Exception {
+    // When
+    final Object result = extension.getClass().getMethod(method).invoke(extension);
+    // Then
+    assertThat(result).isEqualTo(expectedDefault);
+  }
+
+  @Test
+  public void getValue_withProperty_shouldReturnFromPropertyValue() throws Exception {
+    // Given
     extension.javaProject.getProperties().setProperty(property, propertyValue);
     // When
     final Object result = extension.getClass().getMethod(method).invoke(extension);

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftExtensionPropertyTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftExtensionPropertyTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin;
+
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class OpenShiftExtensionPropertyTest {
+  @Parameterized.Parameters(name = "{index} {0}, with {1}={2}, returns {3}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+      new Object[] { "getOpenshiftPullSecretOrDefault", "jkube.build.pullSecret", "pullsecret-jkube", "pullsecret-jkube" },
+      new Object[] { "getS2iBuildNameSuffixOrDefault", "jkube.s2i.buildNameSuffix", "-s2i", "-s2i"},
+      new Object[] { "getS2iImageStreamLookupPolicyLocalOrDefault", "jkube.s2i.imageStreamLookupPolicyLocal", "true", true},
+      new Object[] { "getProcessTemplatesLocallyOrDefault", "jkube.deploy.processTemplatesLocally", "false", false},
+      new Object[] { "getOpenShiftManifestOrDefault", "jkube.openshiftManifest", Paths.get("META-INF", "jkube", "openshift.yml").toString(), Paths.get("META-INF", "jkube", "openshift.yml").toFile()},
+      new Object[] { "getImageStreamManifestOrDefault", "jkube.openshiftImageStreamManifest", Paths.get("test-project-is.yml").toString(), Paths.get("test-project-is.yml").toFile()}
+    );
+  }
+
+  @Parameterized.Parameter
+  public String method;
+
+  @Parameterized.Parameter(1)
+  public String property;
+
+  @Parameterized.Parameter(2)
+  public String propertyValue;
+
+  @Parameterized.Parameter(3)
+  public Object expectedValue;
+
+  @Test
+  public void test() throws Exception {
+    // Given
+    final OpenShiftExtension extension = new TestOpenShiftExtension();
+    extension.javaProject = JavaProject.builder()
+      .artifactId("test-project")
+      .baseDirectory(Paths.get("").toFile())
+      .buildDirectory(new File(Paths.get("").toFile(), "build"))
+      .outputDirectory(new File(Paths.get("").toFile(), "build"))
+      .build();
+    extension.javaProject.getProperties().setProperty(property, propertyValue);
+    // When
+    final Object result = extension.getClass().getMethod(method).invoke(extension);
+    // Then
+    assertThat(result).isEqualTo(expectedValue);
+  }
+}

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/TestOpenShiftExtension.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/TestOpenShiftExtension.java
@@ -15,14 +15,28 @@ package org.eclipse.jkube.gradle.plugin;
 
 import java.io.File;
 
+import org.eclipse.jkube.kit.common.JavaProject;
 import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.provider.Property;
 
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
 public class TestOpenShiftExtension extends OpenShiftExtension {
+
+  public Boolean isOffline;
+  public String buildRecreate;
+  public Boolean isForcePull;
+  public Boolean isFailOnNoKubernetesJson;
+  public Boolean isSkipPush;
+
+  public TestOpenShiftExtension() {
+    javaProject = mock(JavaProject.class, RETURNS_DEEP_STUBS);
+  }
 
   @Override
   public Property<Boolean> getOffline() {
-    return new DefaultProperty<>(Boolean.class).value(true);
+    return new DefaultProperty<>(Boolean.class).value(isOffline);
   }
 
   @Override
@@ -47,7 +61,7 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
 
   @Override
   public Property<String> getBuildRecreate() {
-    return new DefaultProperty<>(String.class);
+    return new DefaultProperty<>(String.class).value(buildRecreate);
   }
 
   @Override
@@ -82,7 +96,7 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
 
   @Override
   public Property<Boolean> getForcePull() {
-    return new DefaultProperty<>(Boolean.class);
+    return new DefaultProperty<>(Boolean.class).value(isForcePull);
   }
 
   @Override
@@ -108,6 +122,16 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
   @Override
   public Property<String> getRegistry() {
     return new DefaultProperty<>(String.class);
+  }
+
+  @Override
+  public Property<Boolean> getProcessTemplatesLocally() {
+    return new DefaultProperty<>(Boolean.class);
+  }
+
+  @Override
+  public Property<Boolean> getIgnoreRunningOAuthClients() {
+    return new DefaultProperty<>(Boolean.class);
   }
 
   @Override
@@ -191,6 +215,16 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
   }
 
   @Override
+  public Property<String> getSourceDirectory() {
+    return new DefaultProperty<>(String.class);
+  }
+
+  @Override
+  public Property<String> getOutputDirectory() {
+    return new DefaultProperty<>(String.class);
+  }
+
+  @Override
   public Property<Boolean> getRecreate() {
     return new DefaultProperty<>(Boolean.class);
   }
@@ -217,7 +251,7 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
 
   @Override
   public Property<Boolean> getFailOnNoKubernetesJson() {
-    return new DefaultProperty<>(Boolean.class);
+    return new DefaultProperty<>(Boolean.class).value(isFailOnNoKubernetesJson);
   }
 
   @Override
@@ -247,7 +281,7 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
 
   @Override
   public Property<Boolean> getSkipPush() {
-    return new DefaultProperty<>(Boolean.class);
+    return new DefaultProperty<>(Boolean.class).value(isSkipPush);
   }
 
   @Override
@@ -263,16 +297,6 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
   @Override
   public Property<Integer> getPushRetries() {
     return new DefaultProperty<>(Integer.class);
-  }
-
-  @Override
-  public Property<String> getSourceDirectory() {
-    return new DefaultProperty<>(String.class);
-  }
-
-  @Override
-  public Property<String> getOutputDirectory() {
-    return new DefaultProperty<>(String.class);
   }
 
   @Override
@@ -308,15 +332,5 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
   @Override
   public Property<File> getImageStreamManifest() {
     return new DefaultProperty<>(File.class);
-  }
-
-  @Override
-  public Property<Boolean> getProcessTemplatesLocally() {
-    return new DefaultProperty<>(Boolean.class);
-  }
-
-  @Override
-  public Property<Boolean> getIgnoreRunningOAuthClients() {
-    return new DefaultProperty<>(Boolean.class);
   }
 }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftApplyTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftApplyTaskTest.java
@@ -25,8 +25,6 @@ import org.eclipse.jkube.kit.config.service.ApplyService;
 
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.eclipse.jgit.util.FileUtils;
-import org.gradle.api.internal.provider.DefaultProperty;
-import org.gradle.api.provider.Property;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -50,8 +48,7 @@ public class OpenShiftApplyTaskTest {
 
   private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
   private MockedConstruction<ApplyService> applyServiceMockedConstruction;
-  private boolean isOffline;
-  private boolean isFailOnUnknownKubernetesJson;
+  private TestOpenShiftExtension extension;
 
   @Before
   public void setUp() {
@@ -62,20 +59,9 @@ public class OpenShiftApplyTaskTest {
       when(mock.createDefaultClient()).thenReturn(openShiftClient);
     });
     applyServiceMockedConstruction = mockConstruction(ApplyService.class);
-    isOffline = false;
-    isFailOnUnknownKubernetesJson = false;
-    final OpenShiftExtension extension = new TestOpenShiftExtension() {
-      @Override
-      public Property<Boolean> getOffline() {
-        return new DefaultProperty<>(Boolean.class).value(isOffline);
-      }
-
-      @Override
-      public Property<Boolean> getFailOnNoKubernetesJson() {
-        return new DefaultProperty<>(Boolean.class).value(isFailOnUnknownKubernetesJson);
-      }
-    };
+    extension = new TestOpenShiftExtension();
     when(taskEnvironment.project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(extension);
+    extension.isFailOnNoKubernetesJson = false;
   }
 
   @After
@@ -87,7 +73,7 @@ public class OpenShiftApplyTaskTest {
   @Test
   public void runTask_withOffline_shouldThrowException() {
     // Given
-    isOffline = true;
+    extension.isOffline = true;
     final OpenShiftApplyTask ocApplyTask = new OpenShiftApplyTask(OpenShiftExtension.class);
 
     // When
@@ -101,7 +87,7 @@ public class OpenShiftApplyTaskTest {
   @Test
   public void runTask_withNoManifest_shouldThrowException() {
     // Given
-    isFailOnUnknownKubernetesJson = true;
+    extension.isFailOnNoKubernetesJson = true;
     final OpenShiftApplyTask ocApplyTask = new OpenShiftApplyTask(OpenShiftExtension.class);
     // When
     final IllegalStateException result = assertThrows(IllegalStateException.class, ocApplyTask::runTask);

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftPushTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftPushTaskTest.java
@@ -22,8 +22,6 @@ import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.service.JKubeServiceException;
 import org.eclipse.jkube.kit.config.service.openshift.OpenshiftBuildService;
 
-import org.gradle.api.internal.provider.DefaultProperty;
-import org.gradle.api.provider.Property;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -43,19 +41,13 @@ public class OpenShiftPushTaskTest {
   public TaskEnvironment taskEnvironment = new TaskEnvironment();
 
   private MockedConstruction<OpenshiftBuildService> openshiftBuildServiceMockedConstruction;
-  private boolean isSkipPush;
-  private OpenShiftExtension extension;
+  private TestOpenShiftExtension extension;
 
   @Before
   public void setUp() {
     openshiftBuildServiceMockedConstruction = mockConstruction(OpenshiftBuildService.class,
         (mock, ctx) -> when(mock.isApplicable()).thenReturn(true));
-    extension = new TestOpenShiftExtension() {
-      @Override
-      public Property<Boolean> getSkipPush() {
-        return new DefaultProperty<>(Boolean.class).value(isSkipPush);
-      }
-    };
+    extension = new TestOpenShiftExtension();
     when(taskEnvironment.project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(extension);
     extension.images = Collections.singletonList(ImageConfiguration.builder()
       .name("foo/bar:latest")
@@ -85,7 +77,7 @@ public class OpenShiftPushTaskTest {
   @Test
   public void run_withSkipPush_shouldNotPushImage() {
     // Given
-    isSkipPush = true;
+    extension.isSkipPush = true;
     final OpenShiftPushTask openShiftPushTask = new OpenShiftPushTask(OpenShiftExtension.class);
     // When
     openShiftPushTask.runTask();

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftUndeployTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftUndeployTaskTest.java
@@ -14,9 +14,7 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Paths;
-import java.util.stream.Stream;
 
 import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
 import org.eclipse.jkube.gradle.plugin.TestOpenShiftExtension;
@@ -25,24 +23,16 @@ import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.openshift.OpenshiftUndeployService;
 
 import io.fabric8.openshift.client.OpenShiftClient;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.Project;
-import org.gradle.api.internal.provider.DefaultProperty;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.provider.Property;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.mockito.MockedConstruction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.times;
@@ -56,7 +46,7 @@ public class OpenShiftUndeployTaskTest {
 
   private MockedConstruction<OpenshiftUndeployService> openshiftUndeployServiceMockedConstruction;
   private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
-  private boolean isOffline;
+  private TestOpenShiftExtension extension;
 
   @Before
   public void setUp() {
@@ -66,13 +56,7 @@ public class OpenShiftUndeployTaskTest {
       when(openShiftClient.isAdaptable(OpenShiftClient.class)).thenReturn(true);
     });
     openshiftUndeployServiceMockedConstruction = mockConstruction(OpenshiftUndeployService.class);
-    isOffline = false;
-    final OpenShiftExtension extension = new TestOpenShiftExtension() {
-      @Override
-      public Property<Boolean> getOffline() {
-        return new DefaultProperty<>(Boolean.class).value(isOffline);
-      }
-    };
+    extension = new TestOpenShiftExtension();
     when(taskEnvironment.project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(extension);
     when(taskEnvironment.project.getName()).thenReturn("test-project");
   }
@@ -86,7 +70,7 @@ public class OpenShiftUndeployTaskTest {
   @Test
   public void runTask_withOffline_shouldThrowException() {
     // Given
-    isOffline = true;
+    extension.isOffline = true;
     final OpenShiftUndeployTask undeployTask = new OpenShiftUndeployTask(OpenShiftExtension.class);
 
     // When


### PR DESCRIPTION
## Description
Fix #952

KubernetesExtension and OpenShiftExtension can be configured via
properties.

Added property resolution logic inside KubernetesExtension and
OpenShiftExtension

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->