### PR TITLE
doc(gradle-plugin): Adding webapp generator doc

### DIFF
--- a/gradle-plugin/doc/src/main/asciidoc/inc/_generator.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/_generator.adoc
@@ -34,15 +34,22 @@ All default generators examine the build information for certain aspects and gen
 | `vertx`
 | Generator for Vert.x applications
 
+
+| <<generator-webapp,Web applications>>
+| `webapps`
+| Generator for WAR based applications supporting Tomcat, Jetty and Wildfly base images
+
 | <<generator-openliberty,Open Liberty>>
 | `openliberty`
 | Generator for Open Liberty applications
+
 |===
 
 include::generator/_options_common.adoc[]
 
 include::generator/_java_exec.adoc[]
 include::generator/_spring_boot.adoc[]
+include::generator/_webapp.adoc[]
 include::generator/_quarkus.adoc[]
 include::generator/_micronaut.adoc[]
 include::generator/_vertx.adoc[]

--- a/gradle-plugin/doc/src/main/asciidoc/inc/generator/_webapp.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/generator/_webapp.adoc
@@ -1,0 +1,68 @@
+[[generator-webapp]]
+=== Web Applications
+
+The `webapp` generator tries to detect WAR builds and selects a base servlet container image based on the configuration found in the `build.gradle`:
+
+* A **Tomcat** base image is selected by default.
+* A **Jetty** base image is selected when one of the files `WEB-INF/jetty-web.xml` or `WEB-INF/jetty-logging.properties` is found.
+* A **Wildfly** base image is chosen when a Wildfly specific deployment descriptor like `jboss-web.xml` is found.
+
+The base images chosen are:
+
+[[generator-webapp-from]]
+.Webapp Base Images
+[cols="1,4,4"]
+|===
+| | Docker Build | S2I Build
+
+| *Tomcat*
+| `quay.io/jkube/jkube-tomcat9`
+| `quay.io/jkube/jkube-tomcat9`
+
+| *Jetty*
+| `quay.io/jkube/jkube-jetty9`
+| `quay.io/jkube/jkube-jetty9`
+
+| *Wildfly*
+| `jboss/wildfly`
+| https://github.com/wildfly/wildfly-s2i[`quay.io/wildfly/wildfly-centos7`]
+|===
+
+In addition to the  <<generator-options-common, common generator options>> this generator can be configured with the following options:
+
+.Webapp configuration options
+[cols="1,6,1"]
+|===
+| Element | Description | Property
+
+| *server*
+| Fix server to use in the base image. Can be either **tomcat**, **jetty** or **wildfly**.
+| `jkube.generator.webapp.server`
+
+| *targetDir*
+| Where to put the war file into the target image. By default its selected by the base image chosen but can be
+  overwritten with this option.
+
+  Defaults to `/deployments`.
+| `jkube.generator.webapp.targetDir`
+
+| *user*
+| User and/or group under which the files should be added. The syntax of this options is descriped in
+  <<config-image-build-assembly-user, Assembly Configuration>>.
+| `jkube.generator.webapp.user`
+
+| *path*
+| Context path with which the application can be reached by default.
+
+  Defaults to `/` (root context).
+| `jkube.generator.webapp.path`
+
+| *cmd*
+| Command to use to start the container. By default the base images startup command is used.
+| `jkube.generator.webapp.cmd`
+
+| *ports*
+| Comma separated list of ports to expose in the image and which eventually are translated later to Kubernetes services.
+  The ports depend on the base image and are selected automatically. But they can be overridden here.
+| `jkube.generator.webapp.ports`
+|===


### PR DESCRIPTION
## Description
Based on maven webapp generator doc
Preview: https://jkubedoc-sutan-jkube-doc-gradle-webapp.surge.sh/#generator-webapp

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->