### PR TITLE
Fix #1049: Add a note in asciidoc about Gradle Plugins being a preview feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Usage:
 * Fix #1036: JKubeTarArchive doesn't load files in memory
 * Fix #1040: Remove deprecated `ExpectedException.none()` and `@Rule` and use `assertThrows` instead
 
+_**Note**_: Kubernetes and OpenShift Gradle Plugins are a preview feature to get early feedback. Only the set of documented features are available to users.
+
 ### 1.4.0 (2021-07-27)
 * Fix #253: Refactor JKubeServiceHub's BuildService election mechanism via ServiceLoader
 * Fix #425: Multi-layer support for Container Images

--- a/gradle-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
@@ -2,6 +2,8 @@
 [[introduction]]
 = Introduction
 
+IMPORTANT: *This is a preview feature to get early feedback.  Only the set of documented features are available to users.*
+
 The *{plugin}* brings your Gradle Java applications on to
 ifeval::["{task-prefix}" == "k8s"]
 http://kubernetes.io/[Kubernetes].


### PR DESCRIPTION
## Description
Fix #1049

Add note stating gradle plugins is a preview feature and only a limited
set of features are available

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->