### PR TITLE
fix: Gradle dependencies completely resolved with versions

### DIFF
--- a/gradle-plugin/it/src/it/extension-configuration/build.gradle
+++ b/gradle-plugin/it/src/it/extension-configuration/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'org.eclipse.jkube.kubernetes' version "${jKubeVersion}"
     id 'org.eclipse.jkube.openshift' version "${jKubeVersion}"
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
 
@@ -11,10 +10,6 @@ sourceCompatibility = '11'
 
 repositories {
     mavenCentral()
-}
-
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 kubernetes {

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SimpleIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SimpleIT.java
@@ -36,15 +36,15 @@ public class SimpleIT {
         .contains("k8sApply - ")
         .contains("k8sBuild - ")
         .contains("k8sLog - ")
+        .contains("k8sPush - ")
         .contains("k8sResource - ")
-        .contains("k8sPush")
         .contains("k8sUndeploy - ")
         .contains("Openshift tasks")
         .contains("ocApply - ")
         .contains("ocBuild - ")
         .contains("ocLog - ")
+        .contains("ocPush - ")
         .contains("ocResource - ")
-        .contains("ocPush")
         .contains("ocUndeploy - ");
   }
 

--- a/quickstarts/gradle/spring-boot/build.gradle
+++ b/quickstarts/gradle/spring-boot/build.gradle
@@ -16,6 +16,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly(gradleApi())
 }
 
 kubernetes {

--- a/quickstarts/gradle/spring-boot/gradle/wrapper/gradle-wrapper.properties
+++ b/quickstarts/gradle/spring-boot/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description
fix: Gradle dependencies completely resolved with versions

Allows Enrichers (like SpringBoot Health Check) to work since
they rely on transitive dependencies with versions.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->