### PR TITLE
Doc and examples: Avoid using prefix KUBERNETES_ on env vars

### DIFF
--- a/gradle-plugin/doc/src/main/asciidoc/inc/scenarios/_fragments.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/scenarios/_fragments.adoc
@@ -26,7 +26,7 @@ The resource fragments are in `src/main/jkube`.
               - name: config
                 mountPath: /app/config
             env:
-              - name: KUBERNETES_NAMESPACE
+              - name: MY_POD_NAMESPACE
                 valueFrom:
                   fieldRef:
                     apiVersion: v1

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
@@ -373,7 +373,7 @@ The resource fragments are in `src/main/jkube`.
               - name: config
                 mountPath: /app/config
             env:
-              - name: KUBERNETES_NAMESPACE
+              - name: MY_POD_NAMESPACE
                 valueFrom:
                   fieldRef:
                     apiVersion: v1

--- a/quickstarts/maven/external-resources/src/main/jkube/deployment.yml
+++ b/quickstarts/maven/external-resources/src/main/jkube/deployment.yml
@@ -28,7 +28,7 @@ spec:
             - name: config
               mountPath: /deployments/config
           env:
-            - name: KUBERNETES_NAMESPACE
+            - name: MY_POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1


### PR DESCRIPTION
We assume the name prefix `KUBERNETES_` on env vars is meant for Kubernetes/OpenShift own use. Therefore we should not encourage users to create custom env vars with this name prefix.

Fixes #1132

Note:  The name `KUBERNETES_NAMESPACE` name is also used in `jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandler.java` which is deliberately not touched in this PR as users may rely on this behavior ... even if it has never been documented/promised anywhere, AFAIK.