### PR TITLE
test (gradle-plugin/it) : Add Gradle Integration test for FileDataSecretEnricher (#1250)

### DIFF
--- a/gradle-plugin/it/src/it/secret-file/build.gradle
+++ b/gradle-plugin/it/src/it/secret-file/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'org.eclipse.jkube.kubernetes' version "${jKubeVersion}"
+    id 'org.eclipse.jkube.openshift' version "${jKubeVersion}"
+    id 'java'
+}
+
+group = 'org.eclipse.jkube.integration.tests.gradle'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '11'
+
+repositories {
+    mavenCentral()
+}
+
+kubernetes {
+    offline = true
+}
+
+openshift {
+    offline = true
+}

--- a/gradle-plugin/it/src/it/secret-file/expected/kubernetes.yml
+++ b/gradle-plugin/it/src/it/secret-file/expected/kubernetes.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        app: secret-file
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube.integration.tests.gradle
+      name: secret-file
+    data:
+      application.properties: a2V5MSA9IHZhbHVlMQprZXkyID0gdmFsdWUyCmtleTMgPSB2YWx1ZTM=

--- a/gradle-plugin/it/src/it/secret-file/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/secret-file/expected/openshift.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        app: secret-file
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube.integration.tests.gradle
+      name: secret-file
+    data:
+      application.properties: a2V5MSA9IHZhbHVlMQprZXkyID0gdmFsdWUyCmtleTMgPSB2YWx1ZTM=

--- a/gradle-plugin/it/src/it/secret-file/src/main/jkube/secret.yml
+++ b/gradle-plugin/it/src/it/secret-file/src/main/jkube/secret.yml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+metadata:
+  name: ${name}
+  annotations:
+    jkube.eclipse.org/secret/application.properties: ${user.dir}/src/it/secret-file/src/test/resources/secret-application.properties

--- a/gradle-plugin/it/src/it/secret-file/src/test/resources/secret-application.properties
+++ b/gradle-plugin/it/src/it/secret-file/src/test/resources/secret-application.properties
@@ -1,0 +1,3 @@
+key1 = value1
+key2 = value2
+key3 = value3

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/FileSecretIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/FileSecretIT.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.tests;
+
+import net.minidev.json.parser.ParseException;
+import org.eclipse.jkube.kit.common.ResourceVerify;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class FileSecretIT {
+  @Rule
+  public final ITGradleRunner gradleRunner = new ITGradleRunner();
+
+  @Test
+  public void k8sResource_whenRun_generatesK8sSecret() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("secret-file").withArguments("k8sResource").build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
+        gradleRunner.resolveFile("expected", "kubernetes.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Running in Kubernetes mode")
+        .contains("Using resource templates from")
+        .contains("Adding revision history limit to 2")
+        .contains("validating");
+  }
+
+  @Test
+  public void ocResource_whenRun_generatesK8sSecret() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("secret-file").withArguments("ocResource").build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
+        gradleRunner.resolveFile("expected", "openshift.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Running in OpenShift mode")
+        .contains("Using resource templates from")
+        .contains("Adding revision history limit to 2")
+        .contains("validating");
+  }
+}

--- a/jkube-kit/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -72,6 +72,9 @@ by other enrichers, {plugin-configuration-type} configuration or fragment.
 | <<jkube-namespace>>
 | Set the _Namespace_ of the generated and processed Kubernetes resources metadata and optionally create a new Namespace
 
+| <<jkube-secret-file>>
+| Add Secret elements defined as annotation.
+
 | <<jkube-service>>
 | Create a default service if missing and extract ports from the Docker image configuration.
 
@@ -115,9 +118,6 @@ ifeval::["{plugin-type}" == "maven"]
 | <<jkube-revision-history-enricher>>
 | Add revision history limit (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit[Kubernetes doc]) as a deployment spec property to the Kubernetes/OpenShift resources.
 
-| <<jkube-secret-file>>
-| Add Secret elements defined as annotation.
-
 | <<jkube-serviceaccount>>
 | Add a ServiceAccount defined as {plugin-configuration-type} or mentioned in resource fragment.
 
@@ -149,6 +149,8 @@ include::enricher/git/_jkube_git.adoc[]
 include::enricher/metadata/_jkube_metadata.adoc[]
 
 include::enricher/namespace/_jkube_namespace.adoc[]
+
+include::enricher/secret-file/_jkube_secret_file.adoc[]
 
 include::enricher/service/_jkube_service.adoc[]
 
@@ -192,8 +194,6 @@ include::enricher/_jkube_prometheus.adoc[]
 include::enricher/_jkube_replicas.adoc[]
 
 include::enricher/_jkube_revision_history.adoc[]
-
-include::enricher/_jkube_secret_file.adoc[]
 
 [[jkube-serviceaccount]]
 ==== jkube-serviceaccount

--- a/jkube-kit/doc/src/main/asciidoc/inc/enricher/secret-file/_jkube_secret_file.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/enricher/secret-file/_jkube_secret_file.adoc
@@ -9,7 +9,12 @@ If you are defining a custom `Secret` file, you can use an annotation to define 
 [source, yaml]
 ----
 metadata:
+ifeval::["{plugin-type}" == "maven"]
   name: ${project.artifactId}
+endif::[]
+ifeval::["{plugin-type}" == "gradle"]
+  name: ${name}
+endif::[]
   annotations:
     jkube.eclipse.org/secret/application.properties: src/test/resources/test-application.properties
 ----


### PR DESCRIPTION
## Description
Fix #1250 

+ Add Gradle integration test to verify `jkube.eclipse.org/secret`
    metadata annotation generates correct secret with base64 content of specified
    files
+ Minor change in FileDataSecretEnricher docs for Gradle plugins related
    to name property. Move FileDataSecretEnricher doc out of maven only
    enrichers docs block.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->