### PR TITLE
deps: Bump Kubernetes Client to 5.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Usage:
 * Fix #1180: `k8s:watch` uses default namespace even if other namespace is configured
 * Fix #1190: OpenShiftBuildService doesn't apply resources in configured namespace
 * Fix #1209: Remove WildFly Swarm support
+* Fix #1219: Bump kubernetes-client to 5.11.2
 
 ### 1.5.1 (2021-10-28)
 * Fix #1084: Gradle dependencies should be test or provided scope

--- a/jkube-kit/config/resource/pom.xml
+++ b/jkube-kit/config/resource/pom.xml
@@ -56,8 +56,8 @@
       <artifactId>openshift-server-mock</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jmockit</groupId>
-      <artifactId>jmockit</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/jkube-kit/config/resource/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/jkube-kit/config/resource/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServiceTest.java
@@ -67,13 +67,13 @@ public class PortForwardServiceTest {
 
         mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods?labelSelector=mykey%3Dmyvalue").andReturn(200, pods1).always();
         mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods").andReturn(200, pods1).always();
-        mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods?labelSelector=mykey%3Dmyvalue&watch=true")
+        mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods?labelSelector=mykey%3Dmyvalue&allowWatchBookmarks=true&watch=true")
                 .andUpgradeToWebSocket().open()
                 .waitFor(1000)
                 .andEmit(new WatchEvent(pod1, "MODIFIED"))
                 .done().always();
 
-        mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods?resourceVersion=1&watch=true")
+        mockServer.expect().get().withPath("/api/v1/namespaces/ns1/pods?resourceVersion=1&allowWatchBookmarks=true&watch=true")
                 .andUpgradeToWebSocket().open()
                 .waitFor(1000)
                 .andEmit(new WatchEvent(pod1, "MODIFIED"))

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceIntegrationTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceIntegrationTest.java
@@ -576,7 +576,7 @@ public class OpenshiftBuildServiceIntegrationTest {
         .always();
 
     mockServer.expect().withPath("/apis/build.openshift.io/v1/namespaces/ns1/builds/" + resourceName).andReturn(200, build).always();
-    mockServer.expect().withPath("/apis/build.openshift.io/v1/namespaces/ns1/builds?fieldSelector=metadata.name%3D" + resourceName + "&watch=true")
+    mockServer.expect().withPath("/apis/build.openshift.io/v1/namespaces/ns1/builds?fieldSelector=metadata.name%3D" + resourceName + "&allowWatchBookmarks=true&watch=true")
         .andUpgradeToWebSocket().open()
         .waitFor(buildDelay)
         .andEmit(new WatchEvent(build, "MODIFIED"))

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -51,7 +51,7 @@
     <version.json-smart>2.2.1</version.json-smart> <!-- Transitive dependency from com.consol.citrus:citrus-core -->
     <version.jsr305>3.0.2</version.jsr305>
     <version.JUnitParams>1.1.1</version.JUnitParams>
-    <version.kubernetes-client>5.10.1</version.kubernetes-client>
+    <version.kubernetes-client>5.11.2</version.kubernetes-client>
     <version.lombok>1.18.12</version.lombok>
     <version.maven-archiver>3.5.0</version.maven-archiver>
     <version.maven-core>3.6.3</version.maven-core>

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/ExecListenerLatch.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/ExecListenerLatch.java
@@ -14,26 +14,24 @@
 package org.eclipse.jkube.watcher.standard;
 
 import io.fabric8.kubernetes.client.dsl.ExecListener;
-import okhttp3.Response;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 
 public class ExecListenerLatch implements ExecListener {
 
   private final CountDownLatch cdl;
   private final AtomicInteger closeCode;
   private final AtomicReference<String> closeReason;
-  private final Consumer<Response> onOpen;
+  private final Runnable onOpen;
 
   public ExecListenerLatch() {
     this(null);
   }
 
-  public ExecListenerLatch(Consumer<Response> onOpen) {
+  public ExecListenerLatch(Runnable onOpen) {
     cdl = new CountDownLatch(1);
     closeCode = new AtomicInteger(-1);
     closeReason = new AtomicReference<>();
@@ -41,9 +39,9 @@ public class ExecListenerLatch implements ExecListener {
   }
 
   @Override
-  public void onOpen(Response response) {
+  public void onOpen() {
     if (onOpen != null) {
-      onOpen.accept(response);
+      onOpen.run();
     }
   }
 

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/PodExecutor.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/PodExecutor.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchException;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
@@ -31,14 +30,13 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
-import okhttp3.Response;
 
 public class PodExecutor {
 
   private final ClusterAccess clusterAccess;
   private final InputStream readingInput;
   private final Duration waitTimeout;
-  private final Consumer<Response> onOpen;
+  private final Runnable onOpen;
   private final ObjectMapper objectMapper;
   private String output;
 
@@ -46,7 +44,7 @@ public class PodExecutor {
     this(clusterAccess, null, waitTimeout, null);
   }
 
-  public PodExecutor(ClusterAccess clusterAccess, InputStream readingInput, Duration waitTimeout, Consumer<Response> onOpen) {
+  public PodExecutor(ClusterAccess clusterAccess, InputStream readingInput, Duration waitTimeout, Runnable onOpen) {
     this.clusterAccess = clusterAccess;
     this.readingInput = readingInput;
     this.waitTimeout = waitTimeout;

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
@@ -20,14 +20,13 @@ import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.eclipse.jkube.kit.build.service.docker.WatchService;
 import org.eclipse.jkube.kit.build.service.docker.watch.CopyFilesTask;
 import org.eclipse.jkube.kit.build.service.docker.watch.ExecTask;
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchContext;
-import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.watcher.api.WatcherContext;
 
 import mockit.Expectations;
@@ -35,7 +34,6 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import mockit.Verifications;
-import okhttp3.Response;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -96,7 +94,6 @@ public class DockerImageWatcherTest {
     // @formatter:on
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void watchCopyFileToPod(@Mocked PodExecutor podExecutor) throws Exception {
     // Given
@@ -108,23 +105,23 @@ public class DockerImageWatcherTest {
     // @formatter:off
     new Verifications() {{
       new PodExecutor(watcherContext.getJKubeServiceHub().getClusterAccess(),
-          (InputStream)any, Duration.ofMinutes(1), (Consumer<Response>)any); times = 1;
+          (InputStream)any, Duration.ofMinutes(1), (Runnable)any); times = 1;
       podExecutor.executeCommandInPod(null, "sh"); times = 1;
     }};
     // @formatter:on
   }
 
   @Test
-  public void uploadFilesConsumer() throws Exception {
+  public void uploadFilesRunnable() throws Exception {
     // Given
     final PipedOutputStream pipedOutputStream = new PipedOutputStream();
     final PipedInputStream pipedInputStream = new PipedInputStream(pipedOutputStream);
     // When
-    DockerImageWatcher.uploadFilesConsumer(
+    DockerImageWatcher.uploadFilesRunnable(
         new File(DockerImageWatcherTest.class.getResource("/file.txt").toURI().getPath()),
         pipedOutputStream,
         watcherContext.getLogger()
-    ).accept(null);
+    ).run();
     assertThat(IOUtils.toString(pipedInputStream, StandardCharsets.UTF_8))
       .isEqualTo("base64 -d << EOF | tar --no-overwrite-dir -C / -xf - && exit 0 || exit 1\nQSBmaWxl\nEOF\n");
   }

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/ExecListenerLatchTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/ExecListenerLatchTest.java
@@ -26,9 +26,9 @@ public class ExecListenerLatchTest {
   public void onOpenWithConsumer() {
     // Given
     final AtomicBoolean consumed = new AtomicBoolean(false);
-    final ExecListenerLatch ell = new ExecListenerLatch(response -> consumed.set(true));
+    final ExecListenerLatch ell = new ExecListenerLatch(() -> consumed.set(true));
     // When
-    ell.onOpen(null);
+    ell.onOpen();
     // Then
     assertThat(consumed.get()).isTrue();
   }


### PR DESCRIPTION
## Description
deps: Bump Kubernetes Client to 5.11.2

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

## CQs

 - [x] [io.fabric8:kubernetes-client:5.11.2](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23904)
 - [x] [io.fabric8:openshift-client:5.11.2](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23905)