### PR TITLE
fix(quickstart-webapp-wildfly): plugin version should not conflict with wildfly version

### DIFF
--- a/quickstarts/maven/webapp-wildfly/pom.xml
+++ b/quickstarts/maven/webapp-wildfly/pom.xml
@@ -35,7 +35,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <wildfly.version>2.0.1.Final</wildfly.version>
+    <wildfly.plugin.version>2.0.1.Final</wildfly.plugin.version>
     <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
   </properties>
 
@@ -53,7 +53,7 @@
       <plugin>
         <groupId>org.wildfly.plugins</groupId>
         <artifactId>wildfly-maven-plugin</artifactId>
-        <version>${wildfly.version}</version>
+        <version>${wildfly.plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.eclipse.jkube</groupId>


### PR DESCRIPTION
## Description
When running the maven goal `mvn wildfly:run`, it was failing trying to
download a distribution of wildfly with the plugin version.
`wildfly.version` was overiden with the plugin version. This is renaming
the plugin version property to avoid the conflict.

Signed-off-by: Sun Seng David TAN <sutan@redhat.com>



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->