### PR TITLE
fix (jkube-kit) : Liveness and readiness TCP ports are not serialized as numbers when defined as numbers (#1126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.7.0-SNAPSHOT
+* Fix #1126: Liveness and readiness TCP ports are not serialized as numbers when defined as numbers
 
 ### 1.6.0 (2022-02-03)
 * Fix #1047: Gradle image build should use the Quarkus generator for Quarkus projects

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ProbeHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ProbeHandler.java
@@ -99,12 +99,11 @@ public class ProbeHandler {
 
     private TCPSocketAction getTCPSocketAction(String getUrl, String port) {
         if (port != null) {
-            IntOrString portObj = new IntOrString(port);
+            IntOrString portObj;
             try {
-                Integer portInt = Integer.parseInt(port);
-                portObj.setIntVal(portInt);
+                portObj = new IntOrString(Integer.parseInt(port));
             } catch (NumberFormatException e) {
-                portObj.setStrVal(port);
+                portObj = new IntOrString(port);
             }
             if(getUrl==null)
                 return new TCPSocketAction(getUrl, portObj);

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ProbeHandlerHTTPUrlTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ProbeHandlerHTTPUrlTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.enricher.handler;
+
+import io.fabric8.kubernetes.api.model.Probe;
+import org.eclipse.jkube.kit.config.resource.ProbeConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@RunWith(Parameterized.class)
+public class ProbeHandlerHTTPUrlTest {
+  private ProbeHandler probeHandler;
+
+  @Parameterized.Parameters(name = "get HTTP Probe with {0} URL returns null probe")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] { null},
+        new Object[] { "tcp://www.healthcheck.com:8080/healthz"},
+        new Object[] { "www.healthcheck.com:8080/healthz"}
+    );
+  }
+
+  @Parameterized.Parameter
+  public String url;
+
+  @Before
+  public void setUp() throws Exception {
+    probeHandler = new ProbeHandler();
+  }
+
+  @Test
+  public void getProbe_withProvidedUrl_shouldGenerateHTTPProbe() {
+    // Given
+    ProbeConfig probeConfig = ProbeConfig.builder()
+        .initialDelaySeconds(5).timeoutSeconds(5).getUrl(url)
+        .build();
+
+    // When
+    Probe generatedProbe = probeHandler.getProbe(probeConfig);
+
+    // Then
+    assertThat(generatedProbe).isNull();
+  }
+}

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ProbeHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ProbeHandlerTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class ProbeHandlerTest {
     Probe probe;
@@ -55,20 +56,6 @@ public class ProbeHandlerTest {
     }
 
     @Test
-    public void getHTTPProbeWithEmptyURLTest() {
-        //ProbeConfig with HTTPGet Action
-
-        //withEmptyUrl
-        probeConfig = ProbeConfig.builder()
-                .initialDelaySeconds(5).timeoutSeconds(5).getUrl(null)
-                .build();
-
-        probe = probeHandler.getProbe(probeConfig);
-        //assertion
-        assertNull(probe);
-    }
-
-    @Test
     public void getHTTPProbeWithHTTPURLTest() {
 
         //ProbeConfig with HTTPGet Action
@@ -92,26 +79,18 @@ public class ProbeHandlerTest {
     }
 
     @Test
-    public void getHTTPProbeWithoutHTTPURLTest() {
-        //ProbeConfig with HTTPGet Action
-        //URL Without http Portocol
-        probeConfig = ProbeConfig.builder()
-                .initialDelaySeconds(5).timeoutSeconds(5).getUrl("www.healthcheck.com:8080/healthz")
-                .build();
-
-        probe = probeHandler.getProbe(probeConfig);
-        assertNull(probe);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
     public void getHTTPProbeWithInvalidURLTest() {
-        //ProbeConfig with HTTPGet Action
-        //withInvalidUrl
+        // Given
         probeConfig = ProbeConfig.builder()
                 .initialDelaySeconds(5).timeoutSeconds(5).getUrl("httphealthcheck.com:8080/healthz")
                 .build();
 
-        probe = probeHandler.getProbe(probeConfig);
+        // When
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> probeHandler.getProbe(probeConfig));
+
+        // Then
+        assertThat(illegalArgumentException)
+            .hasMessageContaining("Invalid URL ");
     }
 
     @Test
@@ -174,6 +153,7 @@ public class ProbeHandlerTest {
         assertNull(probe.getHttpGet());
         assertNotNull(probe.getTcpSocket());
         assertEquals(80,probe.getTcpSocket().getPort().getIntVal().intValue());
+        assertEquals(0, probe.getTcpSocket().getPort().getKind().intValue());
         assertNull(probe.getTcpSocket().getHost());
         assertNull(probe.getExec());
         assertEquals(5,probe.getInitialDelaySeconds().intValue());
@@ -220,7 +200,8 @@ public class ProbeHandlerTest {
         assertNull(probe.getHttpGet());
         assertNotNull(probe.getTcpSocket());
         assertNull(probe.getExec());
-        assertEquals(80,probe.getTcpSocket().getPort().getIntVal().intValue());
+        assertEquals(80, probe.getTcpSocket().getPort().getIntVal().intValue());
+        assertEquals(0, probe.getTcpSocket().getPort().getKind().intValue());
         assertEquals("www.healthcheck.com",probe.getTcpSocket().getHost());
         assertEquals(5,probe.getInitialDelaySeconds().intValue());
         assertEquals(5,probe.getTimeoutSeconds().intValue());
@@ -245,7 +226,8 @@ public class ProbeHandlerTest {
         assertNull(probe.getHttpGet());
         assertNotNull(probe.getTcpSocket());
         assertNull(probe.getExec());
-        assertEquals("httpPort",probe.getTcpSocket().getPort().getStrVal());
+        assertEquals("httpPort", probe.getTcpSocket().getPort().getStrVal());
+        assertEquals(1, probe.getTcpSocket().getPort().getKind().intValue());
         assertEquals("www.healthcheck.com",probe.getTcpSocket().getHost());
         assertEquals(5,probe.getInitialDelaySeconds().intValue());
         assertEquals(5,probe.getTimeoutSeconds().intValue());
@@ -275,20 +257,6 @@ public class ProbeHandlerTest {
         assertEquals("/healthz",probe.getHttpGet().getPath());
         assertEquals(8080,probe.getHttpGet().getPort().getIntVal().intValue());
         assertEquals("HTTP",probe.getHttpGet().getScheme());
-    }
-
-    @Test
-    public void getTCPProbeWithTCPURLTest() {
-        //ProbeConfig with TCP Action
-        //without port and url with tcp request
-        probeConfig = ProbeConfig.builder()
-                .initialDelaySeconds(5).timeoutSeconds(5)
-                .getUrl("tcp://www.healthcheck.com:8080/healthz")
-                .build();
-
-        probe = probeHandler.getProbe(probeConfig);
-        //assertion
-        assertNull(probe);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
## Description
Fix #1126

Fix incorrect mutation of IntOrString port object. Just setting `intVal`
or `strVal` won't result in output serialized as integer or string
respectively. We need to set kind too.

Use constructor directly instead of setting values manually in both try
and catch block.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->