### PR TITLE
Fix #961: `k8sBuild`, `k8sResource` and `k8sApply` don't respect Skip options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ### 1.6.0-SNAPSHOT
 * Fix #887: Incorrect warning about overriding environment variable
 * Fix #802: Update Fabric8 kubernetes Client to v5.10.1
+* Fix #961: `k8sBuild`, `k8sResource` and `k8sApply` tasks don't respect skip options
 * Fix #1054: Log selected Dockerfile in Docker build mode
 * Fix #1120: OpenShiftBuildService flattens assembly only if necessary
 * Fix #1123: Helm supports `.yaml` and `.yml` source files

--- a/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
@@ -374,6 +374,10 @@ Defaults to `false`.
 | If set not images will be build (which implies also _skip.tag_) with `{task-prefix}Build`.
 | `jkube.skip.build`
 
+| *skipResource*
+| If not set resource manifests would be generated with `{task-prefix}Resource`.
+| `jkube.skip.resource`
+
 | *skipTag*
 | If set to `true` this plugin won't add any tags to images that have been built with `{task-prefix}Build`.
 | `jkube.skip.tag`

--- a/gradle-plugin/it/src/it/extension-configuration/build.gradle
+++ b/gradle-plugin/it/src/it/extension-configuration/build.gradle
@@ -41,6 +41,8 @@ kubernetes {
     serviceUrlWaitTimeSeconds = 10
     skipPush = true
     skipTag = true
+    skipBuild = true
+    skipResource = true
     pushRegistry = 'quay.io'
     pushRetries = 5
     kubernetesTemplate = file('build/META-INF/jkube/kubernetes')

--- a/gradle-plugin/it/src/it/extension-configuration/expected/expected-config.yml
+++ b/gradle-plugin/it/src/it/extension-configuration/expected/expected-config.yml
@@ -26,6 +26,8 @@ jsonlogdir: "@endsWith('extension-configuration/build/jkube/applyJson')@"
 serviceurlwaittimeseconds: 10
 skippush: true
 skiptag: true
+skipbuild: true
+skipresource: true
 pushregistry: quay.io
 pushretries: 5
 kubernetestemplate: "@endsWith('extension-configuration/build/META-INF/jkube/kubernetes')@"

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesExtension.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesExtension.java
@@ -229,6 +229,10 @@ public abstract class KubernetesExtension {
 
   public abstract Property<File> getKubernetesTemplate();
 
+  public abstract Property<Boolean> getSkipResource();
+
+  public abstract Property<Boolean> getSkipBuild();
+
   public JKubeBuildStrategy buildStrategy;
 
   public ClusterConfiguration access;
@@ -599,6 +603,14 @@ public abstract class KubernetesExtension {
 
   public File getKubernetesTemplateOrDefault() {
     return getOrDefaultFile("jkube.kubernetesTemplate", this::getKubernetesTemplate, javaProject.getOutputDirectory().toPath().resolve(DEFAULT_KUBERNETES_TEMPLATE).toFile());
+  }
+
+  public boolean getSkipResourceOrDefault() {
+    return getOrDefaultBoolean("jkube.skip.resource", this::getSkipResource, false);
+  }
+
+  public boolean getSkipBuildOrDefault() {
+    return getOrDefaultBoolean("jkube.skip.build", this::getSkipBuild, false);
   }
 
   protected boolean getOrDefaultBoolean(String property, Supplier<Property<Boolean>> dslGetter, boolean defaultValue) {

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -84,7 +84,9 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
     } catch (IOException exception) {
       kitLogger.error("Error in fetching Build timestamps: " + exception.getMessage());
     }
-    run();
+    if (canExecute()) {
+      run();
+    }
   }
 
   @Internal
@@ -174,5 +176,9 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
       }
     }
     return manifest;
+  }
+
+  protected boolean canExecute() {
+    return !kubernetesExtension.getSkipOrDefault();
   }
 }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
@@ -71,6 +71,11 @@ public class KubernetesApplyTask extends AbstractJKubeTask {
     }
   }
 
+  @Override
+  protected boolean canExecute() {
+    return super.canExecute() && !kubernetesExtension.getSkipApplyOrDefault();
+  }
+
   private void applyEntities(String fileName, final Collection<HasMetadata> entities) throws InterruptedException {
     KitLogger serviceLogger = createLogger("[[G]][SVC][[G]] [[s]]");
     applyService.applyEntities(fileName, entities, serviceLogger, kubernetesExtension.getServiceUrlWaitTimeSecondsOrDefault());

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTask.java
@@ -69,6 +69,12 @@ public class KubernetesBuildTask extends AbstractJKubeTask {
     }
   }
 
+
+  @Override
+  protected boolean canExecute() {
+    return super.canExecute() && !kubernetesExtension.getSkipBuildOrDefault();
+  }
+
   protected BuildServiceConfig.BuildServiceConfigBuilder buildServiceConfigBuilder() {
     return TaskUtil.buildServiceConfigBuilder(kubernetesExtension);
   }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
@@ -39,15 +39,17 @@ public class KubernetesPushTask extends AbstractJKubeTask {
 
   @Override
   public void run() {
-    if (kubernetesExtension.getSkipPushOrDefault()) {
-      return;
-    }
-
     try {
       jKubeServiceHub.getBuildService().push(resolvedImages, kubernetesExtension.getPushRetriesOrDefault(), initRegistryConfig(kubernetesExtension.getPushRegistry().getOrNull()), kubernetesExtension.getSkipTagOrDefault());
     } catch (JKubeServiceException e) {
       throw new IllegalStateException("Error in pushing image: " + e.getMessage(), e);
     }
+  }
+
+
+  @Override
+  protected boolean canExecute() {
+    return super.canExecute() && !kubernetesExtension.getSkipPushOrDefault();
   }
 
   private RegistryConfig initRegistryConfig(String specificRegistry) {

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTask.java
@@ -96,6 +96,12 @@ public class KubernetesResourceTask extends AbstractJKubeTask {
     }
   }
 
+
+  @Override
+  protected boolean canExecute() {
+    return super.canExecute() && !kubernetesExtension.getSkipResourceOrDefault();
+  }
+
   private void validateIfRequired(File resourceDir, ResourceClassifier classifier) {
     try {
       if (Boolean.FALSE.equals(kubernetesExtension.getSkipResourceValidationOrDefault())) {

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionPropertyTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionPropertyTest.java
@@ -43,6 +43,8 @@ public class KubernetesExtensionPropertyTest {
         new Object[] { "getInterpolateTemplateParametersOrDefault", "jkube.interpolateTemplateParameters", "false", false,
             true },
         new Object[] { "getSkipResourceValidationOrDefault", "jkube.skipResourceValidation", "true", true, false },
+        new Object[] { "getSkipResourceOrDefault", "jkube.skip.resource", "true", true, false},
+        new Object[] { "getSkipBuildOrDefault", "jkube.skip.build", "true", true, false},
         new Object[] { "getLogFollowOrDefault", "jkube.log.follow", "false", false, true },
         new Object[] { "getRecreateOrDefault", "jkube.recreate", "true", true, false },
         new Object[] { "getSkipApplyOrDefault", "jkube.skip.apply", "true", true, false },

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
@@ -321,4 +321,14 @@ public class TestKubernetesExtension extends KubernetesExtension {
   public Property<File> getKubernetesTemplate() {
     return new DefaultProperty<>(File.class);
   }
+
+  @Override
+  public Property<Boolean> getSkipResource() {
+    return new DefaultProperty<>(Boolean.class);
+  }
+
+  @Override
+  public Property<Boolean> getSkipBuild() {
+    return new DefaultProperty<>(Boolean.class);
+  }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTaskTest.java
@@ -13,7 +13,6 @@
  */
 package org.eclipse.jkube.gradle.plugin.task;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
@@ -24,7 +23,8 @@ import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.service.ApplyService;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.eclipse.jgit.util.FileUtils;
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.provider.Property;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -131,5 +131,24 @@ public class KubernetesApplyTaskTest {
     assertThat(applyServiceMockedConstruction.constructed()).hasSize(1);
     verify(applyServiceMockedConstruction.constructed().iterator().next(), times(1))
         .applyEntities(any(), eq(Collections.emptyList()), any(), eq(5L));
+  }
+
+  @Test
+  public void runTask_withSkipApply_shouldDoNothing() {
+    // Given
+    extension = new TestKubernetesExtension() {
+      @Override
+      public Property<Boolean> getSkipApply() {
+        return new DefaultProperty<>(Boolean.class).value(true);
+      }
+    };
+    when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
+    final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
+
+    // When
+    applyTask.runTask();
+
+    // Then
+    assertThat(applyServiceMockedConstruction.constructed()).isEmpty();
   }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTaskTest.java
@@ -24,6 +24,8 @@ import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.gradle.plugin.TestKubernetesExtension;
 
 import org.apache.commons.io.FileUtils;
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.provider.Property;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -77,6 +79,26 @@ public class KubernetesResourceTaskTest {
         .satisfies(p -> assertThat(p.resolve("configmap.yml")).hasContent("key: value"))
         .satisfies(p -> assertThat(p.resolve("second-configmap.yml"))
             .hasContent("field-1: value\nfield-2: value2\nf3: ${not.here}\nf4: Hard"));
+  }
+
+  @Test
+  public void runTask_withSkipResource_shouldDoNothing() {
+    // Given
+    KubernetesExtension extension = new TestKubernetesExtension() {
+      @Override
+      public Property<Boolean> getSkipResource() {
+        return new DefaultProperty<>(Boolean.class).value(true);
+      }
+    };
+    when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
+    final KubernetesResourceTask kubernetesResourceTask = new KubernetesResourceTask(KubernetesExtension.class);
+
+    // When
+    kubernetesResourceTask.runTask();
+
+    // Then
+    assertThat(taskEnvironment.getRoot().toPath().resolve("build").resolve("jkube"))
+        .doesNotExist();
   }
 
   private void withProperties(Map<String, ?> properties) {

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/TestOpenShiftExtension.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/TestOpenShiftExtension.java
@@ -348,4 +348,14 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
   public Property<File> getKubernetesTemplate() {
     return new DefaultProperty<>(File.class);
   }
+
+  @Override
+  public Property<Boolean> getSkipResource() {
+    return new DefaultProperty<>(Boolean.class);
+  }
+
+  @Override
+  public Property<Boolean> getSkipBuild() {
+    return new DefaultProperty<>(Boolean.class);
+  }
 }


### PR DESCRIPTION
## Description
Fix #961

Add `canExecute` method in AbstractJKubeTask which decides whether a
task would get executed or not. Child Tasks would override this method
to modify factors on which execution would be skipped.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->