### PR TITLE
Fix #1190: OpenShiftBuildService doesn't apply resources in configured namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Usage:
 * Fix #1148: Enable MicronautGenerator with Kubernetes Gradle Plugin
 * Fix #1167: Replace apiextensions.k8s.io/v1beta1 by apiextensions.k8s.io/v1
 * Fix #1180: `k8s:watch` uses default namespace even if other namespace is configured
-
+* Fix #1190: OpenShiftBuildService doesn't apply resources in configured namespace
 
 ### 1.5.1 (2021-10-28)
 * Fix #1084: Gradle dependencies should be test or provided scope

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -47,6 +47,7 @@ import org.gradle.api.tasks.TaskAction;
 
 import static org.eclipse.jkube.kit.build.service.docker.helper.ConfigHelper.initImageConfiguration;
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestamp;
+import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil.updateResourceConfigNamespace;
 
 public abstract class AbstractJKubeTask extends DefaultTask implements KubernetesJKubeTask {
 
@@ -80,6 +81,7 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
         kubernetesExtension.getLogDateOrNull());
     clusterAccess = new ClusterAccess(kitLogger, initClusterConfiguration());
     jKubeServiceHub = initJKubeServiceHubBuilder().build();
+    kubernetesExtension.resources = updateResourceConfigNamespace(kubernetesExtension.getNamespaceOrNull(), kubernetesExtension.resources);
     ImageConfigResolver imageConfigResolver = new ImageConfigResolver();
     try {
       resolvedImages = resolveImages(imageConfigResolver);

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesClientUtil.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesClientUtil.java
@@ -194,4 +194,17 @@ public class KubernetesClientUtil {
                 .map(ClusterAccess::getNamespace)
                 .orElse(null));
     }
+
+    public static ResourceConfig updateResourceConfigNamespace(String namespaceProvidedViaProperty, ResourceConfig resourceConfig) {
+        String resolvedNamespace = Optional.ofNullable(namespaceProvidedViaProperty)
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .orElse(null);
+        if (resourceConfig == null) {
+            resourceConfig = ResourceConfig.builder().namespace(resolvedNamespace).build();
+        } else if (resolvedNamespace != null) {
+            resourceConfig = ResourceConfig.toBuilder(resourceConfig).namespace(resolvedNamespace).build();
+        }
+        return resourceConfig;
+    }
 }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamService.java
@@ -56,10 +56,12 @@ public class ImageStreamService {
     private static final long IMAGE_STREAM_TAG_RETRY_TIMEOUT_IN_MILLIS = 1000;
 
     private final OpenShiftClient client;
+    private final String namespace;
     private final KitLogger log;
 
-    public ImageStreamService(OpenShiftClient client, KitLogger log) {
+    public ImageStreamService(OpenShiftClient client, String namespace, KitLogger log) {
         this.client = client;
+        this.namespace = namespace;
         this.log = log;
     }
 
@@ -120,8 +122,7 @@ public class ImageStreamService {
     }
 
     private void createOrUpdateImageStreamTag(OpenShiftClient client, ImageName image, ImageStream is) {
-        String namespace = client.getNamespace();
-        String tagSha = findTagSha(client, resolveImageStreamName(image), client.getNamespace());
+        String tagSha = findTagSha(client, resolveImageStreamName(image), namespace);
         String name = resolveImageStreamName(image) + "@" + tagSha;
 
         TagReference tag = extractTag(is);
@@ -184,7 +185,7 @@ public class ImageStreamService {
                     Thread.currentThread().interrupt();
                 }
             }
-            currentImageStream = client.imageStreams().withName(imageStreamName).get();
+            currentImageStream = client.imageStreams().inNamespace(namespace).withName(imageStreamName).get();
             if (currentImageStream == null) {
                 continue;
             }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamServiceTest.java
@@ -31,7 +31,6 @@ import org.yaml.snakeyaml.Yaml;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,10 +63,10 @@ public class ImageStreamServiceTest {
 
     @Test
     public void simple() throws Exception {
-        ImageStreamService service = new ImageStreamService(client, log);
+        ImageStreamService service = new ImageStreamService(client, "default", log);
 
         final ImageStream lookedUpIs = lookupImageStream("ab12cd");
-        setupClientMock(lookedUpIs,"test");
+        setupClientMock(lookedUpIs,"default", "test");
         ImageName name = new ImageName("test:1.0");
         File target = File.createTempFile("ImageStreamServiceTest",".yml");
         service.appendImageStreamResource(name, target);
@@ -96,7 +95,7 @@ public class ImageStreamServiceTest {
 
         // Add a second image stream
         ImageStream secondIs = lookupImageStream("secondIS");
-        setupClientMock(secondIs, "second-test");
+        setupClientMock(secondIs, "default", "second-test");
         ImageName name2 = new ImageName("second-test:1.0");
         service.appendImageStreamResource(name2, target);
 
@@ -124,13 +123,11 @@ public class ImageStreamServiceTest {
         return (Map<String,Object>) yaml.load(ios);
     }
 
-    private void setupClientMock(final ImageStream lookedUpIs, final String name) {
+    private void setupClientMock(final ImageStream lookedUpIs, final String namespace, final String name) {
         new Expectations() {{
             client.imageStreams(); result = imageStreamsOp;
-            imageStreamsOp.withName(name); result = resource;
+            imageStreamsOp.inNamespace(namespace).withName(name); result = resource;
             resource.get(); result = lookedUpIs;
-
-            client.getNamespace(); result = "default";
         }};
     }
 
@@ -150,7 +147,7 @@ public class ImageStreamServiceTest {
     @Test
     public void should_return_newer_tag() throws Exception {
         // GIVEN
-        ImageStreamService service = new ImageStreamService(client, log);
+        ImageStreamService service = new ImageStreamService(client, "default", log);
         TagEvent oldTag = new TagEvent("2018-03-09T03:27:05Z\n", null, null, null);
         TagEvent latestTag = new TagEvent("2018-03-09T03:28:05Z\n", null, null, null);
 
@@ -164,7 +161,7 @@ public class ImageStreamServiceTest {
     @Test
     public void should_return_first_tag() throws Exception {
         // GIVEN
-        ImageStreamService service = new ImageStreamService(client, log);
+        ImageStreamService service = new ImageStreamService(client, "default", log);
         TagEvent first = new TagEvent("2018-03-09T03:27:05Z\n", null, null, null);
         TagEvent latestTag = null;
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -92,6 +92,7 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 import static org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory.DockerAccessContext.DEFAULT_MAX_CONNECTIONS;
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestamp;
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestampFile;
+import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil.updateResourceConfigNamespace;
 import static org.eclipse.jkube.maven.plugin.mojo.build.AbstractJKubeMojo.DEFAULT_LOG_PREFIX;
 
 public abstract class AbstractDockerMojo extends AbstractMojo
@@ -379,6 +380,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo
     protected String containerNamePattern = ContainerNamingUtil.DEFAULT_CONTAINER_NAME_PATTERN;
 
     /**
+     * Namespace to use when accessing Kubernetes or OpenShift
+     */
+    @Parameter(property = "jkube.namespace")
+    protected String namespace;
+
+    /**
      * Whether to create the customs networks (user-defined bridge networks) before starting automatically
      */
     @Parameter(property = "jkube.watch.autoCreateCustomNetworks", defaultValue = "false")
@@ -425,6 +432,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo
                 DockerAccess dockerAccess = null;
                 try {
                     javaProject = MavenUtil.convertMavenProjectToJKubeProject(project, session);
+                    resources = updateResourceConfigNamespace(namespace, resources);
                     // The 'real' images configuration to use (configured images + externally resolved images)
                     if (isDockerAccessRequired()) {
                         DockerAccessFactory.DockerAccessContext dockerAccessContext = getDockerAccessContext();

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractJKubeMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractJKubeMojo.java
@@ -43,6 +43,8 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 import java.util.Collections;
 import java.util.Optional;
 
+import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil.updateResourceConfigNamespace;
+
 public abstract class AbstractJKubeMojo extends AbstractMojo implements KitLoggerProvider {
 
     protected static final String DEFAULT_LOG_PREFIX = "k8s: ";
@@ -76,6 +78,9 @@ public abstract class AbstractJKubeMojo extends AbstractMojo implements KitLogge
     @Parameter(defaultValue = "${settings}", readonly = true)
     protected Settings settings;
 
+    @Parameter(property = "jkube.namespace")
+    public String namespace;
+
     @Parameter
     protected ClusterConfiguration access;
 
@@ -96,6 +101,7 @@ public abstract class AbstractJKubeMojo extends AbstractMojo implements KitLogge
         clusterAccess = new ClusterAccess(log, initClusterConfiguration());
         javaProject = MavenUtil.convertMavenProjectToJKubeProject(project, session);
         jkubeServiceHub = initJKubeServiceHubBuilder(javaProject).build();
+        resources = updateResourceConfigNamespace(namespace, resources);
     }
 
     protected boolean canExecute() {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
@@ -138,12 +138,6 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
     @Parameter(property = "jkube.environment")
     private String environment;
 
-    /**
-     * Namespace to use when accessing Kubernetes or OpenShift
-     */
-    @Parameter(property = "jkube.namespace")
-    protected String namespace;
-
     @Parameter(property = "jkube.skip.apply", defaultValue = "false")
     protected boolean skipApply;
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
@@ -38,7 +38,6 @@ import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
 import org.eclipse.jkube.kit.config.resource.MappingConfig;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
-import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 import org.eclipse.jkube.kit.config.resource.ResourceServiceConfig;
@@ -163,12 +162,6 @@ public class ResourceMojo extends AbstractJKubeMojo {
     @Parameter
     private List<MappingConfig> mappings;
 
-    /**
-     * Namespace to use when accessing Kubernetes or OpenShift
-     */
-    @Parameter(property = "jkube.namespace")
-    protected String namespace;
-
     @Parameter(property = "jkube.skip.resource", defaultValue = "false")
     protected boolean skipResource;
 
@@ -239,9 +232,6 @@ public class ResourceMojo extends AbstractJKubeMojo {
     @Override
     protected JKubeServiceHub.JKubeServiceHubBuilder initJKubeServiceHubBuilder(JavaProject javaProject) {
         realResourceDir = ResourceUtil.getFinalResourceDir(resourceDir, environment);
-        if (namespace != null && !namespace.isEmpty()) {
-            resources = ResourceConfig.toBuilder(resources).namespace(namespace).build();
-        }
         final ResourceServiceConfig resourceServiceConfig = ResourceServiceConfig.builder()
             .project(javaProject)
             .resourceDir(realResourceDir)

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
@@ -17,11 +17,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
-import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.maven.plugin.mojo.ManifestProvider;
 import org.eclipse.jkube.maven.plugin.mojo.build.AbstractJKubeMojo;
 
@@ -60,26 +57,9 @@ public class UndeployMojo extends AbstractJKubeMojo implements ManifestProvider 
   @Parameter(property = "jkube.environment")
   private String environment;
 
-  /**
-   * Namespace to use when accessing Kubernetes or OpenShift
-   */
-  @Parameter(property = "jkube.namespace")
-  protected String namespace;
-
   @Override
   public File getKubernetesManifest() {
     return kubernetesManifest;
-  }
-
-  @Override
-  protected void init() throws DependencyResolutionRequiredException {
-    super.init();
-    resources = ResourceConfig.toBuilder(resources)
-        .namespace(Optional.ofNullable(namespace)
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .orElse(null))
-        .build();
   }
 
   @Override

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojoTest.java
@@ -124,7 +124,7 @@ public class ApplyMojoTest {
     applyMojo.execute();
     // Then
     assertThat(applyMojo.applyService.getNamespace()).isEqualTo("configured-namespace");
-    assertThat(applyMojo.applyService.getFallbackNamespace()).isNull();
+    assertThat(applyMojo.applyService.getFallbackNamespace()).isEqualTo("configured-namespace");
   }
 
   @Test


### PR DESCRIPTION
## Description
Fix #1190

OpenShiftBuildService currently applies generated resources (Build,
BuildConfig, ImageStream, ImageStreamTag) in currently logged in
namespace. This means providing namespace configuration in plugin would
have no effect on OpenShift S2I build.

+ Add a namespace parameter to JKubeConfiguration which will be picked by
OpenShiftBuildService for determining namespace while applying
resources.
+ Move `jkube.namespace` property to parent Mojos(AbstractJKubeMojo, AbstractDockerMojo) to 
  avoid duplication

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->