### PR TITLE
Fix #932: Change Working directory for CamelRouteBuilder to `/tmp`

### DIFF
--- a/quickstarts/gradle/spring-boot-camel-complete/src/main/java/org/eclipse/jkube/quickstarts/gradle/springbootcamelcomplete/CamelRouteBuilder.java
+++ b/quickstarts/gradle/spring-boot-camel-complete/src/main/java/org/eclipse/jkube/quickstarts/gradle/springbootcamelcomplete/CamelRouteBuilder.java
@@ -44,11 +44,11 @@ public class CamelRouteBuilder extends RouteBuilder {
         .setHeader(Exchange.FILE_NAME)
         .method(OrderGenerator.class, "generateFileName")
         .log("Generating order ${file:name}")
-        .to("file:work/orders/input");
+        .to("file:/tmp/work/orders/input");
     // Route to consume these orders and move them to a processed directory
-    from("file:work/orders/input")
+    from("file:/tmp/work/orders/input")
         .log("Processing order ${file:name}")
-        .to("file:work/orders/processed");
+        .to("file:/tmp/work/orders/processed");
     // Route to log a Hello world message every second
     from("timer:foo?period=1s")
         .setBody().constant(camelGreeting)

--- a/quickstarts/maven/spring-boot-camel-complete/src/main/java/org/eclipse/jkube/quickstart/springboot/camel/log/CamelRouteBuilder.java
+++ b/quickstarts/maven/spring-boot-camel-complete/src/main/java/org/eclipse/jkube/quickstart/springboot/camel/log/CamelRouteBuilder.java
@@ -44,11 +44,11 @@ public class CamelRouteBuilder extends RouteBuilder {
         .setHeader(Exchange.FILE_NAME)
         .method(OrderGenerator.class, "generateFileName")
         .log("Generating order ${file:name}")
-        .to("file:work/orders/input");
+        .to("file:/tmp/work/orders/input");
     // Route to consume these orders and move them to a processed directory
-    from("file:work/orders/input")
+    from("file:/tmp/work/orders/input")
         .log("Processing order ${file:name}")
-        .to("file:work/orders/processed");
+        .to("file:/tmp/work/orders/processed");
     // Route to log a Hello world message every second
     from("timer:foo?period=1s")
         .setBody().constant(camelGreeting)


### PR DESCRIPTION
## Description
Fix #932

Spring Boot Camel Complete quickstarts generates a new `orders.xml` file
in `work` directory every 5 seconds. Right now `work` is created right under
under current directory, which is `/deployments` when run in jkube zero config
image based container(where jar is executed). Under JIB mode, directories copied are always owned by root
regardless of user provided in image configuration; which results in
permission denied error stacktraces in application logs.

In order to make quickstart work for all cases, change working directory
to `/tmp`.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->