### PR TITLE
fix(jkube-kit) : Push goal doesn't skip push when image build skip field enabled (#1195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Usage:
 * Fix #1167: Replace apiextensions.k8s.io/v1beta1 by apiextensions.k8s.io/v1
 * Fix #1180: `k8s:watch` uses default namespace even if other namespace is configured
 * Fix #1190: OpenShiftBuildService doesn't apply resources in configured namespace
+* Fix #1195: Push goal doesn't respect skip option in image build configuration
 * Fix #1209: Remove WildFly Swarm support
 * Fix #1219: Bump kubernetes-client to 5.11.2
 * Fix #1213: SnakeYaml dependency from Kubernetes Client + uses SafeConstructor

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildService.java
@@ -14,7 +14,6 @@
 package org.eclipse.jkube.kit.config.service.kubernetes;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Objects;
 
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
@@ -67,9 +66,9 @@ public class DockerBuildService extends AbstractImageBuildService {
     }
 
     @Override
-    public void push(Collection<ImageConfiguration> imageConfigs, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException {
+    protected void pushSingleImage(ImageConfiguration imageConfiguration, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException {
         try {
-            dockerServices.getRegistryService().pushImages(imageConfigs, retries, registryConfig, skipTag);
+            dockerServices.getRegistryService().pushImage(imageConfiguration, retries, registryConfig, skipTag);
         } catch (IOException ex) {
             throw new JKubeServiceException("Error while trying to push the image: " + ex.getMessage(), ex);
         }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildService.java
@@ -40,7 +40,6 @@ import org.eclipse.jkube.kit.service.jib.JibServiceUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -109,18 +108,16 @@ public class JibBuildService extends AbstractImageBuildService {
     }
 
     @Override
-    public void push(Collection<ImageConfiguration> imageConfigs, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException {
+    protected void pushSingleImage(ImageConfiguration imageConfiguration, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException {
         try {
-            for (ImageConfiguration imageConfiguration : imageConfigs) {
-                prependRegistry(imageConfiguration, registryConfig.getRegistry());
-                log.info("This push refers to: %s", imageConfiguration.getName());
-                JibServiceUtil.jibPush(
-                    imageConfiguration,
-                    getRegistryCredentials(registryConfig, true, imageConfiguration, log),
-                    getBuildTarArchive(imageConfiguration, configuration),
-                    log
-                );
-            }
+            prependRegistry(imageConfiguration, registryConfig.getRegistry());
+            log.info("This push refers to: %s", imageConfiguration.getName());
+            JibServiceUtil.jibPush(
+                imageConfiguration,
+                getRegistryCredentials(registryConfig, true, imageConfiguration, log),
+                getBuildTarArchive(imageConfiguration, configuration),
+                log
+            );
         } catch (Exception ex) {
             throw new JKubeServiceException("Error when push JIB image", ex);
         }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
@@ -16,7 +16,6 @@ package org.eclipse.jkube.kit.config.service.openshift;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -174,6 +173,12 @@ public class OpenshiftBuildService extends AbstractImageBuildService {
         }
     }
 
+    @Override
+    protected void pushSingleImage(ImageConfiguration imageConfiguration, int retries, RegistryConfig registryConfig, boolean skipTag) {
+        // Do nothing. Image is pushed as part of build phase
+        log.warn("Image is pushed to OpenShift's internal registry during oc:build goal. Skipping...");
+    }
+
     private void applyBuild(String buildName, File dockerTar, KubernetesListBuilder builder)
             throws Exception {
         applyResourceObjects(buildServiceConfig, client, builder);
@@ -183,12 +188,6 @@ public class OpenshiftBuildService extends AbstractImageBuildService {
 
         // Wait until the build finishes
         waitForOpenShiftBuildToComplete(client, build);
-    }
-
-    @Override
-    public void push(Collection<ImageConfiguration> imageConfigs, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException {
-        // Do nothing. Image is pushed as part of build phase
-        log.warn("Image is pushed to OpenShift's internal registry during oc:build goal. Skipping...");
     }
 
     private File getImageStreamFile() {

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
@@ -197,6 +197,22 @@ public class JibBuildServiceTest {
     }
 
     @Test
+    public void push_withImageBuildConfigurationSkipTrue_shouldNotPushImage() throws JKubeServiceException {
+        // Given
+        imageConfiguration = ImageConfiguration.builder()
+            .name("test/foo:latest")
+            .build(BuildConfiguration.builder()
+                .from("test/base:latest")
+                .skip(true)
+                .build())
+            .build();
+        // When
+        new JibBuildService(mockedServiceHub).push(Collections.singletonList(imageConfiguration), 1, registryConfig, false);
+        // Then
+        jibServiceUtilMockedStatic.verify(() -> JibServiceUtil.jibPush(any(), any(), any(), any()), times(0));
+    }
+
+    @Test
     public void build_withImageBuildConfigurationSkipTrue_shouldNotBuildImage() throws JKubeServiceException {
         // Given
         imageConfiguration = ImageConfiguration.builder()


### PR DESCRIPTION
## Description
Fix #1195

There is a skip field in BuildConfiguration class which skips image
build when enabled, but this doesn't work for push. Plugin tries to push
images even when they're not built and fails.

Handle skip field in RegistryService and JibBuildService

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->