### PR TITLE
Fix #1113: `ResourceUtil.deserializeKubernetesListOrTemplate` should also handle YAML manifests with multiple docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Usage:
 * Fix #1054: Log selected Dockerfile in Docker build mode
 * Fix #1120: OpenShiftBuildService flattens assembly only if necessary
 * Fix #1123: Helm supports `.yaml` and `.yml` source files
+* Fix #1113: `ResourceUtil.deserializeKubernetesListOrTemplate` should also handle YAML manifests with multiple docs
 
 ### 1.5.1 (2021-10-28)
 * Fix #1084: Gradle dependencies should be test or provided scope

--- a/jkube-kit/common/src/test/resources/util/resource-util/multiple-k8s-documents.yml
+++ b/jkube-kit/common/src/test/resources/util/resource-util/multiple-k8s-documents.yml
@@ -1,0 +1,60 @@
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app: "test-project"
+    decorated-by: "dekorate"
+    version: "latest"
+    group: "jkube"
+  name: "test-project"
+spec:
+  ports:
+    - name: "http"
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: "test-project"
+    decorated-by: "dekorate"
+    version: "latest"
+    group: "jkube"
+  type: "NodePort"
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  labels:
+    app: "test-project"
+    decorated-by: "dekorate"
+    version: "latest"
+    group: "jkube"
+  name: "test-project"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "test-project"
+      decorated-by: "dekorate"
+      version: "latest"
+      group: "jkube"
+  template:
+    metadata:
+      labels:
+        app: "test-project"
+        decorated-by: "dekorate"
+        version: "latest"
+        group: "jkube"
+    spec:
+      containers:
+        - env:
+            - name: "KUBERNETES_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.namespace"
+          image: "maven/test-project:latest"
+          imagePullPolicy: "IfNotPresent"
+          name: "test-project"
+          ports:
+            - containerPort: 8080
+              name: "http"
+              protocol: "TCP"


### PR DESCRIPTION
## Description
Fix #1113

+ Added logic in `ResourceUtil.deserializeKubernetesListOrTemplate()`
  method to handle YAML manifests which multiple documents. This was
  causing deserialization to fail when JKube was trying to deserialize
  manifests generated by Dekorate

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->