### PR TITLE
fix: JKubeTarArchive doesn't load files in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Usage:
 * Fix #895: FileUtil#createDirectory works for files with trailing separator (`/`)
 * Fix #913: Make provider name configurable
 * Fix #877: LogMojo: Change access modifiers to protected for use in XML configuration
+* Fix : JKubeTarArchive doesn't load files in memory
 
 ### 1.4.0 (2021-07-27)
 * Fix #253: Refactor JKubeServiceHub's BuildService election mechanism via ServiceLoader

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiver.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiver.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +86,9 @@ public class JKubeTarArchiver {
         Optional.ofNullable(tarArchiveEntryCustomizer).ifPresent(tac -> tac.accept(tarEntry));
         tarArchiveOutputStream.putArchiveEntry(tarEntry);
         if (currentFile.isFile()) {
-          tarArchiveOutputStream.write(IOUtils.toByteArray(new FileInputStream(currentFile)));
+          try (InputStream fis = new FileInputStream(currentFile)) {
+            IOUtils.copy(fis, tarArchiveOutputStream);
+          }
         }
         tarArchiveOutputStream.closeArchiveEntry();
       }

--- a/quickstarts/gradle/spring-boot/build.gradle
+++ b/quickstarts/gradle/spring-boot/build.gradle
@@ -17,7 +17,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    runtimeOnly(gradleApi())
 }
 
 kubernetes {


### PR DESCRIPTION
## Description

fix: JKubeTarArchive doesn't load files in memory

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->