### PR TITLE
chore: bump asciidoctorj from 2.1.0 to 2.2.0 and asciidoctor-maven-plugin from 1.6.0 to 2.2.1 to enable doc watch on all files

### DIFF
--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctorj</artifactId>
-        <version>${version.asciidoctor-maven-plugin}</version>
+        <version>${version.asciidoctorj}</version>
       </dependency>
 
       <dependency>

--- a/jkube-kit/doc/pom.xml
+++ b/jkube-kit/doc/pom.xml
@@ -89,43 +89,6 @@
       <activation><activeByDefault>true</activeByDefault></activation>
     </profile>
 
-    <!-- ==== PDF documentation ====================== -->
-
-    <profile>
-      <id>pdf</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.asciidoctor</groupId>
-            <artifactId>asciidoctor-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>output-pdf</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>process-asciidoc</goal>
-                </goals>
-                <configuration>
-                  <backend>pdf</backend>
-                  <sourceHighlighter>rouge</sourceHighlighter>
-                  <attributes>
-                    <toc/>
-                    <imagesdir>${project.build.directory}/generated-docs/images</imagesdir>
-                  </attributes>
-                </configuration>
-              </execution>
-            </executions>
-            <dependencies>
-              <dependency>
-                <groupId>org.asciidoctor</groupId>
-                <artifactId>asciidoctorj-pdf</artifactId>
-                <version>1.5.0-alpha.11</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
 </project>

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -34,8 +34,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.asciidoctor-maven-plugin>1.5.5</version.asciidoctor-maven-plugin>
-    <version.asciidoctorj>1.5.4</version.asciidoctorj>
     <version.bouncycastle.bcpkix>1.61</version.bouncycastle.bcpkix>
     <version.commons-codec>1.15</version.commons-codec>
     <version.commons-compress>1.21</version.commons-compress>

--- a/kubernetes-maven-plugin/doc/pom.xml
+++ b/kubernetes-maven-plugin/doc/pom.xml
@@ -121,7 +121,7 @@
             <dependency>
               <groupId>org.asciidoctor</groupId>
               <artifactId>asciidoctorj</artifactId>
-              <version>${asciidoctorj.version}</version>
+              <version>${version.asciidoctorj}</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/kubernetes-maven-plugin/doc/pom.xml
+++ b/kubernetes-maven-plugin/doc/pom.xml
@@ -95,6 +95,7 @@
           <configuration>
             <sourceDirectory>src/main/asciidoc</sourceDirectory>
             <outputDirectory>${outputHtmlDirectory}</outputDirectory>
+            <refreshOn>.*</refreshOn>
             <attributes>
               <icons>font</icons>
               <pagenums/>
@@ -108,11 +109,6 @@
               <goal-prefix>${goal-prefix}</goal-prefix>
               <cluster>${cluster}</cluster>
             </attributes>
-            <logHandler>
-              <failIf>
-                <severity>DEBUG</severity>
-              </failIf>
-            </logHandler>
             <sourceHighlighter>coderay</sourceHighlighter>
             <backend>html</backend>
           </configuration>
@@ -121,6 +117,11 @@
               <groupId>org.eclipse.jkube</groupId>
               <artifactId>kubernetes-maven-plugin-doc</artifactId>
               <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.asciidoctor</groupId>
+              <artifactId>asciidoctorj</artifactId>
+              <version>${asciidoctorj.version}</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
   <properties>
     <jdk.version>1.8</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.asciidoctor-maven-plugin>1.6.0</version.asciidoctor-maven-plugin>
-    <version.asciidoctorj>2.1.0</version.asciidoctorj>
+    <version.asciidoctor-maven-plugin>2.2.1</version.asciidoctor-maven-plugin>
+    <version.asciidoctorj>2.2.0</version.asciidoctorj>
     <version.citrus-core>2.6.2</version.citrus-core>
     <version.commons-io>2.8.0</version.commons-io>
     <version.gradle>6.1.1</version.gradle>
@@ -211,11 +211,6 @@
               <idseparator>-</idseparator>
               <allow-uri-read>true</allow-uri-read>
             </attributes>
-            <logHandler>
-              <failIf>
-                <severity>DEBUG</severity>
-              </failIf>
-            </logHandler>
           </configuration>
           <dependencies>
             <dependency>


### PR DESCRIPTION
## Description

### CQs
 - [x] org.asciidoctor:asciidoctor-maven-plugin:2.2.1 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23791
 - [x] org.asciidoctor:asciidoctorj:2.2.0 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23792
 - [x] org.asciidoctor:asciidoctorj-diagram:2.2.0 https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23793

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->