### PR TITLE
fix : Throw Exception when podman daemon returns `null` for image id post build(#1055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Usage:
 * Fix #961: `k8sBuild`, `k8sResource` and `k8sApply` tasks don't respect skip options
 * Fix #1030: Update IngressEnricher's default targetApiVersion to `networking.k8s.io/v1`
 * Fix #1054: Log selected Dockerfile in Docker build mode
+* Fix #1055: Throw Exception when podman daemon returns `null` for given image post build
 * Fix #1106: Container Images based on Java 17 (Java-exec, Tomcat, Jetty, Karaf)
 * Fix #1113: `ResourceUtil.deserializeKubernetesListOrTemplate` should also handle YAML manifests with multiple docs
 * Fix #1120: OpenShiftBuildService flattens assembly only if necessary

--- a/jkube-kit/build/service/docker/pom.xml
+++ b/jkube-kit/build/service/docker/pom.xml
@@ -69,6 +69,10 @@
       <artifactId>jmockit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/BuildService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/BuildService.java
@@ -142,6 +142,9 @@ public class BuildService {
                         .cacheFrom(buildConfig.getCacheFrom())
                         .buildArgs(mergedBuildMap);
         String newImageId = doBuildImage(imageName, dockerArchive, opts);
+        if (newImageId == null) {
+            throw new IllegalStateException("Failure in building image, unable to find image built with name " + imageName);
+        }
         log.info("%s: Built image %s", imageConfig.getDescription(), newImageId);
 
         if (oldImageId != null && !oldImageId.equals(newImageId)) {

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/BuildServiceTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/BuildServiceTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.service.docker;
+
+import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
+import org.eclipse.jkube.kit.build.service.docker.access.DockerAccessException;
+import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BuildServiceTest {
+  private DockerAccess mockedDockerAccess;
+  private BuildService buildService;
+  private ImageConfiguration imageConfiguration;
+  private ImagePullManager mockedImagePullManager;
+  private JKubeConfiguration mockedJKubeConfiguration;
+
+  @Before
+  public void setUp() {
+    mockedDockerAccess = mock(DockerAccess.class, RETURNS_DEEP_STUBS);
+    ArchiveService mockedArchiveService = mock(ArchiveService.class, RETURNS_DEEP_STUBS);
+    RegistryService mockedRegistryService = mock(RegistryService.class, RETURNS_DEEP_STUBS);
+    KitLogger mockedLog = mock(KitLogger.SilentLogger.class, RETURNS_DEEP_STUBS);
+    mockedImagePullManager = mock(ImagePullManager.class, RETURNS_DEEP_STUBS);
+    mockedJKubeConfiguration = mock(JKubeConfiguration.class, RETURNS_DEEP_STUBS);
+    QueryService mockedQueryService = new QueryService(mockedDockerAccess);
+    buildService = new BuildService(mockedDockerAccess, mockedQueryService, mockedRegistryService, mockedArchiveService, mockedLog);
+    imageConfiguration = ImageConfiguration.builder()
+        .name("image-name")
+        .build(BuildConfiguration.builder()
+            .from("from")
+            .tags(Collections.singletonList("latest"))
+            .build()
+        ).build();
+  }
+
+  @Test
+  public void buildImage_whenValidImageConfigurationProvidedAndDockerDaemonReturnsValidId_shouldBuildImage() throws IOException {
+    // Given
+    when(mockedDockerAccess.getImageId("image-name")).thenReturn("c8003cb6f5db");
+
+    // When
+    buildService.buildImage(imageConfiguration, mockedImagePullManager, mockedJKubeConfiguration);
+
+    // Then
+    verify(mockedDockerAccess, times(1))
+        .buildImage(eq("image-name"), any(), any());
+  }
+
+  @Test
+  public void buildImage_whenValidImageConfigurationProvidedAndDockerDaemonReturnsNull_shouldBuildImage() throws IOException {
+    // Given
+    when(mockedDockerAccess.getImageId("image-name")).thenReturn(null);
+
+    // When
+    IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
+        () -> buildService.buildImage(imageConfiguration, mockedImagePullManager, mockedJKubeConfiguration));
+
+    // Then
+    assertThat(illegalStateException)
+        .hasMessage("Failure in building image, unable to find image built with name image-name");
+  }
+
+  @Test
+  public void tagImage_whenValidImageConfigurationProvided_shouldTagImage() throws DockerAccessException {
+    // When
+    buildService.tagImage("image-name", imageConfiguration);
+
+    // Then
+    verify(mockedDockerAccess, times(1))
+        .tag(eq("image-name"), eq("image-name:latest"), eq(true));
+  }
+
+}


### PR DESCRIPTION
## Description
Fix #1055

Right now podman daemon doesn't fail the build sometimes when it's not
able to build image sucessfully. In case of #1055, image was being built
but when plugin tries to fet image id of the corresponding built image,
podman fails to resolve it and therefore `null` message is printed.

Add a null check when image id isn't resolved and throw an
IllegalStateException instead.

So instead of logging this:
```
[INFO] k8s: [java/live-stream-question:1.0.0]: Built image null
```
we should see this exception being thrown:
```
[ERROR] k8s: Failed to execute the build [Failure in building image, unable to find image built with name java/live-stream-question:1.0.0]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.229 s
[INFO] Finished at: 2022-01-20T22:41:07+05:30
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.eclipse.jkube:kubernetes-maven-plugin:1.6.0-SNAPSHOT:build (default-cli) on project live-stream-question: Failed to execute the build: Failure in building image, unable to find image built with name java/live-stream-question:1.0.0 -> [Help 1]
```

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->