### PR TITLE
Revert "chore: Update Docker Image used in Sonar workflows to eclipse-temurin:11"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
 
   sonar:
     docker:
-      - image: eclipse-temurin:11
+      - image: cimg/openjdk:11.0
     steps:
     - checkout
     - restore_cache:
@@ -78,7 +78,7 @@ jobs:
 
   sonar-pr:
     docker:
-      - image: eclipse-temurin:11
+      - image: cimg/openjdk:11.0
     steps:
     - checkout
     - restore_cache:


### PR DESCRIPTION
## Description
Revert "chore: Update Docker Image used in Sonar workflows to eclipse-temurin:11"

This reverts commit 5a6c996f6b00b5e1fc8fc52a1518b0762782ba91.

Should no longer be necessary after fixes/refactor in OpenShiftBuildTest

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->