### PR TITLE
PodLogService fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.7.0-SNAPSHOT
+* Fix #1315: Pod Log Service works for Jobs with no selector
 * Fix #1126: Liveness and readiness TCP ports are not serialized as numbers when defined as numbers
 * Fix #1211: Port `java-options-env-merge` integration test and ContainerEnvJavaOptionsMergeEnricher documentation to gradle
 * Fix #1214: Add integration test to verify `jkube.debug.enabled` flag works as expected

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTaskTest.java
@@ -56,7 +56,7 @@ public class KubernetesLogTaskTest {
 
     // Then
     verify(taskEnvironment.logger).lifecycle("k8s: Running in Kubernetes mode");
-    verify(taskEnvironment.logger).warn("k8s: No selector in deployment so cannot watch pods!");
+    verify(taskEnvironment.logger).warn("k8s: No selector detected and no Pod name specified, cannot watch Pods!");
   }
 
   @Test

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -512,13 +512,29 @@ public class KubernetesHelper {
                 selector = spec.getSelector();
             }
         } else if (entity instanceof Job) {
-            Job resource = (Job) entity;
-            JobSpec spec = resource.getSpec();
-            if (spec != null) {
-                selector = spec.getSelector();
-            }
+            selector = toLabelSelector((Job) entity);
         }
         return selector;
+    }
+
+    private static LabelSelector toLabelSelector(Job job) {
+      LabelSelector ret = null;
+      final JobSpec spec = job.getSpec();
+      if (spec != null) {
+        if (spec.getSelector() != null) {
+          ret = spec.getSelector();
+        } else if (spec.getTemplate() != null) {
+          ret = toLabelSelector(spec.getTemplate().getMetadata());
+        }
+      }
+      return ret;
+    }
+
+    private static LabelSelector toLabelSelector(ObjectMeta metadata) {
+      if (metadata != null && metadata.getLabels() != null && !metadata.getLabels().isEmpty()) {
+          return toLabelSelector(metadata.getLabels());
+      }
+      return null;
     }
 
     private static LabelSelector toLabelSelector(Map<String, String> matchLabels) {

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/PodLogService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/PodLogService.java
@@ -58,8 +58,8 @@ public class PodLogService {
     public static final String OPERATION_UNDEPLOY = "undeploy";
     public static final String OPERATION_STOP = "stop";
 
-    private PodLogServiceContext context;
-    private KitLogger log;
+    private final PodLogServiceContext context;
+    private final KitLogger log;
 
     private Watch podWatcher;
     private LogWatch logWatcher;


### PR DESCRIPTION
## Description
This issue solves 2 issues with the PodLogService.

- Logging for `Jobs` with no selector (it's an [optional](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-selector) field), fallback to use a label selector based on the Pod Template metadata labels (if present)
- Logging for a specific Pod name works even if no selector is detected (in case it's detected it is still used to filter out multiple pods).
  e.g. `mvn k8s:log -Djkube.log.pod=helper` would tail the logs of a Pod named `helper`

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->