### PR TITLE
fix (jkube-kit) : Add default restartPolicy in case of controller type Job (#1278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Usage:
 * Fix #1236: Add integration tests for DefaultControllerEnricher in gradle plugins
 * Fix #1237: Add gradle project integration test for DefaultMetadataEnricher
 * Fix #1240: Add documentation for DependencyEnricher
+* Fix #1278: Enricher with type Job does not generate mandatory `spec.template.spec.restartPolicy`
 
 ### 1.6.0 (2022-02-03)
 * Fix #1047: Gradle image build should use the Quarkus generator for Quarkus projects

--- a/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
@@ -615,6 +615,11 @@ Here are the fields available in `resources` Groovy DSL configuration that would
 | `replicas`
 | Number of replicas to create
 
+| `restartPolicy`
+| Pod's restart policy.
+
+For `Job`, this defaults to `OnFailure`. For others, it's not provided ({cluster} assumes it to be `Always`)
+
 | `serviceAccount`
 | ServiceAccount name which will be used by pods created by controller resources(e.g. `Deployment`, `ReplicaSet` etc)
 |===

--- a/gradle-plugin/it/src/it/controller/expected/job/kubernetes.yml
+++ b/gradle-plugin/it/src/it/controller/expected/job/kubernetes.yml
@@ -24,6 +24,7 @@ items:
             version: "@ignore@"
             group: org.eclipse.jkube.integration.tests.gradle
         spec:
+          restartPolicy: OnFailure
           containers:
             - env:
                 - name: KUBERNETES_NAMESPACE

--- a/gradle-plugin/it/src/it/controller/expected/job/openshift.yml
+++ b/gradle-plugin/it/src/it/controller/expected/job/openshift.yml
@@ -26,6 +26,7 @@ items:
           version: "@ignore@"
           group: org.eclipse.jkube.integration.tests.gradle
       spec:
+        restartPolicy: OnFailure
         containers:
         - env:
           - name: KUBERNETES_NAMESPACE

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
@@ -74,6 +74,7 @@ public class ResourceConfig {
   private IngressConfig ingress;
   private OpenshiftBuildConfig openshiftBuildConfig;
   private String routeDomain;
+  private String restartPolicy;
 
   public static ResourceConfigBuilder toBuilder(ResourceConfig original) {
     return Optional.ofNullable(original).orElse(new ResourceConfig()).toBuilder();

--- a/jkube-kit/enricher/api/pom.xml
+++ b/jkube-kit/enricher/api/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>jmockit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DaemonSetHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DaemonSetHandler.java
@@ -64,7 +64,7 @@ public class DaemonSetHandler implements ControllerHandler<DaemonSet> {
 
   private DaemonSetSpec createDaemonSetSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return new DaemonSetSpecBuilder()
-        .withTemplate(podTemplateHandler.getPodTemplate(config, images))
+        .withTemplate(podTemplateHandler.getPodTemplate(config, config.getRestartPolicy(), images))
         .build();
   }
 

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DeploymentConfigHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DeploymentConfigHandler.java
@@ -68,7 +68,7 @@ public class DeploymentConfigHandler implements ControllerHandler<DeploymentConf
   private DeploymentConfigSpec createDeploymentConfigSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return new DeploymentConfigSpecBuilder()
         .withReplicas(config.getReplicas())
-        .withTemplate(podTemplateHandler.getPodTemplate(config, images))
+        .withTemplate(podTemplateHandler.getPodTemplate(config, config.getRestartPolicy(), images))
         .build();
   }
 }

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DeploymentHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/DeploymentHandler.java
@@ -68,7 +68,7 @@ public class DeploymentHandler implements ControllerHandler<Deployment> {
   private DeploymentSpec createDeploymentSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return new DeploymentSpecBuilder()
         .withReplicas(config.getReplicas())
-        .withTemplate(podTemplateHandler.getPodTemplate(config,images))
+        .withTemplate(podTemplateHandler.getPodTemplate(config, config.getRestartPolicy(), images))
         .build();
   }
 }

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/JobHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/JobHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Handler for Jobs
@@ -35,6 +36,7 @@ import java.util.List;
 public class JobHandler implements ControllerHandler<Job> {
 
   private final PodTemplateHandler podTemplateHandler;
+  private static final String DEFAULT_JOB_RESTART_POLICY = "OnFailure";
 
   JobHandler(PodTemplateHandler podTemplateHandler) {
     this.podTemplateHandler = podTemplateHandler;
@@ -66,7 +68,7 @@ public class JobHandler implements ControllerHandler<Job> {
 
   private JobSpec createJobSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return new JobSpecBuilder()
-        .withTemplate(podTemplateHandler.getPodTemplate(config, images))
+        .withTemplate(podTemplateHandler.getPodTemplate(config, Optional.ofNullable(config.getRestartPolicy()).orElse(DEFAULT_JOB_RESTART_POLICY), images))
         .build();
   }
 }

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/PodTemplateHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/PodTemplateHandler.java
@@ -39,10 +39,10 @@ public class PodTemplateHandler {
         this.containerHandler = containerHandler;
     }
 
-    public PodTemplateSpec getPodTemplate(ResourceConfig config, List<ImageConfiguration> images)  {
+    public PodTemplateSpec getPodTemplate(ResourceConfig config, String restartPolicy, List<ImageConfiguration> images)  {
         return new PodTemplateSpecBuilder()
             .withMetadata(createPodMetaData())
-            .withSpec(createPodSpec(config, images))
+            .withSpec(createPodSpec(config, restartPolicy, images))
             .build();
     }
 
@@ -50,10 +50,11 @@ public class PodTemplateHandler {
         return new ObjectMetaBuilder().build();
     }
 
-    private PodSpec createPodSpec(ResourceConfig config, List<ImageConfiguration> images) {
+    private PodSpec createPodSpec(ResourceConfig config, String restartPolicy, List<ImageConfiguration> images) {
 
         return new PodSpecBuilder()
             .withServiceAccountName(config.getServiceAccount())
+            .withRestartPolicy(restartPolicy)
             .withContainers(containerHandler.getContainers(config,images))
             .withVolumes(getVolumes(config))
             .build();

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ReplicaSetHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ReplicaSetHandler.java
@@ -72,7 +72,7 @@ public class ReplicaSetHandler implements ControllerHandler<ReplicaSet> {
   private ReplicaSetSpec createSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return new ReplicaSetSpecBuilder()
         .withReplicas(config.getReplicas())
-        .withTemplate(podTemplateHandler.getPodTemplate(config, images))
+        .withTemplate(podTemplateHandler.getPodTemplate(config, config.getRestartPolicy(), images))
         .build();
   }
 }

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ReplicationControllerHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ReplicationControllerHandler.java
@@ -74,7 +74,7 @@ public class ReplicationControllerHandler implements ControllerHandler<Replicati
   private ReplicationControllerSpec createRcSpec(ResourceConfig config, List<ImageConfiguration> images) {
     return new ReplicationControllerSpecBuilder()
         .withReplicas(config.getReplicas())
-        .withTemplate(podTemplateHandler.getPodTemplate(config, images))
+        .withTemplate(podTemplateHandler.getPodTemplate(config, config.getRestartPolicy(), images))
         .build();
   }
 }

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/StatefulSetHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/StatefulSetHandler.java
@@ -75,7 +75,7 @@ public class StatefulSetHandler implements ControllerHandler<StatefulSet> {
     return new StatefulSetSpecBuilder()
         .withReplicas(config.getReplicas())
         .withServiceName(config.getControllerName())
-        .withTemplate(podTemplateHandler.getPodTemplate(config,images))
+        .withTemplate(podTemplateHandler.getPodTemplate(config, config.getRestartPolicy(), images))
         .build();
   }
 }

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/JobHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/JobHandlerTest.java
@@ -91,6 +91,7 @@ public class JobHandlerTest {
                 .imagePullPolicy("IfNotPresent")
                 .controllerName("testing")
                 .serviceAccount("test-account")
+                .restartPolicy("OnFailure")
                 .volumes(volumes1)
                 .build();
 
@@ -104,6 +105,7 @@ public class JobHandlerTest {
         assertEquals("test-account",job.getSpec().getTemplate()
                 .getSpec().getServiceAccountName());
         assertFalse(job.getSpec().getTemplate().getSpec().getVolumes().isEmpty());
+        assertEquals("OnFailure", job.getSpec().getTemplate().getSpec().getRestartPolicy());
         assertEquals("test",job.getSpec().getTemplate().getSpec().
                 getVolumes().get(0).getName());
         assertEquals("/test/path",job.getSpec().getTemplate()

--- a/jkube-kit/enricher/generic/pom.xml
+++ b/jkube-kit/enricher/generic/pom.xml
@@ -66,6 +66,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
@@ -119,12 +119,13 @@ public class DefaultControllerEnricher extends BaseEnricher {
   public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
     final String name = getConfig(Config.NAME,
         JKubeProjectUtil.createDefaultResourceName(getContext().getGav().getSanitizedArtifactId()));
-    ResourceConfig xmlResourceConfig = Optional.ofNullable(getConfiguration().getResource())
+    ResourceConfig providedResourceConfig = Optional.ofNullable(getConfiguration().getResource())
         .orElse(ResourceConfig.builder().build());
-    ResourceConfig config = ResourceConfig.toBuilder(xmlResourceConfig)
-        .controllerName(getControllerName(xmlResourceConfig, name))
-        .imagePullPolicy(getImagePullPolicy(xmlResourceConfig, getConfig(Config.PULL_POLICY)))
-        .replicas(getReplicaCount(builder, xmlResourceConfig, Configs.asInt(getConfig(Config.REPLICA_COUNT))))
+    ResourceConfig config = ResourceConfig.toBuilder(providedResourceConfig)
+        .controllerName(getControllerName(providedResourceConfig, name))
+        .imagePullPolicy(getImagePullPolicy(providedResourceConfig, getConfig(Config.PULL_POLICY)))
+        .replicas(getReplicaCount(builder, providedResourceConfig, Configs.asInt(getConfig(Config.REPLICA_COUNT))))
+        .restartPolicy(providedResourceConfig.getRestartPolicy())
         .build();
 
     final List<ImageConfiguration> images = getImages();
@@ -144,5 +145,4 @@ public class DefaultControllerEnricher extends BaseEnricher {
   private static List<String> getContainersFromPodSpec(PodTemplateSpec spec) {
     return spec.getSpec().getContainers().stream().map(Container::getName).collect(Collectors.toList());
   }
-
 }

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -196,6 +196,11 @@ Here are the fields available in `<resources>` XML configuration that would work
 | `replicas`
 | Number of replicas to create
 
+| `restartPolicy`
+| Pod's restart policy.
+
+For `Job`, this defaults to `OnFailure`. For others, it's not provided ({cluster} assumes it to be `Always`)
+
 | `serviceAccount`
 | ServiceAccount name which will be used by pods created by controller resources(e.g. `Deployment`, `ReplicaSet` etc)
 |===


### PR DESCRIPTION
## Description
Fix #1278

Right now JKube doesn't generate resources with pod spec's
`restartPolicy` set. This works for most of the controller type
resources (e.g `Deployment`, `StatefulSet`, `DaemonSet`, `ReplicaSet`,
`ReplicationController` ); If not provided Kubernetes assumes it to be
`Always`.

But in case of `Job` it doesn't work and Kubernetes gives `422`. Add a
default restart policy in case of `Job`.

[kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->