### PR TITLE
making private variables as final

### DIFF
--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/log/LogOutputSpec.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/log/LogOutputSpec.java
@@ -41,10 +41,10 @@ public class LogOutputSpec {
     private final boolean useColor;
     private final boolean logStdout;
     private final boolean fgBright;
-    private String prefix;
-    private Ansi.Color color;
-    private DateTimeFormatter timeFormatter;
-    private String file;
+    private final String prefix;
+    private final Ansi.Color color;
+    private final DateTimeFormatter timeFormatter;
+    private final String file;
 
     // Palette used for prefixing the log output
     private static final Ansi.Color[] COLOR_PALETTE = {


### PR DESCRIPTION
## Description
Fix #972 , have made variables final as these were modified only in constructor

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
