### PR TITLE
Fix #887: Incorrect warning about overriding environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.6.0-SNAPSHOT
+* Fix #887: Incorrect warning about overriding environment variable
 
 ### 1.5.1 (2021-10-28)
 * Fix #1084: Gradle dependencies should be test or provided scope

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
@@ -283,28 +283,19 @@ public class ImageEnricher extends BaseEnricher {
                         .withName(resourceEnvEntry.getKey())
                         .withValue(resourceEnvEntry.getValue())
                         .build();
-                if (!hasEnvWithName(containerEnvVars, newEnvVar.getName())) {
+
+                EnvVar oldEnvVar = containerEnvVars.stream()
+                  .filter(e -> e.getName().equals(newEnvVar.getName()))
+                  .findFirst().orElse(null);
+                if (oldEnvVar == null) {
                     containerEnvVars.add(newEnvVar);
-                } else {
+                } else if (!newEnvVar.getValue().equals(oldEnvVar.getValue())) {
                     log.warn(
-                        "Environment variable %s will not be overridden: trying to set the value %s, but its actual value is %s",
-                        newEnvVar.getName(), newEnvVar.getValue(), getEnvValue(containerEnvVars, newEnvVar.getName()));
+                      "Environment variable %s will not be overridden: trying to set the value %s, but its actual value is %s",
+                      newEnvVar.getName(), newEnvVar.getValue(), oldEnvVar.getValue());
                 }
             }
         });
-    }
-
-    private String getEnvValue(List<EnvVar> envVars, String name) {
-        for (EnvVar var : envVars) {
-            if (var.getName().equals(name)) {
-                return var.getValue();
-            }
-        }
-        return "(not found)";
-    }
-
-    private boolean hasEnvWithName(List<EnvVar> envVars, String name) {
-        return envVars.stream().anyMatch(e -> e.getName().equals(name));
     }
 
     static String containerImageName(ImageConfiguration imageConfiguration) {


### PR DESCRIPTION
## Description
Fix #887
Don't log a warning about not overriding environment variable when both
old and new values are same.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->