### PR TITLE
Fix #1180: SpringBootWatcher uses default namespace even if other namespace is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Usage:
 * Fix #1146: VertxGenerator now works with Kubernetes Gradle Plugin
 * Fix #1148: Enable MicronautGenerator with Kubernetes Gradle Plugin
 * Fix #1167: Replace apiextensions.k8s.io/v1beta1 by apiextensions.k8s.io/v1
+* Fix #1180: `k8s:watch` uses default namespace even if other namespace is configured
 
 
 ### 1.5.1 (2021-10-28)

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
@@ -43,10 +43,8 @@ public class KubernetesUndeployTask extends AbstractJKubeTask {
         .build();
       final File environmentResourceDir = ResourceUtil.getFinalResourceDir(resolveResourceSourceDirectory(),
           kubernetesExtension.getResourceEnvironmentOrNull());
-      final String fallbackNamespace = Optional.ofNullable(kubernetesExtension.resources)
-        .map(ResourceConfig::getNamespace).orElse(clusterAccess.getNamespace());
       jKubeServiceHub.getUndeployService()
-        .undeploy(fallbackNamespace, environmentResourceDir, resources, findManifestsToUndeploy().toArray(new File[0]));
+        .undeploy(environmentResourceDir, resources, findManifestsToUndeploy().toArray(new File[0]));
     } catch (IOException e) {
       throw new IllegalStateException(e.getMessage(), e);
     }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
@@ -24,6 +24,7 @@ import org.eclipse.jkube.kit.build.service.docker.watch.WatchContext;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 import org.eclipse.jkube.kit.profile.ProfileUtil;
@@ -34,6 +35,7 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+import java.util.Optional;
 
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestamp;
 
@@ -62,7 +64,13 @@ public class KubernetesWatchTask extends AbstractJKubeTask {
         List<HasMetadata> resources = KubernetesHelper.loadResources(getManifest(kubernetesClient));
         WatcherContext context = createWatcherContext();
 
-        WatcherManager.watch(resolvedImages, resources, context);
+        WatcherManager.watch(resolvedImages,
+            Optional.ofNullable(kubernetesExtension.getNamespaceOrNull())
+                .orElse(Optional.ofNullable(kubernetesExtension.resources)
+                    .map(ResourceConfig::getNamespace)
+                    .orElse(clusterAccess.getNamespace())),
+            resources,
+            context);
       } catch (KubernetesClientException kubernetesClientException) {
         KubernetesResourceUtil.handleKubernetesClientException(kubernetesClientException, kitLogger);
       } catch (Exception ioException) {

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
@@ -24,7 +24,6 @@ import org.eclipse.jkube.kit.build.service.docker.watch.WatchContext;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
-import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 import org.eclipse.jkube.kit.profile.ProfileUtil;
@@ -35,9 +34,9 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
-import java.util.Optional;
 
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestamp;
+import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil.applicableNamespace;
 
 public class KubernetesWatchTask extends AbstractJKubeTask {
   @Inject
@@ -65,10 +64,7 @@ public class KubernetesWatchTask extends AbstractJKubeTask {
         WatcherContext context = createWatcherContext();
 
         WatcherManager.watch(resolvedImages,
-            Optional.ofNullable(kubernetesExtension.getNamespaceOrNull())
-                .orElse(Optional.ofNullable(kubernetesExtension.resources)
-                    .map(ResourceConfig::getNamespace)
-                    .orElse(clusterAccess.getNamespace())),
+            applicableNamespace(null, kubernetesExtension.getNamespaceOrNull(), kubernetesExtension.resources, clusterAccess),
             resources,
             context);
       } catch (KubernetesClientException kubernetesClientException) {

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTaskTest.java
@@ -32,8 +32,6 @@ import org.mockito.MockedConstruction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.times;
@@ -93,11 +91,10 @@ public class KubernetesUndeployTaskTest {
     assertThat(kubernetesUndeployServiceMockedConstruction.constructed()).hasSize(1);
     verify(kubernetesUndeployServiceMockedConstruction.constructed().iterator().next(), times(1))
       .undeploy(
-            isNull(),
-            eq(taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
-                .toFile()),
-            eq(ResourceConfig.builder().build()), eq(taskEnvironment.getRoot().toPath()
-                .resolve(Paths.get("build", "classes", "java", "main", "META-INF", "jkube", "kubernetes.yml")).toFile())
+            taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
+                .toFile(),
+            ResourceConfig.builder().build(), taskEnvironment.getRoot().toPath()
+                .resolve(Paths.get("build", "classes", "java", "main", "META-INF", "jkube", "kubernetes.yml")).toFile()
       );
   }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTaskTest.java
@@ -35,6 +35,7 @@ import java.net.URL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -103,6 +104,6 @@ public class KubernetesWatchTaskTest {
     // Then
     AssertionsForClassTypes.assertThat(watchTask.jKubeServiceHub.getBuildService()).isNotNull()
         .isInstanceOf(DockerBuildService.class);
-    watcherManagerMockedStatic.verify(() -> WatcherManager.watch(any(), any(), any()), times(1));
+    watcherManagerMockedStatic.verify(() -> WatcherManager.watch(any(), isNull(), any(), any()), times(1));
   }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTaskTest.java
@@ -19,6 +19,7 @@ import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.gradle.plugin.TestKubernetesExtension;
 import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
 import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
+import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.service.kubernetes.DockerBuildService;
 import org.eclipse.jkube.watcher.api.WatcherManager;
@@ -51,6 +52,7 @@ public class KubernetesWatchTaskTest {
   private MockedConstruction<DockerBuildService> dockerBuildServiceMockedConstruction;
   private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
   private MockedStatic<WatcherManager> watcherManagerMockedStatic;
+  private MockedStatic<KubernetesHelper> kubernetesHelperMockedStatic;
   private TestKubernetesExtension extension;
 
   @Before
@@ -67,14 +69,17 @@ public class KubernetesWatchTaskTest {
       when(mock.createDefaultClient()).thenReturn(kubernetesClient);
     });
     watcherManagerMockedStatic = mockStatic(WatcherManager.class);
+    kubernetesHelperMockedStatic = mockStatic(KubernetesHelper.class);
     extension = new TestKubernetesExtension();
     when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
+    kubernetesHelperMockedStatic.when(KubernetesHelper::getDefaultNamespace).thenReturn(null);
     extension.isFailOnNoKubernetesJson = false;
   }
 
   @After
   public void tearDown() {
     watcherManagerMockedStatic.close();
+    kubernetesHelperMockedStatic.close();
     clusterAccessMockedConstruction.close();
     dockerBuildServiceMockedConstruction.close();
     dockerAccessFactoryMockedConstruction.close();

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftUndeployTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftUndeployTaskTest.java
@@ -31,8 +31,6 @@ import org.mockito.MockedConstruction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.times;
@@ -93,12 +91,11 @@ public class OpenShiftUndeployTaskTest {
     assertThat(openshiftUndeployServiceMockedConstruction.constructed()).hasSize(1);
     verify(openshiftUndeployServiceMockedConstruction.constructed().iterator().next(), times(1))
       .undeploy(
-            isNull(),
-            eq(taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
-                .toFile()),
-            eq(ResourceConfig.builder().build()), eq(taskEnvironment.getRoot().toPath()
-                .resolve(Paths.get("build", "classes", "java", "main", "META-INF", "jkube", "openshift.yml")).toFile()),
-            eq(taskEnvironment.getRoot().toPath().resolve(Paths.get("build", "test-project-is.yml")).toFile())
+            taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
+                .toFile(),
+            ResourceConfig.builder().build(), taskEnvironment.getRoot().toPath()
+                .resolve(Paths.get("build", "classes", "java", "main", "META-INF", "jkube", "openshift.yml")).toFile(),
+            taskEnvironment.getRoot().toPath().resolve(Paths.get("build", "test-project-is.yml")).toFile()
       );
   }
 }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTaskTest.java
@@ -31,6 +31,7 @@ import java.net.URL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -85,6 +86,6 @@ public class OpenShiftWatchTaskTest {
     // When
     watchTask.runTask();
     // Then
-    watcherManagerMockedStatic.verify(() -> WatcherManager.watch(any(), any(), any()), times(1));
+    watcherManagerMockedStatic.verify(() -> WatcherManager.watch(any(), isNull(), any(), any()), times(1));
   }
 }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTaskTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.gradle.plugin.task;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
 import org.eclipse.jkube.gradle.plugin.TestOpenShiftExtension;
+import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.watcher.api.WatcherManager;
 import org.junit.After;
@@ -45,6 +46,7 @@ public class OpenShiftWatchTaskTest {
 
   private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
   private MockedStatic<WatcherManager> watcherManagerMockedStatic;
+  private MockedStatic<KubernetesHelper> kubernetesHelperMockedStatic;
   private TestOpenShiftExtension extension;
 
   @Before
@@ -55,8 +57,10 @@ public class OpenShiftWatchTaskTest {
       when(mock.createDefaultClient()).thenReturn(openShiftClient);
     });
     watcherManagerMockedStatic = mockStatic(WatcherManager.class);
+    kubernetesHelperMockedStatic = mockStatic(KubernetesHelper.class);
     extension = new TestOpenShiftExtension();
     when(taskEnvironment.project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(extension);
+    kubernetesHelperMockedStatic.when(KubernetesHelper::getDefaultNamespace).thenReturn(null);
     extension.isFailOnNoKubernetesJson = false;
   }
 
@@ -64,6 +68,7 @@ public class OpenShiftWatchTaskTest {
   public void tearDown() {
     watcherManagerMockedStatic.close();
     clusterAccessMockedConstruction.close();
+    kubernetesHelperMockedStatic.close();
   }
 
   @Test

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -735,12 +735,11 @@ public class KubernetesHelper {
         return expose != null && expose.equalsIgnoreCase("true");
     }
 
-    public static String getServiceExposeUrl(KubernetesClient kubernetes, Collection<HasMetadata> resources, long serviceUrlWaitTimeSeconds, String exposeServiceAnnotationKey) throws InterruptedException {
+    public static String getServiceExposeUrl(KubernetesClient kubernetes, String namespace, Collection<HasMetadata> resources, long serviceUrlWaitTimeSeconds, String exposeServiceAnnotationKey) throws InterruptedException {
         for (HasMetadata entity : resources) {
             if (entity instanceof Service) {
                 Service service = (Service) entity;
                 String name = KubernetesHelper.getName(service);
-                String namespace = kubernetes.getNamespace();
                 Resource<Service> serviceResource = kubernetes.services().inNamespace(namespace).withName(name);
                 String url = pollServiceForExposeUrl(serviceUrlWaitTimeSeconds, service, serviceResource, exposeServiceAnnotationKey);
 

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -282,7 +282,7 @@ public class KubernetesHelperTest {
         Set<HasMetadata> entities = new HashSet<>();
         entities.add(svc);
         new Expectations() {{
-            kubernetesClient.services().inNamespace(anyString).withName("svc1");
+            kubernetesClient.services().inNamespace("ns1").withName("svc1");
             result = svcResource;
             svcResource.get();
             result = new ServiceBuilder()
@@ -294,12 +294,12 @@ public class KubernetesHelperTest {
         }};
 
         // When
-        String result = KubernetesHelper.getServiceExposeUrl(kubernetesClient, entities, 3, "exposeUrl");
+        String result = KubernetesHelper.getServiceExposeUrl(kubernetesClient, "ns1", entities, 3, "exposeUrl");
 
         // Then
         assertEquals("http://example.com", result);
         new Verifications() {{
-            kubernetesClient.services().inNamespace(anyString).withName("svc1");
+            kubernetesClient.services().inNamespace("ns1").withName("svc1");
             times = 1;
             svcResource.get();
             times = 1;
@@ -313,7 +313,7 @@ public class KubernetesHelperTest {
         Set<HasMetadata> entities = new HashSet<>();
         entities.add(svc);
         new Expectations() {{
-            kubernetesClient.services().inNamespace(anyString).withName("svc1");
+            kubernetesClient.services().inNamespace("ns1").withName("svc1");
             result = svcResource;
             svcResource.get();
             result = new ServiceBuilder()
@@ -324,12 +324,12 @@ public class KubernetesHelperTest {
         }};
 
         // When
-        String result = KubernetesHelper.getServiceExposeUrl(kubernetesClient, entities, 1, "exposeUrl");
+        String result = KubernetesHelper.getServiceExposeUrl(kubernetesClient, "ns1", entities, 1, "exposeUrl");
 
         // Then
         assertNull(result);
         new Verifications() {{
-            kubernetesClient.services().inNamespace(anyString).withName("svc1");
+            kubernetesClient.services().inNamespace("ns1").withName("svc1");
             times = 1;
             svcResource.get();
             times = 1;

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
@@ -1358,7 +1358,7 @@ public class ApplyService {
     }
 
     private void logExposeServiceUrl(Collection<HasMetadata> entities, KitLogger serviceLogger, long serviceUrlWaitTimeSeconds) throws InterruptedException {
-        String url = KubernetesHelper.getServiceExposeUrl(kubernetesClient, entities, serviceUrlWaitTimeSeconds, JKubeAnnotations.SERVICE_EXPOSE_URL.value());
+        String url = KubernetesHelper.getServiceExposeUrl(kubernetesClient, namespace, entities, serviceUrlWaitTimeSeconds, JKubeAnnotations.SERVICE_EXPOSE_URL.value());
         if (url != null) {
             serviceLogger.info("ExposeController Service URL: %s", url);
         }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/UndeployService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/UndeployService.java
@@ -20,5 +20,5 @@ import java.io.IOException;
 
 public interface UndeployService {
 
-  void undeploy(String fallbackNamespace, File resourceDir, ResourceConfig resourceConfig, File... manifestFiles) throws IOException;
+  void undeploy(File resourceDir, ResourceConfig resourceConfig, File... manifestFiles) throws IOException;
 }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
@@ -50,7 +50,8 @@ public class KubernetesUndeployService implements UndeployService {
   }
 
   @Override
-  public void undeploy(String fallbackNamespace, File resourceDir, ResourceConfig resourceConfig, File... manifestFiles) throws IOException {
+  public void undeploy(File resourceDir, ResourceConfig resourceConfig, File... manifestFiles) throws IOException {
+    final String fallbackNamespace = KubernetesClientUtil.resolveFallbackNamespace(resourceConfig, jKubeServiceHub.getClusterAccess());
     final List<File> manifests = Stream.of(manifestFiles)
         .filter(Objects::nonNull).filter(File::exists).filter(File::isFile)
         .collect(Collectors.toList());

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServiceTest.java
@@ -65,15 +65,15 @@ public class PortForwardServiceTest {
                 .endMetadata()
                 .build();
 
-        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods?labelSelector=mykey%3Dmyvalue").andReturn(200, pods1).always();
-        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods").andReturn(200, pods1).always();
-        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods?labelSelector=mykey%3Dmyvalue&watch=true")
+        mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods?labelSelector=mykey%3Dmyvalue").andReturn(200, pods1).always();
+        mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods").andReturn(200, pods1).always();
+        mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods?labelSelector=mykey%3Dmyvalue&watch=true")
                 .andUpgradeToWebSocket().open()
                 .waitFor(1000)
                 .andEmit(new WatchEvent(pod1, "MODIFIED"))
                 .done().always();
 
-        mockServer.expect().get().withPath("/api/v1/namespaces/test/pods?resourceVersion=1&watch=true")
+        mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods?resourceVersion=1&watch=true")
                 .andUpgradeToWebSocket().open()
                 .waitFor(1000)
                 .andEmit(new WatchEvent(pod1, "MODIFIED"))
@@ -87,7 +87,7 @@ public class PortForwardServiceTest {
             }
         };
 
-        try (Closeable c = service.forwardPortAsync(new LabelSelectorBuilder().withMatchLabels(Collections.singletonMap("mykey", "myvalue")).build(), 8080, 9000)) {
+        try (Closeable c = service.forwardPortAsync(new LabelSelectorBuilder().withMatchLabels(Collections.singletonMap("mykey", "myvalue")).build(), "ns1", 8080, 9000)) {
             Thread.sleep(3000);
         }
     }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesClientUtilTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesClientUtilTest.java
@@ -15,12 +15,20 @@ package org.eclipse.jkube.kit.config.service.kubernetes;
 
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import mockit.Mocked;
 import mockit.Verifications;
+import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil.doDeleteAndWait;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KubernetesClientUtilTest {
 
@@ -43,6 +51,82 @@ public class KubernetesClientUtilTest {
       kubernetesClient.genericKubernetesResources("org.eclipse.jkube/v1beta1", "JKubeCustomResource").inNamespace("namespace").withName("name").delete(); times = 1;
     }};
     // @formatter:on
+  }
+
+  @Test
+  public void applicableNamespace_whenNamespaceProvidedViaConfiguration_shouldReturnProvidedNamespace() {
+    // Given
+    String namespaceViaPluginConfigOrJkubeNamespaceProperty = "ns1";
+
+    // When
+    String resolvedNamespace = KubernetesClientUtil.applicableNamespace(null, namespaceViaPluginConfigOrJkubeNamespaceProperty, null);
+
+    // Then
+    assertThat(resolvedNamespace).isEqualTo(namespaceViaPluginConfigOrJkubeNamespaceProperty);
+  }
+
+  @Test
+  public void applicableNamespace_whenNamespaceInResourceMetadata_shouldReturnProvidedNamespace() {
+    // Given
+    Pod pod = new PodBuilder()
+        .withNewMetadata().withNamespace("test").endMetadata()
+        .build();
+
+    // When
+    String resolvedNamespace = KubernetesClientUtil.applicableNamespace(pod, null, null);
+
+    // Then
+    assertThat(resolvedNamespace).isEqualTo("test");
+  }
+
+  @Test
+  public void applicableNamespace_whenNamespaceProvidedViaClusterAccess_shouldReturnProvidedNamespace() {
+    // Given
+    ClusterAccess mockedClusterAccess = mock(ClusterAccess.class, RETURNS_DEEP_STUBS);
+    when(mockedClusterAccess.getNamespace()).thenReturn("ns1");
+
+    // When
+    String resolvedNamespace = KubernetesClientUtil.applicableNamespace(null, null, null, mockedClusterAccess);
+
+    // Then
+    assertThat(resolvedNamespace).isEqualTo("ns1");
+  }
+
+  @Test
+  public void applicableNamespace_whenNamespaceProvidedViaResourceConfiguration_shouldReturnProvidedNamespace() {
+    // Given
+    ResourceConfig resourceConfig = ResourceConfig.builder().namespace("ns1").build();
+
+    // When
+    String resolvedNamespace = KubernetesClientUtil.applicableNamespace(null, null, resourceConfig, null);
+
+    // Then
+    assertThat(resolvedNamespace).isEqualTo("ns1");
+  }
+
+  @Test
+  public void resolveFallbackNamespace_whenNamespaceProvidedViaResourceConfiguration_shouldReturnProvidedNamespace() {
+    // Given
+    ResourceConfig resourceConfig = ResourceConfig.builder().namespace("ns1").build();
+
+    // When
+    String resolvedNamespace = KubernetesClientUtil.resolveFallbackNamespace(resourceConfig, null);
+
+    // Then
+    assertThat(resolvedNamespace).isEqualTo(resourceConfig.getNamespace());
+  }
+
+  @Test
+  public void resolveFallbackNamespace_whenNamespaceProvidedViaClusterAccess_shouldReturnProvidedNamespace() {
+    // Given
+    ClusterAccess mockedClusterAccess = mock(ClusterAccess.class, RETURNS_DEEP_STUBS);
+    when(mockedClusterAccess.getNamespace()).thenReturn("ns1");
+
+    // When
+    String resolvedNamespace = KubernetesClientUtil.resolveFallbackNamespace(null, mockedClusterAccess);
+
+    // Then
+    assertThat(resolvedNamespace).isEqualTo("ns1");
   }
 
 }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
@@ -66,7 +66,7 @@ public class KubernetesUndeployServiceTest {
     // Given
     final File nonexistent = new File("I don't exist");
     // When
-    kubernetesUndeployService.undeploy(null, null, ResourceConfig.builder().build(), nonexistent, null);
+    kubernetesUndeployService.undeploy(null, ResourceConfig.builder().build(), nonexistent, null);
     // Then
     // @formatter:off
     new Verifications() {{
@@ -90,7 +90,7 @@ public class KubernetesUndeployServiceTest {
     }};
     // @formatter:on
     // When
-    kubernetesUndeployService.undeploy(null, null, resourceConfig, file);
+    kubernetesUndeployService.undeploy(null, resourceConfig, file);
     // Then
     // @formatter:off
     new Verifications() {{
@@ -136,7 +136,7 @@ public class KubernetesUndeployServiceTest {
     }};
     // @formatter:on
     // When
-    kubernetesUndeployService.undeploy(null, null, resourceConfig, manifest);
+    kubernetesUndeployService.undeploy(null, resourceConfig, manifest);
     // Then
     // @formatter:off
     new Verifications() {{
@@ -160,10 +160,11 @@ public class KubernetesUndeployServiceTest {
       kubernetesHelper.loadResources(file); result = Arrays.asList(configMap, pod, service);
       kubernetesHelper.getNamespace(configMap); result = "ns1";
       kubernetesHelper.getNamespace(pod); result = "ns2";
+      KubernetesHelper.getDefaultNamespace(); result = "default";
     }};
     // @formatter:on
     // When
-    kubernetesUndeployService.undeploy("default", null, resourceConfig, file);
+    kubernetesUndeployService.undeploy(null, resourceConfig, file);
     // Then
     // @formatter:off
     new Verifications() {{

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftUndeployServiceTest.java
@@ -16,7 +16,6 @@ package org.eclipse.jkube.kit.config.service.openshift;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
@@ -131,7 +130,7 @@ public class OpenshiftUndeployServiceTest {
     }};
     // @formatter:on
     // When
-    openshiftUndeployService.undeploy(null, null, ResourceConfig.builder().build(), temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null, ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(1);
     assertDeleted(entity);
@@ -143,7 +142,7 @@ public class OpenshiftUndeployServiceTest {
     final Pod entity = new Pod();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(1);
     assertDeleted(entity);
@@ -158,7 +157,7 @@ public class OpenshiftUndeployServiceTest {
         .build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(1);
     assertDeleted(entity);
@@ -180,7 +179,7 @@ public class OpenshiftUndeployServiceTest {
         .build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(3);
     assertDeleted(entity);
@@ -214,7 +213,7 @@ public class OpenshiftUndeployServiceTest {
         .endSpec().build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(3);
     assertDeleted(entity);
@@ -249,7 +248,7 @@ public class OpenshiftUndeployServiceTest {
         .endSpec().build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(1);
     assertDeleted(entity);
@@ -284,7 +283,7 @@ public class OpenshiftUndeployServiceTest {
         .endSpec().build();
     withLoadedEntities(entity);
     // When
-    openshiftUndeployService.undeploy(null, null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
+    openshiftUndeployService.undeploy(null,  ResourceConfig.builder().build(), temporaryFolder.newFile());
     // Then
     assertDeleteCount(2);
     assertDeleted(entity);

--- a/jkube-kit/enricher/api/pom.xml
+++ b/jkube-kit/enricher/api/pom.xml
@@ -59,5 +59,9 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcherTest.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcherTest.java
@@ -105,12 +105,12 @@ public class SpringBootWatcherTest {
         SpringBootWatcher springBootWatcher = new SpringBootWatcher(watcherContext);
 
         // When
-        String portForwardUrl = springBootWatcher.getPortForwardUrl(resources);
+        String portForwardUrl = springBootWatcher.getPortForwardUrl("ns1", resources);
 
         // Then
         assertTrue(portForwardUrl.contains("http://localhost:"));
         new Verifications() {{
-            portForwardService.forwardPortAsync((LabelSelector) any, 9001, anyInt);
+            portForwardService.forwardPortAsync((LabelSelector) any, "ns1", 9001, anyInt);
         }};
     }
 

--- a/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/Watcher.java
+++ b/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/Watcher.java
@@ -38,7 +38,11 @@ public interface Watcher extends Named {
      * Watch the resources and kick a rebuild when they change.
      *
      * @param configs all image configurations
+     * @param namespace namespace in which resources are deployed
+     * @param resources list of resources applied
+     * @param mode {@link PlatformMode}
+     * @throws Exception in case of any failure
      */
-    void watch(List<ImageConfiguration> configs, Collection<HasMetadata> resources, PlatformMode mode) throws Exception;
+    void watch(List<ImageConfiguration> configs, String namespace, Collection<HasMetadata> resources, PlatformMode mode) throws Exception;
 
 }

--- a/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherManager.java
+++ b/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherManager.java
@@ -38,7 +38,7 @@ public class WatcherManager {
   private WatcherManager() {
   }
 
-  public static void watch(List<ImageConfiguration> ret, Collection<HasMetadata> resources, WatcherContext watcherCtx)
+  public static void watch(List<ImageConfiguration> ret, String namespace, Collection<HasMetadata> resources, WatcherContext watcherCtx)
       throws Exception {
 
     final PluginServiceFactory<WatcherContext> pluginFactory = new PluginServiceFactory<>(watcherCtx);
@@ -73,6 +73,6 @@ public class WatcherManager {
     }
 
     log.info("Running watcher %s", chosen.getName());
-    chosen.watch(ret, resources, mode);
+    chosen.watch(ret, namespace, resources, mode);
   }
 }

--- a/jkube-kit/watcher/api/src/test/java/org/eclipse/jkube/watcher/api/WatcherManagerTest.java
+++ b/jkube-kit/watcher/api/src/test/java/org/eclipse/jkube/watcher/api/WatcherManagerTest.java
@@ -63,7 +63,7 @@ public class WatcherManagerTest {
     // Given
     final List<ImageConfiguration> images = Collections.singletonList(new ImageConfiguration());
     // When
-    WatcherManager.watch(images, Collections.emptyList(), watcherContext);
+    WatcherManager.watch(images, null, Collections.emptyList(), watcherContext);
     // Then
     assertThat(images)
         .hasSize(1)
@@ -93,7 +93,7 @@ public class WatcherManagerTest {
     }
 
     @Override
-    public void watch(List<ImageConfiguration> configs, Collection<HasMetadata> resources, PlatformMode mode) {
+    public void watch(List<ImageConfiguration> configs, String namespace, Collection<HasMetadata> resources, PlatformMode mode) {
       configs.forEach(ic -> ic.setName("processed-by-test"));
     }
   }

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
@@ -74,7 +74,7 @@ public class DockerImageWatcher extends BaseWatcher {
     }
 
     @Override
-    public void watch(List<ImageConfiguration> configs, final Collection<HasMetadata> resources, PlatformMode mode) {
+    public void watch(List<ImageConfiguration> configs, String namespace, final Collection<HasMetadata> resources, PlatformMode mode) {
 
         WatchContext watchContext = getContext().getWatchContext();
 

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
@@ -72,7 +72,7 @@ public class DockerImageWatcherTest {
   @Test
   public void watchShouldInitWatchContext() {
     // When
-    dockerImageWatcher.watch(null, null, null);
+    dockerImageWatcher.watch(null, null, null, null);
     // Then
     assertThat(watchContext)
         .isNotNull()
@@ -83,7 +83,7 @@ public class DockerImageWatcherTest {
   @Test
   public void watchExecuteCommandInPodTask(@Mocked PodExecutor podExecutor) throws Exception {
     // Given
-    dockerImageWatcher.watch(null, null, null);
+    dockerImageWatcher.watch(null, null, null, null);
     final ExecTask execTask = watchContext.getContainerCommandExecutor();
     // When
     execTask.exec("the command");
@@ -100,7 +100,7 @@ public class DockerImageWatcherTest {
   @Test
   public void watchCopyFileToPod(@Mocked PodExecutor podExecutor) throws Exception {
     // Given
-    dockerImageWatcher.watch(null, null, null);
+    dockerImageWatcher.watch(null, null, null, null);
     final CopyFilesTask copyFilesTask = watchContext.getContainerCopyTask();
     // When
     copyFilesTask.copy(null);

--- a/kubernetes-maven-plugin/plugin/pom.xml
+++ b/kubernetes-maven-plugin/plugin/pom.xml
@@ -157,6 +157,10 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
@@ -182,7 +182,10 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
             }
             KubernetesResourceUtil.validateKubernetesMasterUrl(masterUrl);
             List<HasMetadata> entities = KubernetesHelper.loadResources(manifest);
-            log.info("Using %s at %s in namespace %s with manifest %s ", clusterKind, masterUrl, clusterAccess.getNamespace(), manifest);
+            log.info("Using %s at %s in namespace %s with manifest %s ", clusterKind, masterUrl, Optional.ofNullable(namespace)
+                .orElse(Optional.ofNullable(resources)
+                    .map(ResourceConfig::getNamespace)
+                    .orElse(clusterAccess.getNamespace())), manifest);
 
             configureApplyService(kubernetes);
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
@@ -93,10 +93,8 @@ public class UndeployMojo extends AbstractJKubeMojo implements ManifestProvider 
 
   protected void undeploy() throws IOException {
     final File environmentResourceDir = ResourceUtil.getFinalResourceDir(resourceDir, environment);
-    final String fallbackNamespace = Optional.ofNullable(resources)
-            .map(ResourceConfig::getNamespace).orElse(clusterAccess.getNamespace());
     jkubeServiceHub.getUndeployService()
-        .undeploy(fallbackNamespace, environmentResourceDir, resources, getManifestsToUndeploy().toArray(new File[0]));
+        .undeploy(environmentResourceDir, resources, getManifestsToUndeploy().toArray(new File[0]));
   }
 
   protected List<File> getManifestsToUndeploy() {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
-import java.util.Optional;
 
 import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.generator.api.GeneratorMode;
@@ -30,7 +29,6 @@ import org.eclipse.jkube.kit.common.util.MavenUtil;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
-import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 import org.eclipse.jkube.kit.profile.ProfileUtil;
 import org.eclipse.jkube.maven.plugin.mojo.ManifestProvider;
@@ -52,6 +50,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.eclipse.jkube.watcher.api.WatcherManager;
 
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestamp;
+import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil.applicableNamespace;
 import static org.eclipse.jkube.maven.plugin.mojo.build.ApplyMojo.DEFAULT_KUBERNETES_MANIFEST;
 
 
@@ -108,10 +107,7 @@ public class WatchMojo extends AbstractDockerMojo implements ManifestProvider {
             WatcherContext context = getWatcherContext();
 
             WatcherManager.watch(getResolvedImages(),
-                Optional.ofNullable(namespace)
-                    .orElse(Optional.ofNullable(resources)
-                        .map(ResourceConfig::getNamespace)
-                        .orElse(clusterAccess.getNamespace())),
+                applicableNamespace(null, namespace, resources, clusterAccess),
                 appliedK8sResources,
                 context);
 

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojoTest.java
@@ -36,7 +36,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.runners.statements.ExpectException;
 import org.junit.rules.TemporaryFolder;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojoTest.java
@@ -95,7 +95,7 @@ public class UndeployMojoTest {
   private void assertUndeployServiceUndeployWasCalled() throws Exception {
     // @formatter:off
     new Verifications() {{
-      jKubeServiceHub.getUndeployService().undeploy(null, mockResourceDir, withNotNull(), mockManifest);
+      jKubeServiceHub.getUndeployService().undeploy(mockResourceDir, withNotNull(), mockManifest);
       times = 1;
     }};
     // @formatter:on

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojoTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.maven.plugin.mojo.develop;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
+import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
+import org.eclipse.jkube.kit.build.service.docker.config.handler.ImageConfigResolver;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
+import org.eclipse.jkube.kit.config.service.ApplyService;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+import org.eclipse.jkube.watcher.api.WatcherManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Properties;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+public class WatchMojoTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private File kubernetesManifestFile;
+
+  private KitLogger logger;
+  private JKubeServiceHub mockedJKubeServiceHub;
+  private ClusterAccess mockedClusterAccess;
+  private MavenProject mavenProject;
+  private JavaProject mockedJavaProject;
+  private Settings mavenSettings;
+  private DefaultKubernetesClient defaultKubernetesClient;
+  private ImageConfigResolver mockedImageConfigResolver;
+  private DockerAccessFactory mockedDockerAccessFactory;
+  private MockedStatic<WatcherManager> watcherManagerMockedStatic;
+
+  private WatchMojo watchMojo;
+
+  @Before
+  public void setUp() throws IOException {
+    kubernetesManifestFile = temporaryFolder.newFile("kubernetes.yml");
+    logger = mock(KitLogger.class);
+    mockedJKubeServiceHub = mock(JKubeServiceHub.class);
+    mavenProject = mock(MavenProject.class);
+    mavenSettings = mock(Settings.class);
+    mockedImageConfigResolver = mock(ImageConfigResolver.class);
+    defaultKubernetesClient = mock(DefaultKubernetesClient.class);
+    mockedDockerAccessFactory = mock(DockerAccessFactory.class);
+    mockedJavaProject = mock(JavaProject.class);
+    mockedClusterAccess = mock(ClusterAccess.class);
+    watcherManagerMockedStatic = mockStatic(WatcherManager.class);
+
+    when(mockedJKubeServiceHub.getApplyService()).thenReturn(new ApplyService(defaultKubernetesClient, logger));
+    when(mockedJavaProject.getProperties()).thenReturn(new Properties());
+    when(mavenProject.getArtifactId()).thenReturn("artifact-id");
+    when(mavenProject.getVersion()).thenReturn("1337");
+    when(mavenProject.getDescription()).thenReturn("A description from Maven");
+    when(mavenProject.getParent()).thenReturn(null);
+    when(defaultKubernetesClient.isAdaptable(OpenShiftClient.class)).thenReturn(false);
+    when(defaultKubernetesClient.getMasterUrl()).thenReturn(URI.create("https://www.example.com").toURL());
+    when(mockedClusterAccess.getNamespace()).thenReturn("namespace-from-config");
+  }
+
+  @After
+  public void tearDown() {
+    mavenProject = null;
+    watchMojo = null;
+    watcherManagerMockedStatic.close();
+  }
+
+  @Test
+  public void executeInternal_whenNoNamespaceConfigured_shouldDelegateToWatcherManagerWithClusterAccessNamespace() throws MojoExecutionException {
+    // Given
+    watchMojo = new WatchMojo() { {
+      project = mavenProject;
+      settings = mavenSettings;
+      kubernetesManifest = kubernetesManifestFile;
+      imageConfigResolver = mockedImageConfigResolver;
+      dockerAccessFactory = mockedDockerAccessFactory;
+      kubernetesClient = defaultKubernetesClient;
+      javaProject = mockedJavaProject;
+      jkubeServiceHub = mockedJKubeServiceHub;
+      clusterAccess = mockedClusterAccess;
+    }};
+
+    // When
+    watchMojo.executeInternal();
+
+    // Then
+    watcherManagerMockedStatic.verify(() -> WatcherManager.watch(any(), eq("namespace-from-config"), any(), any()), times(1));
+  }
+
+  @Test
+  public void executeInternal_whenNamespaceConfiguredInResourceConfig_shouldDelegateToWatcherManagerWithClusterAccessNamespace() throws MojoExecutionException {
+    // Given
+    ResourceConfig mockedResourceConfig = mock(ResourceConfig.class);
+    when(mockedResourceConfig.getNamespace()).thenReturn("namespace-from-resourceconfig");
+    watchMojo = new WatchMojo() { {
+      project = mavenProject;
+      settings = mavenSettings;
+      kubernetesManifest = kubernetesManifestFile;
+      imageConfigResolver = mockedImageConfigResolver;
+      dockerAccessFactory = mockedDockerAccessFactory;
+      kubernetesClient = defaultKubernetesClient;
+      javaProject = mockedJavaProject;
+      jkubeServiceHub = mockedJKubeServiceHub;
+      clusterAccess = mockedClusterAccess;
+      resources = mockedResourceConfig;
+    }};
+
+    // When
+    watchMojo.executeInternal();
+
+    // Then
+    watcherManagerMockedStatic.verify(() -> WatcherManager.watch(any(), eq("namespace-from-resourceconfig"), any(), any()), times(1));
+  }
+
+  @Test
+  public void executeInternal_whenNamespaceConfigured_shouldDelegateToWatcherManagerWithClusterAccessNamespace() throws MojoExecutionException {
+    // Given
+    watchMojo = new WatchMojo() { {
+      project = mavenProject;
+      settings = mavenSettings;
+      kubernetesManifest = kubernetesManifestFile;
+      imageConfigResolver = mockedImageConfigResolver;
+      dockerAccessFactory = mockedDockerAccessFactory;
+      kubernetesClient = defaultKubernetesClient;
+      javaProject = mockedJavaProject;
+      jkubeServiceHub = mockedJKubeServiceHub;
+      clusterAccess = mockedClusterAccess;
+      namespace = "configured-namespace";
+    }};
+
+    // When
+    watchMojo.executeInternal();
+
+    // Then
+    watcherManagerMockedStatic.verify(() -> WatcherManager.watch(any(), eq("configured-namespace"), any(), any()), times(1));
+  }
+}

--- a/kubernetes-maven-plugin/plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/kubernetes-maven-plugin/plugin/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Description
Fix #1180

No namespace is specified to Watcher while delegating watch task from
Mojos/Tasks to JKube Kit. Right now Watcher was just picking namespace
from `clusterAccess.getNamespace()` (namespace provided in current
context in `.kube/config`).

Add an additional namespace parameter in Watcher.watch(...) method for
providing configured namespace.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->