### PR TITLE
OpenShiftBuildService flattens assembly only if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ### 1.6.0-SNAPSHOT
 * Fix #887: Incorrect warning about overriding environment variable
 * Fix #802: Update Fabric8 kubernetes Client to v5.10.1
+* Fix #1054: Log selected Dockerfile in Docker build mode
 
 ### 1.5.1 (2021-10-28)
 * Fix #1084: Gradle dependencies should be test or provided scope
@@ -44,6 +45,7 @@ Usage:
 * Fix #877: LogMojo: Change access modifiers to protected for use in XML configuration
 * Fix #1036: JKubeTarArchive doesn't load files in memory
 * Fix #1040: Remove deprecated `ExpectedException.none()` and `@Rule` and use `assertThrows` instead
+* Fix #891: VolumePermissionEnricher has configurable image with `busybox` as default
 
 _**Note**_: Kubernetes and OpenShift Gradle Plugins are a preview feature to get early feedback.
 Only the set of documented features are available to users.
@@ -93,6 +95,7 @@ Only the set of documented features are available to users.
 * Fix #690: Helm charts can be generated for custom resources, even those with same name (different apiGroup)
 * Fix #676: Define Helm Chart dependencies
 * Fix #590: Only assembled files are copied to 'Docker' build target directory
+* Fix #655: Set image creation time on JIB build (!breaks image reproducibility)
 
 ### 1.2.0 (2021-03-31)
 * Fix #529: `.maven-dockerignore`, `.maven-dockerexclude`, `.maven-dockerinclude` are no longer supported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Usage:
 * Fix #887: Incorrect warning about overriding environment variable
 * Fix #802: Update Fabric8 kubernetes Client to v5.10.1
 * Fix #1054: Log selected Dockerfile in Docker build mode
+* Fix #1120: OpenShiftBuildService flattens assembly only if necessary
 
 ### 1.5.1 (2021-10-28)
 * Fix #1084: Gradle dependencies should be test or provided scope

--- a/jkube-kit/config/service/pom.xml
+++ b/jkube-kit/config/service/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
@@ -126,7 +126,8 @@ public class OpenshiftBuildService implements BuildService {
         String buildName = null;
         try {
             final ImageConfiguration.ImageConfigurationBuilder applicableImageConfigBuilder = imageConfig.toBuilder();
-            if (imageConfig.getBuildConfiguration() != null && imageConfig.getBuildConfiguration().getAssembly() != null) {
+            if (imageConfig.getBuildConfiguration() != null && !imageConfig.getBuildConfiguration().isDockerFileMode()
+                && imageConfig.getBuildConfiguration().getAssembly() != null) {
                 applicableImageConfigBuilder.build(imageConfig.getBuild().toBuilder().assembly(
                     imageConfig.getBuildConfiguration().getAssembly().getFlattenedClone(jKubeServiceHub.getConfiguration()))
                     .build());

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/JKubeServiceHubBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/JKubeServiceHubBuildServiceTest.java
@@ -16,7 +16,6 @@ package org.eclipse.jkube.kit.config.service;
 import java.util.Arrays;
 import java.util.Collection;
 
-import mockit.Mocked;
 import org.eclipse.jkube.kit.build.service.docker.ServiceHub;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
 import org.eclipse.jkube.kit.common.KitLogger;
@@ -32,6 +31,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
 public class JKubeServiceHubBuildServiceTest {
@@ -59,15 +60,12 @@ public class JKubeServiceHubBuildServiceTest {
   @Parameterized.Parameter(2)
   public Class<? extends BuildService> buildServiceClass;
 
-  @Mocked
-  private ServiceHub dockerServiceHub;
-
   @Test
   public void getBuildService() {
     // Given
     final BuildServiceConfig config = BuildServiceConfig.builder().jKubeBuildStrategy(buildStrategy).build();
     final JKubeServiceHub jKubeServiceHub = new JKubeServiceHub(
-        null, runtimeMode, new KitLogger.StdoutLogger(), dockerServiceHub, new JKubeConfiguration(), config, new LazyBuilder<>(() -> null), true);
+        null, runtimeMode, new KitLogger.StdoutLogger(), mock(ServiceHub.class, RETURNS_DEEP_STUBS), new JKubeConfiguration(), config, new LazyBuilder<>(() -> null), true);
     // When
     final BuildService result = jKubeServiceHub.getBuildService();
     // Then

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceIntegrationTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceIntegrationTest.java
@@ -194,6 +194,23 @@ public class OpenshiftBuildServiceIntegrationTest {
   }
 
   @Test
+  public void build_withAssembly_shouldSucceed() throws Exception {
+    // Given
+    final BuildServiceConfig config = withBuildServiceConfig(defaultConfig.build());
+    final WebServerEventCollector collector = prepareMockServer(config, true, false, false);
+    image.setBuild(BuildConfiguration.builder()
+        .from(projectName)
+        .assembly(AssemblyConfiguration.builder()
+            .layer(Assembly.builder().id("one").build())
+            .build())
+        .build());
+    // When
+    new OpenshiftBuildService(jKubeServiceHub).build(image);
+    // Then
+    collector.assertEventsRecordedInOrder("build-config-check", "new-build-config", "pushed");
+  }
+
+  @Test
   public void build_withDockerfileModeAndFlattenedAssembly_shouldThrowException() {
     //Given
     image.setBuild(BuildConfiguration.builder()

--- a/jkube-kit/config/service/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/jkube-kit/config/service/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Description

Waiting for #1120 

- fix #1115: OpenShiftBuildService flattens assembly only if necessary
- test: replaced jmockit with mockito
- chore: Add missing changelog entries
### After merge tasks
- [ ] Remove no longer applicable changelog_missing labels in affected PRs
 
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->