### PR TITLE
Fix #1030: Update IngressEnricher's default targetApiVersion to `networking.k8s.io/v1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,16 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.6.0-SNAPSHOT
-* Fix #1136: ConcurrentModificationException when running gradle k8sBuild on Quarkus sample
-* Fix #887: Incorrect warning about overriding environment variable
+* Fix #778: Support deserialization of fragments with mismatched field types of target Java class 
 * Fix #802: Update Fabric8 kubernetes Client to v5.10.1
+* Fix #887: Incorrect warning about overriding environment variable
 * Fix #961: `k8sBuild`, `k8sResource` and `k8sApply` tasks don't respect skip options
+* Fix #1030: Update IngressEnricher's default targetApiVersion to `networking.k8s.io/v1`
 * Fix #1054: Log selected Dockerfile in Docker build mode
+* Fix #1113: `ResourceUtil.deserializeKubernetesListOrTemplate` should also handle YAML manifests with multiple docs
 * Fix #1120: OpenShiftBuildService flattens assembly only if necessary
 * Fix #1123: Helm supports `.yaml` and `.yml` source files
-* Fix #1113: `ResourceUtil.deserializeKubernetesListOrTemplate` should also handle YAML manifests with multiple docs
-* Fix #778: Support deserialization of fragments with mismatched field types of target Java class
+* Fix #1136: ConcurrentModificationException when running gradle k8sBuild on Quarkus sample
 * Fix #1145: Remove redundant ServiceHubFactory
 
 ### 1.5.1 (2021-10-28)

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
@@ -50,7 +50,7 @@ public class IngressEnricher extends BaseEnricher {
     @AllArgsConstructor
     public enum Config implements Configs.Config {
         HOST("host", null),
-        TARGET_API_VERSION("targetApiVersion", "extensions/v1beta1");
+        TARGET_API_VERSION("targetApiVersion", "networking.k8s.io/v1");
 
         @Getter
         protected String key;

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_ingress.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_ingress.adoc
@@ -18,6 +18,6 @@ JKube generates Ingress only for Services which have either `expose=true` or `ex
 | *targetApiVersion*
 | Whether to generate `extensions/v1beta1` Ingress or `networking.k8s.io/v1` Ingress.
 
-  Defaults to `extensions/v1beta1`.
+  Defaults to `networking.k8s.io/v1`.
 | `jkube.enricher.jkube-ingress.targetApiVersion`
 |===

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/xml-config/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/xml-config/kubernetes.yml
@@ -96,7 +96,7 @@ items:
             protocol: TCP
           securityContext:
             privileged: false
-- apiVersion: extensions/v1beta1
+- apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     annotations:
@@ -114,8 +114,10 @@ items:
       http:
         paths:
         - backend:
-            serviceName: ingress-xml-config
-            servicePort: 8080
+            service:
+              name: ingress-xml-config
+              port:
+                number: 8080
           path: /
           pathType: ImplementationSpecific
     tls:

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/zero-config-extensionsv1beta1-enricher-config/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/zero-config-extensionsv1beta1-enricher-config/kubernetes.yml
@@ -96,7 +96,7 @@ items:
             protocol: TCP
           securityContext:
             privileged: false
-- apiVersion: networking.k8s.io/v1
+- apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
     annotations:
@@ -109,14 +109,6 @@ items:
       group: org.eclipse.jkube
     name: ingress-xml-config
   spec:
-    rules:
-      - host: test.example.com
-        http:
-          paths:
-            - backend:
-                service:
-                  name: ingress-xml-config
-                  port:
-                    number: 8080
-              path: /
-              pathType: ImplementationSpecific
+    backend:
+      serviceName: ingress-xml-config
+      servicePort: 8080

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/zero-config-extensionsv1beta1-host-enricher-config/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/zero-config-extensionsv1beta1-host-enricher-config/kubernetes.yml
@@ -96,7 +96,7 @@ items:
             protocol: TCP
           securityContext:
             privileged: false
-- apiVersion: networking.k8s.io/v1
+- apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
     annotations:
@@ -109,8 +109,12 @@ items:
       group: org.eclipse.jkube
     name: ingress-xml-config
   spec:
-    defaultBackend:
-      service:
-        name: ingress-xml-config
-        port:
-          number: 8080
+    rules:
+      - host: test.example.com
+        http:
+          paths:
+            - backend:
+                serviceName: ingress-xml-config
+                servicePort: 8080
+              path: /
+              pathType: ImplementationSpecific

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/zero-config-host-enricher-config/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/zero-config-host-enricher-config/kubernetes.yml
@@ -96,7 +96,7 @@ items:
             protocol: TCP
           securityContext:
             privileged: false
-- apiVersion: extensions/v1beta1
+- apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     annotations:
@@ -114,5 +114,9 @@ items:
       http:
         paths:
         - backend:
-            serviceName: ingress-xml-config
-            servicePort: 8080
+            service:
+              name: ingress-xml-config
+              port:
+                number: 8080
+          path: /
+          pathType: ImplementationSpecific

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/zero-config-no-host/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/expected/zero-config-no-host/kubernetes.yml
@@ -96,7 +96,7 @@ items:
             protocol: TCP
           securityContext:
             privileged: false
-- apiVersion: extensions/v1beta1
+- apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
     annotations:
@@ -109,6 +109,8 @@ items:
       group: org.eclipse.jkube
     name: ingress-xml-config
   spec:
-    backend:
-      serviceName: ingress-xml-config
-      servicePort: 8080
+    defaultBackend:
+      service:
+        name: ingress-xml-config
+        port:
+          number: 8080

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/invoker.properties
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/invoker.properties
@@ -15,7 +15,7 @@
 invoker.goals.1=clean k8s:resource -Pxml-config
 invoker.goals.2=clean k8s:resource -Pzero-config-host-enricher-config
 invoker.goals.3=clean k8s:resource -Pzero-config-no-host
-invoker.goals.4=clean k8s:resource -Pzero-config-networkv1-host-enricher-config
-invoker.goals.5=clean k8s:resource -Pzero-config-networkv1-enricher-config
+invoker.goals.4=clean k8s:resource -Pzero-config-extensionsv1beta1-host-enricher-config
+invoker.goals.5=clean k8s:resource -Pzero-config-extensionsv1beta1-enricher-config
 invoker.debug=false
 invoker.mavenOpts=-Djkube.offline=true

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/pom.xml
@@ -82,11 +82,11 @@
       </build>
     </profile>
     <profile>
-      <id>zero-config-networkv1-host-enricher-config</id>
+      <id>zero-config-extensionsv1beta1-host-enricher-config</id>
       <properties>
         <jkube.enricher.jkube-ingress.host>test.example.com</jkube.enricher.jkube-ingress.host>
-        <jkube.enricher.jkube-ingress.targetApiVersion>networking.k8s.io/v1</jkube.enricher.jkube-ingress.targetApiVersion>
-        <target>zero-config-networkv1-host-enricher-config</target>
+        <jkube.enricher.jkube-ingress.targetApiVersion>extensions/v1beta1</jkube.enricher.jkube-ingress.targetApiVersion>
+        <target>zero-config-extensionsv1beta1-host-enricher-config</target>
       </properties>
       <build>
         <plugins>
@@ -99,10 +99,10 @@
       </build>
     </profile>
     <profile>
-      <id>zero-config-networkv1-enricher-config</id>
+      <id>zero-config-extensionsv1beta1-enricher-config</id>
       <properties>
-        <jkube.enricher.jkube-ingress.targetApiVersion>networking.k8s.io/v1</jkube.enricher.jkube-ingress.targetApiVersion>
-        <target>zero-config-networkv1-enricher-config</target>
+        <jkube.enricher.jkube-ingress.targetApiVersion>extensions/v1beta1</jkube.enricher.jkube-ingress.targetApiVersion>
+        <target>zero-config-extensionsv1beta1-enricher-config</target>
       </properties>
       <build>
         <plugins>

--- a/kubernetes-maven-plugin/it/src/it/ingress-xml-config/verify.groovy
+++ b/kubernetes-maven-plugin/it/src/it/ingress-xml-config/verify.groovy
@@ -13,7 +13,7 @@
  */
 import org.eclipse.jkube.maven.it.Verify
 
-[ "xml-config", "zero-config-host-enricher-config", "zero-config-no-host", "zero-config-networkv1-host-enricher-config","zero-config-networkv1-enricher-config"  ].each {
+[ "xml-config", "zero-config-host-enricher-config", "zero-config-no-host", "zero-config-extensionsv1beta1-host-enricher-config","zero-config-extensionsv1beta1-enricher-config"  ].each {
   Verify.verifyResourceDescriptors(
           new File(basedir, sprintf("/%s/classes/META-INF/jkube/kubernetes.yml",it)),
           new File(basedir, sprintf("/expected/%s/kubernetes.yml",it)))


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fix #1030 

Change IngressEnricher's `targetApiVersion` to `networking.k8s.io/v1`
from `extensions/v1beta1`. Now default Ingress would be of
`networking.k8s.io/v1` apiVersion.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->