### PR TITLE
Add Documentation Vert.x zero config scenario to Common Scenarios

### DIFF
--- a/gradle-plugin/doc/src/main/asciidoc/inc/getting-started/_index.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/getting-started/_index.adoc
@@ -23,3 +23,5 @@ ifeval::["{task-prefix}" == "oc"]
 include::_openshift.adoc[]
 
 endif::[]
+
+include::_vertx.adoc[]

--- a/gradle-plugin/doc/src/main/asciidoc/inc/getting-started/_vertx.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/getting-started/_vertx.adoc
@@ -1,0 +1,29 @@
+[[vertx-scenario]]
+== Vert.x
+
+You can easily get started with using {plugin} on an https://start.vertx.io/[Eclipse Vert.x] without providing any explicit configuration. {plugin} would generate an opinionated container image and manifests by inspecting your project configuration.
+
+[[vertx-set-service-port]]
+=== How to set Service Port?
+
+By default, in Vert.x applications, application port value is 8888. {plugin} opinionated defaults use port 8080. If you want to change this, you'll need to configure {plugin} to generate image with desired port:
+
+.Example for setting port number for vertx apps
+[source,groovy,subs="attributes+"]
+----
+{pluginExtension} {
+  generator {
+      config {
+          'vertx' {
+              webPort = '8888'
+          }
+      }
+  }
+}
+----
+
+Once configured, you can go ahead and deploy application to Kubernetes:
+[source,shell,subs="attributes+"]
+----
+$ gradle build {task-prefix}Build {task-prefix}Resource {task-prefix}Apply
+----


### PR DESCRIPTION
## Description

Add a quick getting started doc for Vert.x to common scenarios section

Related to #1146 

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->