### PR TITLE
Fix #951: Implement `oc:debug` equivalent `ocDebug` task in OpenShift Gradle Plugin

### DIFF
--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
@@ -26,6 +26,7 @@ import org.eclipse.jkube.gradle.plugin.task.KubernetesLogTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesResourceTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftApplyTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftBuildTask;
+import org.eclipse.jkube.gradle.plugin.task.OpenShiftDebugTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftPushTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftResourceTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftUndeployTask;
@@ -54,7 +55,7 @@ public class OpenShiftPlugin extends AbstractJKubePlugin<OpenShiftExtension> {
     register(project, "ocApply", OpenShiftApplyTask.class);
     register(project, "ocBuild", OpenShiftBuildTask.class);
     register(project, "ocConfigView", KubernetesConfigViewTask.class);
-    register(project, "ocDebug", KubernetesDebugTask.class);
+    register(project, "ocDebug", OpenShiftDebugTask.class);
     register(project, "ocLog", KubernetesLogTask.class);
     register(project, "ocPush", OpenShiftPushTask.class);
     register(project, "ocResource", OpenShiftResourceTask.class);

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftDebugTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftDebugTask.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+
+import javax.inject.Inject;
+
+public class OpenShiftDebugTask extends KubernetesDebugTask implements OpenShiftJKubeTask {
+  @Inject
+  public OpenShiftDebugTask(Class<? extends OpenShiftExtension> extensionClass) {
+    super(extensionClass);
+    setDescription(
+      "Ensures that the current app has debug enabled, then opens the debug port so that you can debug the latest pod from your IDE");
+  }
+}

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginRegisterTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginRegisterTaskTest.java
@@ -17,10 +17,10 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.jkube.gradle.plugin.task.KubernetesConfigViewTask;
-import org.eclipse.jkube.gradle.plugin.task.KubernetesDebugTask;
 import org.eclipse.jkube.gradle.plugin.task.KubernetesLogTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftApplyTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftBuildTask;
+import org.eclipse.jkube.gradle.plugin.task.OpenShiftDebugTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftPushTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftResourceTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftUndeployTask;
@@ -46,7 +46,7 @@ public class OpenShiftPluginRegisterTaskTest {
         new Object[] { "ocApply", OpenShiftApplyTask.class },
         new Object[] { "ocBuild", OpenShiftBuildTask.class },
         new Object[] { "ocConfigView", KubernetesConfigViewTask.class },
-        new Object[] { "ocDebug", KubernetesDebugTask.class },
+        new Object[] { "ocDebug", OpenShiftDebugTask.class },
         new Object[] { "ocLog", KubernetesLogTask.class },
         new Object[] { "ocPush", OpenShiftPushTask.class },
         new Object[] { "ocResource", OpenShiftResourceTask.class },

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftDebugTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftDebugTaskTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.GradleLogger;
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+import org.eclipse.jkube.gradle.plugin.TestOpenShiftExtension;
+import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
+import org.eclipse.jkube.kit.config.service.DebugService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OpenShiftDebugTaskTest {
+
+  @Rule
+  public TaskEnvironment taskEnvironment = new TaskEnvironment();
+
+  private MockedConstruction<DebugService> debugServiceMockedConstruction;
+  private TestOpenShiftExtension extension;
+  private MockedStatic<OpenshiftHelper> openShiftHelperMockedStatic;
+
+  @Before
+  public void setUp() {
+    debugServiceMockedConstruction = mockConstruction(DebugService.class);
+    extension = new TestOpenShiftExtension();
+    when(taskEnvironment.project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(extension);
+    openShiftHelperMockedStatic = Mockito.mockStatic(OpenshiftHelper.class);
+    openShiftHelperMockedStatic.when(() -> OpenshiftHelper.isOpenShift(any())).thenReturn(true);
+  }
+
+  @After
+  public void tearDown() {
+    debugServiceMockedConstruction.close();
+    openShiftHelperMockedStatic.close();
+  }
+
+  @Test
+  public void runTask_withNoManifest_shouldThrowException() {
+    // Given
+    extension.isFailOnNoKubernetesJson = true;
+    final OpenShiftDebugTask debugTask = new OpenShiftDebugTask(OpenShiftExtension.class);
+    // When
+    final IllegalStateException result = assertThrows(IllegalStateException.class, debugTask::runTask);
+    // Then
+    assertThat(result)
+      .hasMessageMatching("No such generated manifest file: .+openshift\\.yml");
+  }
+
+  @Test
+  public void runTask_withManifest_shouldStartDebug() throws Exception {
+    // Given
+    taskEnvironment.withOpenShiftManifest();
+    final OpenShiftDebugTask debugTask = new OpenShiftDebugTask(OpenShiftExtension.class);
+    // When
+    debugTask.runTask();
+    // Then
+    assertThat(debugServiceMockedConstruction.constructed()).hasSize(1);
+    verify(debugServiceMockedConstruction.constructed().iterator().next(), times(1))
+      .debug(any(), eq("openshift.yml"), eq(Collections.emptyList()), eq("5005"), eq(false), any(GradleLogger.class));
+  }
+
+}

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskEnvironment.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskEnvironment.java
@@ -13,8 +13,11 @@
  */
 package org.eclipse.jkube.gradle.plugin.task;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.stream.Stream;
 
+import org.eclipse.jgit.util.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
@@ -53,5 +56,10 @@ public class TaskEnvironment extends TemporaryFolder {
   protected void after() {
     super.after();
     defaultTaskMockedConstruction.close();
+  }
+
+  public void withOpenShiftManifest() throws IOException {
+    final File manifestsDir = newFolder("build", "classes", "java", "main", "META-INF", "jkube");
+    FileUtils.touch(new File(manifestsDir, "openshift.yml").toPath());
   }
 }


### PR DESCRIPTION
## Description
Fix #951

Add `ocDebug` task to OpenShift Gradle Plugin. Ported OpenShiftDebugMojo
functinality to OpenShiftDebugTask

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->