### PR TITLE
doc: Quickstart showing how to use JKube kit to dynamically generate Helm charts

### DIFF
--- a/quickstarts/kit/docker-image/src/main/java/org/eclipse/jkube/quickstart/kit/docker/Main.java
+++ b/quickstarts/kit/docker-image/src/main/java/org/eclipse/jkube/quickstart/kit/docker/Main.java
@@ -95,6 +95,6 @@ public class Main {
     if (currentWorkDir.toAbsolutePath().endsWith("docker-image")) {
       return currentWorkDir.toAbsolutePath();
     }
-    return currentWorkDir.resolve("quickstarts").resolve("kit").resolve("docker-image");
+    return currentWorkDir.resolve("kit").resolve("docker-image");
   }
 }

--- a/quickstarts/kit/dynamic-docker-image-file-multi-layer/src/main/java/org/eclipse/jkube/quickstart/kit/docker/dynamic/Main.java
+++ b/quickstarts/kit/dynamic-docker-image-file-multi-layer/src/main/java/org/eclipse/jkube/quickstart/kit/docker/dynamic/Main.java
@@ -73,6 +73,6 @@ public class Main {
     if (currentWorkDir.toAbsolutePath().endsWith("dynamic-docker-image-file-multi-layer")) {
       return currentWorkDir.toAbsolutePath();
     }
-    return currentWorkDir.resolve("quickstarts").resolve("kit").resolve("dynamic-docker-image-file-multi-layer");
+    return currentWorkDir.resolve("kit").resolve("dynamic-docker-image-file-multi-layer");
   }
 }

--- a/quickstarts/kit/helm/README.md
+++ b/quickstarts/kit/helm/README.md
@@ -1,0 +1,41 @@
+# JKube Kit - Docker Image Build  from Dynamic multilayered Dockerfile Example
+
+This [quickstart](../../../quickstarts) will generate Helm charts using JKube Kit API.
+
+It first creates a temporary directory containing the source manifests/templates that will be included in the chart.
+These manifests include some that are generated programatically using the Fabric8 Kubernetes client. And some that are
+copied from the static directory.
+
+Once the process completes, the new generated chart is available in the `target/helm` directory and as a tarball in the
+`target` directory.
+
+## How to run
+
+Run the `mvn package` from your terminal.
+
+Once the process completes, a success informative message is printed.
+
+You can now install the generated chart using the `helm install jkube-example ./target/helm/kubernetes` command.
+
+
+```shell script
+$ mvn clean package
+# ...
+Creating Helm Chart "Demo Chart" for Kubernetes
+Source directory: /home/user/00-MN/projects/forks/jkube/quickstarts/kit/helm/target/helm-sources
+OutputDir: /home/user/00-MN/projects/forks/jkube/quickstarts/kit/helm/target/helm
+Processing source files
+Creating Chart.yaml
+Copying additional files
+Processing YAML templates
+Creating Helm configuration Tarball: '/home/user/00-MN/projects/forks/jkube/quickstarts/kit/helm/target/Demo Chart-1.33.7-helm.tar.gz'
+# ...
+$ helm install jkube-example ./target/helm/kubernetes
+# ...
+NAME: jkube-example
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+# ...
+```

--- a/quickstarts/kit/helm/pom.xml
+++ b/quickstarts/kit/helm/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.eclipse.jkube.quickstarts.kit</groupId>
+  <artifactId>helm</artifactId>
+  <version>1.5.1</version>
+  <name>Eclipse JKube :: Quickstarts :: Kit :: Helm</name>
+  <packaging>jar</packaging>
+
+  <description>
+    Eclipse JKube Kit example showing how to generate a Helm Charts using Eclipse JKube in standalone mode.
+  </description>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <jkube.version>${project.version}</jkube.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jkube</groupId>
+      <artifactId>jkube-kit-config-service</artifactId>
+      <version>${jkube.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eclipse.jkube.quickstart.kit.Main</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/quickstarts/kit/helm/src/main/java/org/eclipse/jkube/quickstart/kit/Main.java
+++ b/quickstarts/kit/helm/src/main/java/org/eclipse/jkube/quickstart/kit/Main.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.quickstart.kit;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.util.Collections;
+
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.openshift.api.model.Template;
+import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.resource.RuntimeMode;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+import org.eclipse.jkube.kit.resource.helm.HelmConfig;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.openshift.api.model.ParameterBuilder;
+import io.fabric8.openshift.api.model.TemplateBuilder;
+import org.apache.commons.io.FileUtils;
+
+public class Main {
+
+  private static final String APP_NAME = "jkube-helm-example";
+  private static final String CONFIG_MAP_NAME = APP_NAME + "-config-map";
+  private static final String SERVICE_NAME = APP_NAME + "-service";
+
+  public static void main(String[] args) throws IOException {
+    final File targetDir = getProjectDir().resolve("target").toFile();
+    final File helmSourceDir = new File(targetDir, "helm-sources");
+    final File kubernetesHelmInputDir = new File(helmSourceDir, "kubernetes");
+    FileUtils.forceMkdir(kubernetesHelmInputDir);
+
+    Files.walkFileTree(getProjectDir().resolve("static").toAbsolutePath(), new SimpleFileVisitor<Path>(){
+      @Override
+      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        FileUtils.copyFileToDirectory(file.toFile(), kubernetesHelmInputDir);
+        return super.visitFile(file, attrs);
+      }
+    });
+
+    final Template values = new TemplateBuilder()
+        .addToParameters(new ParameterBuilder().withName("serviceAccountName").withValue("default").build())
+        .addToParameters(new ParameterBuilder().withName("labelsAppName").withValue(APP_NAME).build())
+        .addToParameters(new ParameterBuilder()
+            .withName("containerName").withValue("{{ .Chart.Name }}").build())
+        .addToParameters(new ParameterBuilder().withName("containerImagePullPolicy").withValue("Always").build())
+        .addToParameters(new ParameterBuilder().withName("volumeName").withValue("config-map-volume").build())
+        .addToParameters(new ParameterBuilder().withName("serviceType").withValue("NodePort").build())
+        .addToParameters(new ParameterBuilder().withName("configMapName").withValue(CONFIG_MAP_NAME).build())
+        .addToParameters(new ParameterBuilder().withName("helmBuildLogFilename").withValue("helm-generate.log").build())
+        .build();
+
+    final KubernetesListBuilder klb = new KubernetesListBuilder()
+        .addToItems(
+            new ConfigMapBuilder()
+                .withNewMetadata().withName("${configMapName}").addToLabels("app", "${labelsAppName}").endMetadata()
+                .addToData("${helmBuildLogFilename}", String.format("Chart generated: %s\n", Instant.now().toString()))
+                .build()
+        )
+        .addToItems(new ServiceBuilder()
+            .withNewMetadata().withName(SERVICE_NAME).addToLabels("app", "${labelsAppName}").endMetadata()
+            .withNewSpec()
+            .addToSelector("app", "${labelsAppName}")
+            .addNewPort().withPort(8080).withNewTargetPort(8080).endPort()
+            .withType("${serviceType}")
+            .endSpec()
+            .build());
+    FileUtils.write(
+        new File(kubernetesHelmInputDir, "kubernetes.yml"), Serialization.asYaml(klb.build()), StandardCharsets.UTF_8);
+
+    final HelmConfig helmConfig = HelmConfig.builder()
+        .chart(APP_NAME + "-chart")
+        .version("1.33.7")
+        .templates(Collections.singletonList(values))
+        .sourceDir(helmSourceDir.getAbsolutePath())
+        .outputDir(new File(targetDir, "helm").getAbsolutePath())
+        .tarballOutputDir(targetDir.getAbsolutePath())
+        .chartExtension("tar.gz")
+        .types(Collections.singletonList(HelmConfig.HelmType.KUBERNETES))
+        .build();
+    JKubeServiceHub.builder()
+        .configuration(JKubeConfiguration.builder()
+            .project(JavaProject.builder()
+                .baseDirectory(getProjectDir().toFile())
+                .build())
+            .outputDirectory("target")
+            .build())
+        .platformMode(RuntimeMode.KUBERNETES)
+        .log(new KitLogger.StdoutLogger())
+        .build().getHelmService()
+        .generateHelmCharts(helmConfig);
+  }
+
+  private static Path getProjectDir() {
+    final Path currentWorkDir = Paths.get("");
+    if (currentWorkDir.toAbsolutePath().endsWith("helm")) {
+      return currentWorkDir.toAbsolutePath();
+    }
+    return currentWorkDir.resolve("kit").resolve("helm");
+  }
+}

--- a/quickstarts/kit/helm/static/deployment.yml
+++ b/quickstarts/kit/helm/static/deployment.yml
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jkube-helm-deployment
+  labels:
+    app: ${labelsAppName}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${labelsAppName}
+  template:
+    metadata:
+      labels:
+        app: ${labelsAppName}
+    spec:
+      serviceAccountName: ${serviceAccountName}
+      containers:
+        - name: ${containerName}
+          image: marcnuri/chuck-norris
+          imagePullPolicy: ${containerImagePullPolicy}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "cat /var/log/${helmBuildLogFilename} > /proc/1/fd/1"]
+          volumeMounts:
+            - name: ${volumeName}
+              mountPath: /var/log/
+      volumes:
+        - name: ${volumeName}
+          configMap:
+            name: ${configMapName}


### PR DESCRIPTION
## Description
doc: Quickstart showing how to use JKube kit to dynamically generate Helm charts


This quickstart showcases most of the JKube's features regarding Helm chart generation.
- Use a Template to declare Chart values/variables
- Generate resource YAML manifests using Fabric8 Kubernetes client with placeholder to use variables
- Reuse existing YAML files to read pre-generated manifests

This should be a good starting point for users who want to generate Helm charts programmatically.

/cc @iocanel

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->