### PR TITLE
feat: Gradle Plugin classes persisted in JavaProject

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
@@ -76,6 +76,8 @@ public class GradleUtil {
         .dependenciesWithTransitive(extractDependenciesWithTransitive(gradleProject))
 //        .localRepositoryBaseDirectory(gradleProject.)
         .plugins(extractPlugins(gradleProject))
+        .gradlePlugins(new ArrayList<>(gradleProject.getPlugins()).stream()
+            .map(Object::getClass).map(Class::getName).collect(Collectors.toList()))
 //
 //        .site(gradleProject.)
 //        .organizationName(gradleProject.)

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/GradleUtilTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/GradleUtilTest.java
@@ -39,6 +39,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.internal.plugins.DefaultPluginContainer;
 import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
@@ -75,13 +76,14 @@ public class GradleUtilTest {
 
     final ConfigurationContainer cc = mock(ConfigurationContainer.class);
     when(project.getConfigurations()).thenReturn(cc);
-    projectConfigurations = new ArrayList<Configuration>();
+    projectConfigurations = new ArrayList<>();
     when(cc.stream()).thenAnswer(i -> projectConfigurations.stream());
     when(cc.toArray()).thenAnswer(i -> projectConfigurations.toArray());
 
     when(project.getBuildscript().getConfigurations().stream()).thenAnswer(i -> Stream.empty());
     when(project.getProperties()).thenReturn(Collections.emptyMap());
     when(project.getBuildDir()).thenReturn(folder.newFolder("build"));
+    when(project.getPlugins()).thenReturn(new DefaultPluginContainer(null, null, null));
     when(project.getConvention().getPlugin(JavaPluginConvention.class)).thenReturn(javaPlugin);
   }
 

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskEnvironment.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskEnvironment.java
@@ -18,6 +18,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.internal.plugins.DefaultPluginContainer;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.junit.rules.TemporaryFolder;
@@ -47,6 +48,7 @@ public class TaskEnvironment extends TemporaryFolder {
     logger = mock(Logger.class);
     when(project.getProjectDir()).thenReturn(getRoot());
     when(project.getBuildDir()).thenReturn(newFolder("build"));
+    when(project.getPlugins()).thenReturn(new DefaultPluginContainer(null, null, null));
 
     final ConfigurationContainer cc = mock(ConfigurationContainer.class);
     when(project.getConfigurations()).thenReturn(cc);

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskEnvironment.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/TaskEnvironment.java
@@ -24,6 +24,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.internal.plugins.DefaultPluginContainer;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.junit.rules.TemporaryFolder;
@@ -47,6 +48,7 @@ public class TaskEnvironment extends TemporaryFolder {
     logger = mock(Logger.class);
     when(project.getProjectDir()).thenReturn(getRoot());
     when(project.getBuildDir()).thenReturn(newFolder("build"));
+    when(project.getPlugins()).thenReturn(new DefaultPluginContainer(null, null, null));
 
     final ConfigurationContainer cc = mock(ConfigurationContainer.class);
     when(project.getConfigurations()).thenReturn(cc);

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/JavaProject.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/JavaProject.java
@@ -139,6 +139,13 @@ public class JavaProject implements Serializable {
    */
   private List<Plugin> plugins;
   /**
+   * List of applied plugin classes (Only applicable for Gradle projects).
+   *
+   * @param gradlePlugins Classes of the applied Gradle plugins.
+   * @return The project's applied Gradle plugin Classes.
+   */
+  private List<String> gradlePlugins;
+  /**
    * URL to the project's homepage.
    *
    * @param site New homepage for the project.
@@ -240,7 +247,7 @@ public class JavaProject implements Serializable {
       String name, String groupId, String artifactId, String version,
       File outputDirectory, File baseDirectory, File buildDirectory, File buildPackageDirectory,
       Properties properties, @Singular List<String> compileClassPathElements, @Singular List<Dependency> dependencies,
-      List<Dependency> dependenciesWithTransitive, @Singular List<Plugin> plugins,
+      List<Dependency> dependenciesWithTransitive, @Singular List<Plugin> plugins, @Singular List<String> gradlePlugins,
       String site, String description, String organizationName, String documentationUrl,
       String buildFinalName, File artifact, String packaging, String issueManagementSystem, String issueManagementUrl,
       String url, String scmUrl, String scmTag,
@@ -258,6 +265,7 @@ public class JavaProject implements Serializable {
     this.dependencies = dependencies;
     this.dependenciesWithTransitive = dependenciesWithTransitive;
     this.plugins = plugins;
+    this.gradlePlugins = gradlePlugins;
     this.site = site;
     this.description = description;
     this.organizationName = organizationName;

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/JKubeProjectUtil.java
@@ -67,6 +67,12 @@ public class JKubeProjectUtil {
         return getPlugin(jkubeProject, artifactId) != null;
     }
 
+    public static boolean hasGradlePlugin(JavaProject javaProject, String pluginClassName) {
+      return Optional.ofNullable(javaProject.getGradlePlugins())
+          .map(classes -> classes.contains(pluginClassName))
+          .orElse(false);
+    }
+
     public static boolean hasDependency(JavaProject jkubeProject, String groupId, String artifactId) {
         return getDependency(jkubeProject, groupId, artifactId) != null;
     }


### PR DESCRIPTION
## Description
feat: Gradle Plugin classes persisted in JavaProject

Required for some generators.

Can be used like:
```java
JKubeProjectUtil.hasGradlePlugin(getProject(), "io.openliberty.tools.gradle.Liberty")
```
or
```java
JKubeProjectUtil.hasGradlePlugin(getProject(), "org.gradle.api.plugins.JavaPlugin")
```

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->