### PR TITLE
chore: Deprecate `maven.jkube.io` annotation prefix from enrichers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Usage:
 * Fix #1213: SnakeYaml dependency from Kubernetes Client + uses SafeConstructor
 * Fix #1142: Log informative message whenever a goal/task is skipped
 * Fix #1197: Kubernetes Gradle Build tasks don't account for image model configuration skip field
+* Fix #1245: Deprecate `maven.jkube.io` annotation prefix used in enrichers in favor of `jkube.eclipse.org`
 
 ### 1.5.1 (2021-10-28)
 * Fix #1084: Gradle dependencies should be test or provided scope

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/Enricher.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/Enricher.java
@@ -24,6 +24,7 @@ import org.eclipse.jkube.kit.config.resource.PlatformMode;
  * @since 01/04/16
  */
 public interface Enricher extends Named {
+    String INTERNAL_ANNOTATION_PREFIX = "jkube.eclipse.org";
 
     /**
      * Add default resources when they are missing. Each enricher should be responsible

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/Constants.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/Constants.java
@@ -18,7 +18,15 @@ package org.eclipse.jkube.kit.enricher.api.util;
 // TODO-F8SPEC : Should be move the to AppCatalog mojo and must not be in the general available util package
 // Also consider whether the Constants class pattern makes (should probably change to real enums ???)
 public class Constants {
+    /**
+     * @deprecated Use annotations with <code>jkube.eclipse.org</code> prefix instead
+     */
+    @Deprecated
     public static final String RESOURCE_SOURCE_URL_ANNOTATION = "maven.jkube.io/source-url";
+    /**
+     * @deprecated Use annotations with <code>jkube.eclipse.org</code> prefix instead
+     */
+    @Deprecated
     public static final String RESOURCE_APP_CATALOG_ANNOTATION = "maven.jkube.io/app-catalog";
 
     private Constants() { }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ConfigMapEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ConfigMapEnricher.java
@@ -42,7 +42,13 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 
 public class ConfigMapEnricher extends BaseEnricher {
 
+    /**
+     * @deprecated Use <code>jkube.eclipse.org/cm/</code> prefix instead
+     */
+    @Deprecated
     protected static final String PREFIX_ANNOTATION = "maven.jkube.io/cm/";
+
+    protected static final String CONFIGMAP_PREFIX_ANNOTATION = INTERNAL_ANNOTATION_PREFIX + "/cm/";
 
     public ConfigMapEnricher(JKubeEnricherContext enricherContext) {
         super(enricherContext, "jkube-configmap-file");
@@ -78,7 +84,7 @@ public class ConfigMapEnricher extends BaseEnricher {
             Map.Entry<String, String> entry = it.next();
             final String key = entry.getKey();
 
-            if (key.startsWith(PREFIX_ANNOTATION)) {
+            if (key.startsWith(PREFIX_ANNOTATION) || key.startsWith(CONFIGMAP_PREFIX_ANNOTATION)) {
                 addConfigMapEntryFromDirOrFile(configMapBuilder, getOutput(key), entry.getValue());
                 it.remove();
             }
@@ -121,7 +127,10 @@ public class ConfigMapEnricher extends BaseEnricher {
     }
 
     private String getOutput(String key) {
-        return key.substring(PREFIX_ANNOTATION.length());
+        if (key.startsWith(PREFIX_ANNOTATION)) {
+            return key.substring(PREFIX_ANNOTATION.length());
+        }
+        return key.substring(CONFIGMAP_PREFIX_ANNOTATION.length());
     }
 
     private void addConfigMapFromXmlConfigurations(KubernetesListBuilder builder) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DockerRegistrySecretEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DockerRegistrySecretEnricher.java
@@ -24,7 +24,12 @@ import java.util.Map;
 import java.util.Optional;
 
 public class DockerRegistrySecretEnricher extends SecretEnricher {
+    /**
+     * @deprecated Use <code>jkube.eclipse.org/dockerServerId</code> instead.
+     */
+    @Deprecated
     private static final String ANNOTATION_KEY = "maven.jkube.io/dockerServerId";
+    private static final String DOCKER_SERVER_ID_ANNOTATION_KEY = INTERNAL_ANNOTATION_PREFIX + "/dockerServerId";
     private static final String ENRICHER_NAME = "jkube-docker-registry-secret";
 
 
@@ -34,6 +39,11 @@ public class DockerRegistrySecretEnricher extends SecretEnricher {
 
     @Override
     protected String getAnnotationKey() {
+        return DOCKER_SERVER_ID_ANNOTATION_KEY;
+    }
+
+    @Override
+    protected String getDeprecatedAnnotationKey() {
         return ANNOTATION_KEY;
     }
 

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/FileDataSecretEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/FileDataSecretEnricher.java
@@ -31,7 +31,12 @@ import java.util.Set;
 
 public class FileDataSecretEnricher extends BaseEnricher {
 
+    /**
+     * @deprecated Use <code>jkube.eclipse.org/secret/</code> instead
+     */
+    @Deprecated
     protected static final String PREFIX_ANNOTATION = "maven.jkube.io/secret/";
+    protected static final String FILEDATASECRET_PREFIX_ANNOTATION = INTERNAL_ANNOTATION_PREFIX + "/secret/";
 
     public FileDataSecretEnricher(JKubeEnricherContext buildContext) {
         super(buildContext, "jkube-secret-file");
@@ -68,7 +73,8 @@ public class FileDataSecretEnricher extends BaseEnricher {
             Map.Entry<String, String> entry = it.next();
             final String key = entry.getKey();
 
-            if(key.startsWith(PREFIX_ANNOTATION)) {
+            String secretFileLocationKey = getOutput(key);
+            if(secretFileLocationKey != null) {
                 byte[] bytes = readContent(entry.getValue());
                 secretFileLocations.put(getOutput(key), Base64Util.encodeToString(bytes));
                 it.remove();
@@ -83,6 +89,11 @@ public class FileDataSecretEnricher extends BaseEnricher {
     }
 
     private String getOutput(String key) {
-        return key.substring(PREFIX_ANNOTATION.length());
+        if (key.startsWith(PREFIX_ANNOTATION)) {
+            return key.substring(PREFIX_ANNOTATION.length());
+        } else if (key.startsWith(FILEDATASECRET_PREFIX_ANNOTATION)) {
+            return key.substring(FILEDATASECRET_PREFIX_ANNOTATION.length());
+        }
+        return null;
     }
 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/SecretEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/SecretEnricher.java
@@ -54,10 +54,10 @@ public abstract class SecretEnricher extends BaseEnricher {
             public void visit(SecretBuilder secretBuilder) {
                 Map<String, String> annotation = secretBuilder.buildMetadata().getAnnotations();
                 if (annotation != null) {
-                    if (!annotation.containsKey(getAnnotationKey())) {
+                    String dockerId = getDockerIdFromAnnotation(annotation);
+                    if (dockerId == null) {
                         return;
                     }
-                    String dockerId = annotation.get(getAnnotationKey());
                     Map<String, String> data = generateData(dockerId);
                     if (data == null) {
                         return;
@@ -135,7 +135,18 @@ public abstract class SecretEnricher extends BaseEnricher {
         return null;
     }
 
+    private String getDockerIdFromAnnotation(Map<String, String> annotation) {
+        if (annotation.containsKey(getDeprecatedAnnotationKey())) {
+            return annotation.get(getDeprecatedAnnotationKey());
+        } else if (annotation.containsKey(getAnnotationKey())) {
+            return annotation.get(getAnnotationKey());
+        }
+        return null;
+    }
+
     protected abstract String getAnnotationKey();
+
+    protected abstract String getDeprecatedAnnotationKey();
 
     protected abstract Map<String, String> generateData(String key);
 }

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_configmap_file.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_configmap_file.adoc
@@ -89,7 +89,7 @@ If you are defining a custom `ConfigMap` file, you can use an annotation to defi
 metadata:
   name: ${project.artifactId}
   annotations:
-    maven.jkube.io/cm/application.properties: src/test/resources/test-application.properties
+    jkube.eclipse.org/cm/application.properties: src/test/resources/test-application.properties
 ----
 
 This creates a `ConfigMap` data with key `application.properties` (part defined after `cm`) and value the content of `src/test/resources/test-application.properties` file. 
@@ -101,7 +101,7 @@ You can specify a directory instead of a file:
 metadata:
   name: ${project.artifactId}
   annotations:
-    maven.jkube.io/cm/application.properties: src/test/resources/test-dir
+    jkube.eclipse.org/cm/application.properties: src/test/resources/test-dir
 ----
 
 This creates a `ConfigMap` named `application.properties` (part defined after `cm`) and for each file under the directory `test-dir` one entry with file name as key and its content as the value; subdirectories are ignored.

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_secret_file.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/enricher/_jkube_secret_file.adoc
@@ -11,7 +11,7 @@ If you are defining a custom `Secret` file, you can use an annotation to define 
 metadata:
   name: ${project.artifactId}
   annotations:
-    maven.jkube.io/secret/application.properties: src/test/resources/test-application.properties
+    jkube.eclipse.org/secret/application.properties: src/test/resources/test-application.properties
 ----
 
 This creates a `Secret` data with the key `application.properties` (part defined after `secret`) and value content of

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -457,7 +457,7 @@ This is best explained by an example.
 
 
 You can create a secret using a yaml fragment. You can reference the docker server id with an annotation
-`maven.jkube.io/dockerServerId`. The yaml fragment file should be put under
+`jkube.eclipse.org/dockerServerId`. The yaml fragment file should be put under
 the `src/main/jkube/` folder.
 
 .Example
@@ -470,7 +470,7 @@ metadata:
   name: mydockerkey
   namespace: default
   annotations:
-    maven.jkube.io/dockerServerId: ${docker.registry}
+    jkube.eclipse.org/dockerServerId: ${docker.registry}
 type: kubernetes.io/dockercfg
 ----
 

--- a/kubernetes-maven-plugin/it/src/it/secret-config/src/main/jkube/docker.yml
+++ b/kubernetes-maven-plugin/it/src/it/secret-config/src/main/jkube/docker.yml
@@ -18,5 +18,5 @@ metadata:
   name: mydockerkey
   namespace: default
   annotations:
-    maven.jkube.io/dockerServerId: docker.io
+    jkube.eclipse.org/dockerServerId: docker.io
 type: kubernetes.io/dockercfg

--- a/openshift-maven-plugin/it/src/it/secret-config/src/main/jkube/docker.yml
+++ b/openshift-maven-plugin/it/src/it/secret-config/src/main/jkube/docker.yml
@@ -18,5 +18,5 @@ metadata:
   name: mydockerkey
   namespace: default
   annotations:
-    maven.jkube.io/dockerServerId: docker.io
+    jkube.eclipse.org/dockerServerId: docker.io
 type: kubernetes.io/dockercfg


### PR DESCRIPTION
## Description
`maven.jkube.io` seems to be a side effect of search-replace during
migration from FMP to JKube. Deprecate all annotation properties
starting with this prefix.

Introduce the use of `jkube.eclipse.org` prefix instead.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->