### PR TITLE
Fix #1232: Remove check for existing temporary tag

### DIFF
--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/DockerAccessWithHcClient.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/DockerAccessWithHcClient.java
@@ -657,12 +657,6 @@ public class DockerAccessWithHcClient implements DockerAccess {
     private String tagTemporaryImage(ImageName name, String registry) throws DockerAccessException {
         String targetImage = name.getFullName(registry);
         if (!name.hasRegistry() && registry != null) {
-            if (hasImage(targetImage)) {
-                throw new DockerAccessException(
-                        String.format("Cannot temporarily tag %s with %s because target image already exists. " +
-                                        "Please remove this and retry.",
-                                name.getFullName(), targetImage));
-            }
             tag(name.getFullName(), targetImage, false);
             return targetImage;
         }

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/DockerAccessWithHcClientTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/DockerAccessWithHcClientTest.java
@@ -15,24 +15,39 @@ package org.eclipse.jkube.kit.build.service.docker.access.hc;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
 
 import org.eclipse.jkube.kit.build.api.auth.AuthConfig;
+import org.eclipse.jkube.kit.build.service.docker.access.DockerAccessException;
 import org.eclipse.jkube.kit.build.service.docker.access.hc.util.ClientBuilder;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.archive.ArchiveCompression;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.ResponseHandler;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.stubbing.OngoingStubbing;
 
+import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class DockerAccessWithHcClientTest {
+
+    private static final String BASE_URL = "tcp://1.2.3.4:2375";
 
     private AuthConfig authConfig;
 
@@ -40,21 +55,19 @@ public class DockerAccessWithHcClientTest {
 
     private String imageName;
 
-    @Mocked
     private ApacheHttpClientDelegate mockDelegate;
 
     private int pushRetries;
 
     private String registry;
 
-    private Exception thrownException;
     private String archiveFile;
     private String filename;
     private ArchiveCompression compression;
 
-
     @Before
     public void setup() throws IOException {
+        mockDelegate = mock(ApacheHttpClientDelegate.class, RETURNS_DEEP_STUBS);
         client = new DockerAccessWithHcClient("tcp://1.2.3.4:2375", null, 1, new KitLogger.SilentLogger()) {
             @Override
             ApacheHttpClientDelegate createHttpClient(ClientBuilder builder) {
@@ -64,20 +77,53 @@ public class DockerAccessWithHcClientTest {
     }
 
     @Test
+    public void testPushImage_replacementOfExistingOfTheSameTag() throws Exception {
+        String image = "test-image";
+        String tag = "test-tag";
+        String taggedImageName = String.format("%s:%s", image, tag);
+
+        givenAnImageName(taggedImageName);
+        givenRegistry("test-registry");
+        givenThatGetWillSucceedWithOk();
+
+        whenPushImage();
+
+        thenImageWasTagged(image, tag);
+        thenPushSucceeded(image, tag);
+    }
+
+    @Test
+    public void testPushImage_imageOfTheSameTagDoesNotExist() throws Exception {
+        String image = "test-image";
+        String tag = "test-tag";
+        String taggedImageName = String.format("%s:%s", image, tag);
+
+        givenAnImageName(taggedImageName);
+        givenRegistry("test-registry");
+        givenThatGetWillSucceedWithNotFound();
+        givenThatDeleteWillSucceed();
+
+        whenPushImage();
+
+        thenImageWasTagged(image, tag);
+        thenPushSucceeded(image, tag);
+    }
+
+    @Test
     public void testPushFailes_noRetry() throws Exception {
         givenAnImageName("test");
         givenThePushWillFail(0);
-        whenPushImage();
-        thenImageWasNotPushed();
+        DockerAccessException dae = assertThrows(DockerAccessException.class, this::whenPushImage);
+        assertThat(dae).isNotNull();
     }
 
     @Test
     public void testRetryPush() throws Exception {
         givenAnImageName("test");
         givenANumberOfRetries(1);
-        givenThePushWillFailAndEventuallySucceed(1);
+        givenThePushWillFailAndEventuallySucceed();
         whenPushImage();
-        thenImageWasPushed();
+        verify(mockDelegate, times(2)).post(anyString(), isNull(), anyMap(), any(), anyInt());
     }
 
     @Test
@@ -85,33 +131,34 @@ public class DockerAccessWithHcClientTest {
         givenAnImageName("test");
         givenANumberOfRetries(1);
         givenThePushWillFail(1);
-        whenPushImage();
-        thenImageWasNotPushed();
+        DockerAccessException dae = assertThrows(DockerAccessException.class, this::whenPushImage);
+        assertThat(dae).isNotNull();
     }
 
     @Test
-    public void testLoadImage() {
+    public void testLoadImage() throws IOException {
         givenAnImageName("test");
         givenArchiveFile("test.tar");
         whenLoadImage();
-        thenNoException();
+        verify(mockDelegate).post(anyString(), any(), any(ApacheHttpClientDelegate.BodyAndStatusResponseHandler.class), eq(HTTP_OK));
     }
+
     @Test
     public void testLoadImageFail() throws IOException {
         givenAnImageName("test");
         givenArchiveFile("test.tar");
         givenThePostWillFail();
-        whenLoadImage();
-        thenImageWasNotLoaded();
+        DockerAccessException dockerAccessException = assertThrows(DockerAccessException.class, () -> client.loadImage(imageName, new File(archiveFile)));
+        assertThat(dockerAccessException).isNotNull();
     }
 
     @Test
-    public void testSaveImage() {
+    public void testSaveImage() throws IOException {
         givenAnImageName("test");
         givenFilename("test.tar");
         givenCompression(ArchiveCompression.none);
         whenSaveImage();
-        thenNoException();
+        verify(mockDelegate).get(anyString(), any(ResponseHandler.class), eq(HTTP_OK));
     }
 
     @Test
@@ -120,8 +167,12 @@ public class DockerAccessWithHcClientTest {
         givenFilename("test.tar");
         givenCompression(ArchiveCompression.none);
         givenTheGetWillFail();
-        whenSaveImage();
-        thenImageWasNotSaved();
+        DockerAccessException dae = assertThrows(DockerAccessException.class, this::whenSaveImage);
+        assertThat(dae).isNotNull();
+    }
+
+    private void givenRegistry(String registry) {
+        this.registry = registry;
     }
 
     private void givenAnImageName(String imageName) {
@@ -145,82 +196,74 @@ public class DockerAccessWithHcClientTest {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private void givenThePushWillFailAndEventuallySucceed(final int retries) throws IOException {
-        new Expectations() {{
-            int fail = retries;
-            mockDelegate.post(anyString, null, (Map<String, String>) any, (ResponseHandler) any,  200);
-            minTimes = fail; maxTimes = fail;
-            result = new HttpResponseException(HTTP_INTERNAL_ERROR, "error");
-            mockDelegate.post(anyString, null, (Map<String, String>) any, (ResponseHandler) any, 200);
-            minTimes = 1; maxTimes = 1;
-        }};
+    private void givenThePushWillFailAndEventuallySucceed() throws IOException {
+        when(mockDelegate.post(anyString(), isNull(), anyMap(), any(), anyInt()))
+            .thenThrow(new HttpResponseException(HTTP_INTERNAL_ERROR, "error"))
+            .thenReturn(null);
     }
 
     private void givenThePushWillFail(final int retries) throws IOException {
-        new Expectations() {{
-            int fail = retries + 1;
-            mockDelegate.post(anyString, null, (Map<String, String>) any, (ResponseHandler) any,  200);
-            minTimes = fail; maxTimes = fail;
-            result = new HttpResponseException(HTTP_INTERNAL_ERROR, "error");
-        }};
+        OngoingStubbing<ApacheHttpClientDelegate> stubbing = when(mockDelegate.post(anyString(), isNull(), anyMap(), any(), eq(200)));
+
+        for (int i = 0; i < retries + 1; i++) {
+            stubbing.thenThrow(new HttpResponseException(HTTP_INTERNAL_ERROR, "error"));
+        }
     }
 
     private void givenThePostWillFail() throws IOException {
-        new Expectations() {{
-            mockDelegate.post(anyString, any, (ResponseHandler) any, 200);
-            result = new HttpResponseException(HTTP_INTERNAL_ERROR, "error");
-        }};
+        when(mockDelegate.post(anyString(), any(), any(ResponseHandler.class), eq(200)))
+            .thenThrow(new HttpResponseException(HTTP_INTERNAL_ERROR, "error"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void givenThatGetWillSucceedWithOk() throws IOException {
+        when(mockDelegate.get(anyString(), any(ResponseHandler.class), eq(HTTP_OK), eq(HTTP_NOT_FOUND)))
+            .thenReturn(HTTP_OK);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void givenThatGetWillSucceedWithNotFound() throws IOException {
+        when(mockDelegate.get(anyString(), any(ResponseHandler.class), eq(HTTP_OK), eq(HTTP_NOT_FOUND)))
+            .thenReturn(HTTP_NOT_FOUND);
     }
 
     private void givenTheGetWillFail() throws IOException {
-        new Expectations() {{
-            mockDelegate.get(anyString, (ResponseHandler) any, 200);
-            result = new HttpResponseException(HTTP_INTERNAL_ERROR, "error");
-        }};
+        when(mockDelegate.get(anyString(), any(ResponseHandler.class), eq(200)))
+            .thenThrow(new HttpResponseException(HTTP_INTERNAL_ERROR, "error"));
     }
 
-    private void thenImageWasNotPushed() {
-        assertNotNull(thrownException);
+    @SuppressWarnings("unchecked")
+    private void givenThatDeleteWillSucceed() throws IOException {
+        when(mockDelegate.delete(anyString(), any(ResponseHandler.class), eq(HTTP_OK), eq(HTTP_NOT_FOUND)))
+            .thenReturn(new ApacheHttpClientDelegate.HttpBodyAndStatus(HTTP_OK, "foo"));
     }
 
-    private void thenImageWasPushed() {
-        assertNull(thrownException);
+    private void thenPushSucceeded(String imageNameWithoutTag, String tag) throws IOException {
+        String expectedUrl = String.format("%s/vnull/images/%s%%2F%s/push?force=1&tag=%s", BASE_URL, registry,
+            imageNameWithoutTag, tag);
+        verify(mockDelegate).post(eq(expectedUrl), isNull(), anyMap(), any(), eq(HTTP_OK));
     }
 
-    private void whenPushImage() {
-        try {
-            client.pushImage(imageName, authConfig, registry, pushRetries);
-        } catch (Exception e) {
-            thrownException = e;
-        }
-    }
-    private void whenLoadImage() {
-        try {
-            client.loadImage(imageName, new File(archiveFile));
-        } catch (Exception e) {
-            thrownException = e;
-        }
-    }
-
-    private void whenSaveImage() {
-        try {
-            client.saveImage(imageName, filename, compression);
-        } catch (Exception e) {
-            thrownException = e;
-        }
-    }
-
-    private void thenNoException() {
-        assertNull(thrownException);
-    }
-
-    private void thenImageWasNotLoaded() {
-        assertNotNull(thrownException);
-    }
-
-    private void thenImageWasNotSaved() {
-        assertNotNull(thrownException);
+    private void thenImageWasTagged(String imageNameWithoutTag, String tag) throws IOException {
+        String expectedUrl = String.format("%s/vnull/images/%s%%3A%s/tag?force=0&repo=%s%%2F%s&tag=%s", BASE_URL,
+            imageNameWithoutTag, tag, registry, imageNameWithoutTag, tag);
+        verify(mockDelegate).post(expectedUrl, HTTP_CREATED);
     }
 
 
+    private void whenPushImage() throws DockerAccessException {
+        client.pushImage(imageName, authConfig, registry, pushRetries);
+    }
+
+    private void whenLoadImage() throws DockerAccessException {
+        client.loadImage(imageName, new File(archiveFile));
+    }
+
+    private void whenSaveImage() throws DockerAccessException {
+        client.saveImage(imageName, filename, compression);
+    }
+
+    private String getImageNameWithRegistry() {
+        return registry + "/" + imageName;
+    }
 }


### PR DESCRIPTION
## Description

Fixes #1232 

This issue repeats the same issue from docker-maven-plugin and the proposed solution is identical - https://github.com/fabric8io/docker-maven-plugin/issues/838

The problem appears when someone wants to tag the image with "latest" version which already exists in the repo but pushing this new image should remove "latest" tag from an older image. This behavior is impossible to achieve without this fix.