### PR TITLE
fix: gradle image build should use the Quarkus generator for Quarkus projects #1047

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.6.0-SNAPSHOT
+* Fix #1047: Gradle image build should use the Quarkus generator for Quarkus projects
 * Fix #778: Support deserialization of fragments with mismatched field types of target Java class 
 * Fix #802: Update Fabric8 kubernetes Client to v5.10.1
 * Fix #887: Incorrect warning about overriding environment variable

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
@@ -142,7 +142,8 @@ public class QuarkusUtils {
 
   public static boolean hasQuarkusPlugin(JavaProject javaProject) {
     return JKubeProjectUtil.hasPlugin(javaProject, QUARKUS_GROUP_ID, "quarkus-maven-plugin") ||
-           JKubeProjectUtil.hasPlugin(javaProject, QUARKUS_PLATFORM_GROUP_ID, "quarkus-maven-plugin");
+           JKubeProjectUtil.hasPlugin(javaProject, QUARKUS_PLATFORM_GROUP_ID, "quarkus-maven-plugin") ||
+           JKubeProjectUtil.hasPlugin(javaProject, QUARKUS_GROUP_ID, "io.quarkus.gradle.plugin");
   }
 
   /**

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/generator/QuarkusGeneratorTest.java
@@ -136,6 +136,23 @@ public class QuarkusGeneratorTest {
   }
 
   @Test
+  public void isApplicable_withQuarkusGradlePlugin_shouldReturnTrue() {
+    // Given
+    // @formatter:off
+    new Expectations() {{
+      project.getPlugins(); result = Collections.singletonList(Plugin.builder()
+        .groupId("io.quarkus")
+        .artifactId("io.quarkus.gradle.plugin")
+        .build());
+    }};
+    // @formatter:on
+    // When
+    final boolean result = new QuarkusGenerator(ctx).isApplicable(new ArrayList<>());
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
   public void customize_inOpenShift_shouldReturnS2iFrom() {
     // Given
     in(RuntimeMode.OPENSHIFT);


### PR DESCRIPTION
## Description
Relates to #1047 

gradle image build should use the Quarkus generator for Quarkus projects #1047

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->