### PR TITLE
Fix #900: Remove `projectArtifactId` and `projectVersion` from `gradle.properties` in Spring Boot Helm Quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Usage:
 * Fix #778: Support deserialization of fragments with mismatched field types of target Java class 
 * Fix #802: Update Fabric8 kubernetes Client to v5.10.1
 * Fix #887: Incorrect warning about overriding environment variable
+* Fix #900: Fix #900: Remove `projectArtifactId` and `projectVersion` from `gradle.properties` in Spring Boot Helm Quickstart
 * Fix #961: `k8sBuild`, `k8sResource` and `k8sApply` tasks don't respect skip options
 * Fix #1030: Update IngressEnricher's default targetApiVersion to `networking.k8s.io/v1`
 * Fix #1054: Log selected Dockerfile in Docker build mode

--- a/quickstarts/gradle/spring-boot-helm/gradle.properties
+++ b/quickstarts/gradle/spring-boot-helm/gradle.properties
@@ -15,5 +15,3 @@
 helm_namespace = 'default'
 golang_expression = 'n/a development'
 golang_expression_scalar = 'n/a development'
-projectArtifactId = 'spring-boot-helm'
-projectVersion = '1.5.1'

--- a/quickstarts/gradle/spring-boot-helm/src/main/jkube/deployment.yml
+++ b/quickstarts/gradle/spring-boot-helm/src/main/jkube/deployment.yml
@@ -15,10 +15,10 @@
 metadata:
   namespace: ${helm_namespace}
   labels:
-    project: ${projectArtifactId}
+    project: ${name}
     hystrix.enabled: true
     hystrix.cluster: default
-    version: ${projectVersion}
+    version: ${version}
   annotations:
     jkube.helm.sh/expression-example: ${golang_expression}
     jkube.helm.sh/expression-example-scalar: ${golang_expression_scalar}
@@ -28,10 +28,10 @@ spec:
     metadata:
       namespace: ${helm_namespace}
       labels:
-        project: ${projectArtifactId}
+        project: ${name}
         hystrix.enabled: true
         hystrix.cluster: default
-        version: ${projectVersion}
+        version: ${version}
     spec:
       containers:
         - resources:


### PR DESCRIPTION
## Description
Fix #900

+ Use already provided properties `name` and `version` for getting
      project artifactId and version rather than hardcoded properties

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->