### PR TITLE
fix: No NPE for k8sBuild and no package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,11 @@ Usage:
 * Fix #904: DeploymentConfig ImageChange trigger seems to be wrong for custom images
 * Fix #904: `%g` should be resolved to namespace in OpenShift Maven Plugin
 * Fix #908: OpenShift-Maven-Plugin doesn't remove periods from container name
-* Fix #923: QuakusGenerator not applicable when using `io.quarkus.platform` groupId
+* Fix #923: QuarkusGenerator not applicable when using `io.quarkus.platform` groupId
 * Fix #895: FileUtil#createDirectory works for files with trailing separator (`/`)
 * Fix #913: Make provider name configurable
 * Fix #877: LogMojo: Change access modifiers to protected for use in XML configuration
-* Fix : JKubeTarArchive doesn't load files in memory
+* Fix #1036: JKubeTarArchive doesn't load files in memory
 * Fix #1040: Remove deprecated `ExpectedException.none()` and `@Rule` and use `assertThrows` instead
 
 ### 1.4.0 (2021-07-27)

--- a/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/FatJarDetector.java
+++ b/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/FatJarDetector.java
@@ -40,7 +40,7 @@ public class FatJarDetector {
     }
 
     public Result scan() {
-        if (!directory.exists()) {
+        if (directory == null || !directory.exists()) {
             return null;
         }
         // Scanning is lazy ...

--- a/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
+++ b/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
@@ -180,11 +180,9 @@ public class JavaExecGenerator extends BaseGenerator {
 
     private Assembly createDefaultLayer() {
         final List<AssemblyFileSet> fileSets = new ArrayList<>(addAdditionalFiles());
-        if (isFatJar()) {
-            FatJarDetector.Result fatJar = detectFatJar();
-            if (fatJar != null) {
-                fileSets.add(getOutputDirectoryFileSet(fatJar, getProject()));
-            }
+        final FatJarDetector.Result fatJar = detectFatJar();
+        if (isFatJar() && fatJar != null) {
+            fileSets.add(getOutputDirectoryFileSet(fatJar, getProject()));
         } else {
             log.warn("No fat Jar detected, make sure your image assembly configuration contains all the required" +
                 " dependencies for your application to run.");


### PR DESCRIPTION
## Description
Partial fix for #931 

Build `k8sBuild` no longer fails with a NullPointerException. An informative warning is displayed showing that a fat jar was not detected and the build fails because there is no main class configured.

```shell
$ gradle clean k8sBuild                                           

> Task :k8sBuild FAILED
k8s: Running in Kubernetes mode
k8s: Running generator spring-boot
k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java-binary-s2i:0.0.10 as base / builder
k8s: spring-boot: No fat Jar detected, make sure your image assembly configuration contains all the required dependencies for your application to run.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':k8sBuild'.
> Cannot extract main class to startup
```

As far as I can tell, the SpringBootGenerator should/might also work with non-packaged projects, but a deeper inspection is needed.
When we refactor the SpringBootGenerator, we need to consider all possible scenarios (it's also used for watch, etc.) and provide better checks and UX by showing messages specific to what might be missing.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->