### PR TITLE
Fix #1110: Implement `oc:watch` equivalent functionality ocWatch for OpenShift Gradle Plugin

### DIFF
--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/OpenShiftPlugin.java
@@ -33,6 +33,7 @@ import org.eclipse.jkube.gradle.plugin.task.OpenShiftPushTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftResourceTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftUndeployTask;
 
+import org.eclipse.jkube.gradle.plugin.task.OpenShiftWatchTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 
@@ -66,6 +67,7 @@ public class OpenShiftPlugin extends AbstractJKubePlugin<OpenShiftExtension> {
     register(project, "ocUndeploy", OpenShiftUndeployTask.class);
     register(project, "ocHelm", OpenShiftHelmTask.class);
     register(project, "ocHelmPush", OpenShiftHelmPushTask.class);
+    register(project, "ocWatch", OpenShiftWatchTask.class);
   }
 
 }

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTask.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+
+import javax.inject.Inject;
+
+public class OpenShiftWatchTask extends KubernetesWatchTask implements OpenShiftJKubeTask {
+  @Inject
+  public OpenShiftWatchTask(Class<? extends OpenShiftExtension> extensionClass) {
+    super(extensionClass);
+    setDescription(
+        "Used to automatically rebuild images and restart containers in case of updates.");
+  }
+}

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginRegisterTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/OpenShiftPluginRegisterTaskTest.java
@@ -27,6 +27,7 @@ import org.eclipse.jkube.gradle.plugin.task.OpenShiftPushTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftResourceTask;
 import org.eclipse.jkube.gradle.plugin.task.OpenShiftUndeployTask;
 
+import org.eclipse.jkube.gradle.plugin.task.OpenShiftWatchTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.junit.Before;
@@ -54,7 +55,8 @@ public class OpenShiftPluginRegisterTaskTest {
         new Object[] { "ocResource", OpenShiftResourceTask.class },
         new Object[] { "ocUndeploy", OpenShiftUndeployTask.class },
         new Object[] { "ocHelm", OpenShiftHelmTask.class},
-        new Object[] { "ocHelmPush", OpenShiftHelmPushTask.class});
+        new Object[] { "ocHelmPush", OpenShiftHelmPushTask.class},
+        new Object[] { "ocWatch", OpenShiftWatchTask.class});
   }
 
   @Parameterized.Parameter

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTaskTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.task;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
+import org.eclipse.jkube.gradle.plugin.TestOpenShiftExtension;
+import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.eclipse.jkube.watcher.api.WatcherManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+public class OpenShiftWatchTaskTest {
+
+  @Rule
+  public TaskEnvironment taskEnvironment = new TaskEnvironment();
+
+  private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
+  private MockedStatic<WatcherManager> watcherManagerMockedStatic;
+  private TestOpenShiftExtension extension;
+
+  @Before
+  public void setUp() throws IOException {
+    clusterAccessMockedConstruction = mockConstruction(ClusterAccess.class, (mock, ctx) -> {
+      final OpenShiftClient openShiftClient = mock(OpenShiftClient.class);
+      when(openShiftClient.getMasterUrl()).thenReturn(new URL("http://openshiftapps.com:6443"));
+      when(mock.createDefaultClient()).thenReturn(openShiftClient);
+    });
+    watcherManagerMockedStatic = mockStatic(WatcherManager.class);
+    extension = new TestOpenShiftExtension();
+    when(taskEnvironment.project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(extension);
+    extension.isFailOnNoKubernetesJson = false;
+  }
+
+  @After
+  public void tearDown() {
+    watcherManagerMockedStatic.close();
+    clusterAccessMockedConstruction.close();
+  }
+
+  @Test
+  public void runTask_withNoManifest_shouldThrowException() {
+    // Given
+    extension.isFailOnNoKubernetesJson = true;
+    final OpenShiftWatchTask watchTask = new OpenShiftWatchTask(OpenShiftExtension.class);
+    // When
+    final IllegalStateException result = assertThrows(IllegalStateException.class, watchTask::runTask);
+    // Then
+    assertThat(result)
+        .hasMessageContaining("An error has occurred while while trying to watch the resources");
+  }
+
+  @Test
+  public void runTask_withManifest_shouldWatchEntities() throws Exception {
+    // Given
+    taskEnvironment.withOpenShiftManifest();
+    final OpenShiftWatchTask watchTask = new OpenShiftWatchTask(OpenShiftExtension.class);
+    // When
+    watchTask.runTask();
+    // Then
+    watcherManagerMockedStatic.verify(() -> WatcherManager.watch(any(), any(), any()), times(1));
+  }
+}


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fix #1110 

Add OpenShiftWatchTask to OpenShift Gradle Plugin

Requires #1133 to be merged first

Signed-off-by: Rohan Kumar <rohaan@redhat.com>



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->