### PR TITLE
chore: #1034 enable documentation autorefresh for jkit and gradle doc

### DIFF
--- a/gradle-plugin/doc/pom.xml
+++ b/gradle-plugin/doc/pom.xml
@@ -29,19 +29,11 @@
     <name>Gradle Plugin :: Documentation</name>
 
     <properties>
-      <jkube.kit.version>${project.version}</jkube.kit.version>
       <plugin>kubernetes-gradle-plugin</plugin>
       <task-prefix>k8s</task-prefix>
       <cluster>Kubernetes</cluster>
       <pluginExtension>kubernetes</pluginExtension>
     </properties>
-
-    <dependencies>
-      <dependency>
-        <groupId>org.asciidoctor</groupId>
-        <artifactId>asciidoctorj</artifactId>
-      </dependency>
-    </dependencies>
 
   <build>
     <plugins>
@@ -85,6 +77,23 @@
         </executions>
       </plugin>
     </plugins>
+
+    <pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctor-maven-plugin</artifactId>
+            <configuration>
+              <attributes>
+                <plugin>${plugin}</plugin>
+                <task-prefix>${task-prefix}</task-prefix>
+                <cluster>${cluster}</cluster>
+                <pluginExtension>${pluginExtension}</pluginExtension>
+              </attributes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </pluginManagement>
   </build>
 
   <!-- ==== HTML documentation ====================== -->
@@ -103,20 +112,6 @@
                 <goals>
                   <goal>process-asciidoc</goal>
                 </goals>
-                <configuration>
-                  <sourceHighlighter>coderay</sourceHighlighter>
-                  <backend>html</backend>
-                  <sourceHighlighter>coderay</sourceHighlighter>
-                  <attributes>
-                    <toc>left</toc>
-                    <linkcss>false</linkcss>
-                    <plugin>${plugin}</plugin>
-                    <task-prefix>${task-prefix}</task-prefix>
-                    <cluster>${cluster}</cluster>
-                    <version>${project.version}</version>
-                    <pluginExtension>${pluginExtension}</pluginExtension>
-                  </attributes>
-                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -124,5 +119,25 @@
       </build>
       <activation><activeByDefault>true</activeByDefault></activation>
     </profile>
+    <profile>
+        <id>doc-watch</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.asciidoctor</groupId>
+              <artifactId>asciidoctor-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>output-html</id>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>auto-refresh</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
   </profiles>
 </project>

--- a/jkube-kit/doc/pom.xml
+++ b/jkube-kit/doc/pom.xml
@@ -38,18 +38,9 @@
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
           <configuration>
-            <sourceDirectory>src/main/asciidoc</sourceDirectory>
             <requires>
               <require>asciidoctor-diagram</require>
             </requires>
-            <attributes>
-              <icons>font</icons>
-              <pagenums/>
-              <version>${project.version}</version>
-              <idprefix/>
-              <idseparator>-</idseparator>
-              <allow-uri-read>true</allow-uri-read>
-            </attributes>
           </configuration>
         </plugin>
       </plugins>
@@ -73,13 +64,6 @@
                   <goal>process-asciidoc</goal>
                 </goals>
                 <configuration>
-                  <sourceHighlighter>coderay</sourceHighlighter>
-                  <backend>html5</backend>
-                  <sourceHighlighter>coderay</sourceHighlighter>
-                  <attributes>
-                    <toc>left</toc>
-                    <linkcss>false</linkcss>
-                  </attributes>
                 </configuration>
               </execution>
             </executions>
@@ -88,7 +72,26 @@
       </build>
       <activation><activeByDefault>true</activeByDefault></activation>
     </profile>
-
+    <profile>
+        <id>doc-watch</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.asciidoctor</groupId>
+              <artifactId>asciidoctor-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>output-html</id>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>auto-refresh</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
   </profiles>
 
 </project>

--- a/kubernetes-maven-plugin/doc/pom.xml
+++ b/kubernetes-maven-plugin/doc/pom.xml
@@ -33,7 +33,6 @@
     <plugin>kubernetes-maven-plugin</plugin>
     <goal-prefix>k8s</goal-prefix>
     <cluster>Kubernetes</cluster>
-    <outputHtmlDirectory>${project.build.directory}/generated-docs</outputHtmlDirectory>
   </properties>
 
   <build>
@@ -85,32 +84,12 @@
           <groupId>org.asciidoctor</groupId>
           <artifactId>asciidoctor-maven-plugin</artifactId>
           <configuration>
-            <sourceDirectory>src/main/asciidoc</sourceDirectory>
-            <outputDirectory>${outputHtmlDirectory}</outputDirectory>
-            <refreshOn>.*</refreshOn>
             <attributes>
-              <icons>font</icons>
-              <pagenums/>
-              <version>${project.version}</version>
-              <idprefix/>
-              <idseparator>-</idseparator>
-              <allow-uri-read>true</allow-uri-read>
-              <toc>left</toc>
-              <linkcss>false</linkcss>
               <plugin>${plugin}</plugin>
               <goal-prefix>${goal-prefix}</goal-prefix>
               <cluster>${cluster}</cluster>
             </attributes>
-            <sourceHighlighter>coderay</sourceHighlighter>
-            <backend>html</backend>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.asciidoctor</groupId>
-              <artifactId>asciidoctorj</artifactId>
-              <version>${version.asciidoctorj}</version>
-            </dependency>
-          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
     <version.slf4j-api>1.7.25</version.slf4j-api>
     <version.license-maven-plugin>3.0</version.license-maven-plugin>
     <project.build.outputTimestamp>2020-11-08T11:04:00Z</project.build.outputTimestamp>
+    <asciidoctor.outputHtmlDirectory>${project.build.directory}/generated-docs</asciidoctor.outputHtmlDirectory>
   </properties>
 
   <modules>
@@ -203,15 +204,28 @@
           <version>${version.asciidoctor-maven-plugin}</version>
           <configuration>
             <sourceDirectory>src/main/asciidoc</sourceDirectory>
+            <outputDirectory>${asciidoctor.outputHtmlDirectory}</outputDirectory>
+            <refreshOn>.*</refreshOn>
             <attributes>
-              <icons>font</icons>
-              <pagenums/>
-              <version>${project.version}</version>
-              <idprefix/>
-              <idseparator>-</idseparator>
-              <allow-uri-read>true</allow-uri-read>
+                <icons>font</icons>
+                <pagenums/>
+                <version>${project.version}</version>
+                <idprefix/>
+                <idseparator>-</idseparator>
+                <allow-uri-read>true</allow-uri-read>
+                <toc>left</toc>
+                <linkcss>false</linkcss>
             </attributes>
+            <sourceHighlighter>coderay</sourceHighlighter>
+            <backend>html5</backend>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.asciidoctor</groupId>
+              <artifactId>asciidoctorj</artifactId>
+              <version>${version.asciidoctorj}</version>
+            </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
## Description
Fix #1034
This is finalising https://github.com/eclipse/jkube/issues/1034
1. extract common properties to the jkube parent pom.xml
2. added doc-watch profile for jkit and gradle doc

to try it run in either jkit or gradle doc project:
```
mvn clean -Pdoc-watch package
```
Make some changes in adoc files and see the site updated when refreshing the browser

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->