### PR TITLE
fix : Spring Boot actuator endpoints don't generate if `deployment.yml` fragment is used (#1295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.8.0-SNAPSHOT
+* Fix #1295: Spring Boot actuator endpoints failed to generate automatically if `deployment.yml` resource fragment is used
 
 ### 1.7.0 (2022-02-25)
 * Fix #1315: Pod Log Service works for Jobs with no selector

--- a/gradle-plugin/it/src/it/spring-boot-with-fragment/build.gradle
+++ b/gradle-plugin/it/src/it/spring-boot-with-fragment/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'org.eclipse.jkube.kubernetes' version "${jKubeVersion}"
+    id 'org.eclipse.jkube.openshift' version "${jKubeVersion}"
+    id 'org.springframework.boot' version '2.5.2'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'java'
+}
+
+group = 'org.eclipse.jkube.integration.tests.gradle'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+}
+
+kubernetes {
+    offline = true
+}
+openshift {
+    offline = true
+}

--- a/gradle-plugin/it/src/it/spring-boot-with-fragment/expected/kubernetes.yml
+++ b/gradle-plugin/it/src/it/spring-boot-with-fragment/expected/kubernetes.yml
@@ -1,0 +1,103 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      prometheus.io/path: /metrics
+      jkube.io/git-branch: "@ignore@"
+      prometheus.io/port: "@ignore@"
+      prometheus.io/scrape: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+    labels:
+      expose: "true"
+      app: spring-boot-with-fragment
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: spring-boot-with-fragment
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: spring-boot-with-fragment
+      provider: jkube
+      group: org.eclipse.jkube.integration.tests.gradle
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: spring-boot-with-fragment
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: spring-boot-with-fragment
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      matchLabels:
+        app: spring-boot-with-fragment
+        provider: jkube
+        group: org.eclipse.jkube.integration.tests.gradle
+    template:
+      metadata:
+        annotations:
+          jkube.io/git-url: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: spring-boot-with-fragment
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube.integration.tests.gradle
+      spec:
+        containers:
+        - env:
+            - name: ABC
+              value: dummy
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: gradle/spring-boot-with-fragment:latest
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 180
+            successThreshold: 1
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            successThreshold: 1
+          securityContext:
+            privileged: false

--- a/gradle-plugin/it/src/it/spring-boot-with-fragment/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/spring-boot-with-fragment/expected/openshift.yml
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: spring-boot-with-fragment
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: spring-boot-with-fragment
+      provider: jkube
+      group: org.eclipse.jkube.integration.tests.gradle
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      provider: jkube
+      app: spring-boot-with-fragment
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: spring-boot-with-fragment
+  spec:
+    replicas: 1
+    selector:
+      app: spring-boot-with-fragment
+      provider: jkube
+      group: org.eclipse.jkube.integration.tests.gradle
+    template:
+      metadata:
+        labels:
+          provider: jkube
+          app: spring-boot-with-fragment
+          version: "@ignore@"
+          group: org.eclipse.jkube.integration.tests.gradle
+      spec:
+        containers:
+        - env:
+          - name: ABC
+            value: dummy
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: spring-boot-with-fragment:latest
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 180
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 10
+          securityContext:
+            privileged: false
+    triggers:
+      - type: ConfigChange
+      - imageChangeParams:
+          automatic: true
+          containerNames:
+            - spring-boot
+          from:
+            kind: ImageStreamTag
+            name: spring-boot-with-fragment:latest
+        type: ImageChange

--- a/gradle-plugin/it/src/it/spring-boot-with-fragment/src/main/java/org/eclipse/jkube/it/gradle/spring/boot/Application.java
+++ b/gradle-plugin/it/src/it/spring-boot-with-fragment/src/main/java/org/eclipse/jkube/it/gradle/spring/boot/Application.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.it.gradle.spring.boot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/gradle-plugin/it/src/it/spring-boot-with-fragment/src/main/jkube/deployment.yml
+++ b/gradle-plugin/it/src/it/spring-boot-with-fragment/src/main/jkube/deployment.yml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+spec:
+  template:
+    spec:
+      containers:
+        - env:
+            - name: ABC
+              value: dummy

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootWithFragmentIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootWithFragmentIT.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.tests;
+
+import net.minidev.json.parser.ParseException;
+import org.eclipse.jkube.kit.common.ResourceVerify;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class SpringBootWithFragmentIT {
+  @Rule
+  public final ITGradleRunner gradleRunner = new ITGradleRunner();
+
+  @Test
+  public void k8sResource_whenRun_generatesK8sManifests() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("spring-boot-with-fragment")
+        .withArguments("build", "k8sResource", "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
+        gradleRunner.resolveFile("expected", "kubernetes.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Running in Kubernetes mode")
+        .contains("Running generator spring-boot")
+        .contains("jkube-service: Adding a default service")
+        .contains("jkube-healthcheck-spring-boot: Adding readiness probe on port 8080")
+        .contains("jkube-healthcheck-spring-boot: Adding liveness probe on port 8080")
+        .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
+        .contains("jkube-revision-history: Adding revision history limit to 2");
+  }
+
+  @Test
+  public void ocResource_whenRun_generatesOpenShiftManifests() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("spring-boot-with-fragment")
+        .withArguments("build", "ocResource", "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
+        gradleRunner.resolveFile("expected", "openshift.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Running in OpenShift mode")
+        .contains("Running generator spring-boot")
+        .contains("jkube-service: Adding a default service")
+        .contains("jkube-openshift-deploymentconfig: Converting Deployment to DeploymentConfig")
+        .contains("jkube-healthcheck-spring-boot: Adding readiness probe on port 8080")
+        .contains("jkube-healthcheck-spring-boot: Adding liveness probe on port 8080")
+        .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
+        .contains("jkube-revision-history: Adding revision history limit to 2");
+  }
+}

--- a/gradle-plugin/kubernetes/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/gradle-plugin/kubernetes/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -45,7 +45,6 @@
       # Route exposure
       - jkube-openshift-service-expose
       - jkube-openshift-route
-      - jkube-openshift-deploymentconfig
       - jkube-openshift-project
 
       # Ingress

--- a/gradle-plugin/openshift/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/gradle-plugin/openshift/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -17,6 +17,8 @@
 # tag::default[]
 # Default profile which is always activated
 - name: default
+  # This profile overrides the default profile in the Kubernetes plugin give a higher priority so it takes precedence
+  order: 10
   enricher:
     # The order given in "includes" is the order in which enrichers are called
     includes:
@@ -42,7 +44,6 @@
     - jkube-configmap-file
     - jkube-secret-file
 
-
     # -----------------------------------------
     # TODO: Document and verify enrichers below
     # Health checks
@@ -55,17 +56,19 @@
     - jkube-healthcheck-docker
     - jkube-healthcheck-webapp
     - jkube-healthcheck-micronaut
+
+    # Route exposure
+    - jkube-openshift-service-expose
+    # DeploymentConfigEnricher converts Deployment into DeploymentConfig
+    - jkube-openshift-deploymentconfig
+    - jkube-openshift-route
+    - jkube-openshift-project
+
     - jkube-prometheus
     - jkube-service-discovery
 
     # Value merge enrichers
     - jkube-container-env-java-options
-
-      # Route exposure
-    - jkube-openshift-service-expose
-    - jkube-openshift-route
-    - jkube-openshift-deploymentconfig
-    - jkube-openshift-project
 
     # Dependencies shouldn't be enriched anymore, therefore it's last in the list
     - jkube-dependency

--- a/gradle-plugin/openshift/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/gradle-plugin/openshift/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -42,11 +42,6 @@
     - jkube-configmap-file
     - jkube-secret-file
 
-    # Route exposure
-    - jkube-openshift-service-expose
-    - jkube-openshift-route
-    - jkube-openshift-deploymentconfig
-    - jkube-openshift-project
 
     # -----------------------------------------
     # TODO: Document and verify enrichers below
@@ -65,6 +60,12 @@
 
     # Value merge enrichers
     - jkube-container-env-java-options
+
+      # Route exposure
+    - jkube-openshift-service-expose
+    - jkube-openshift-route
+    - jkube-openshift-deploymentconfig
+    - jkube-openshift-project
 
     # Dependencies shouldn't be enriched anymore, therefore it's last in the list
     - jkube-dependency

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/RevisionHistoryEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/RevisionHistoryEnricher.java
@@ -54,32 +54,30 @@ public class RevisionHistoryEnricher extends BaseEnricher {
 
         log.info("Adding revision history limit to %s", maxRevisionHistories);
 
-        if(platformMode == PlatformMode.kubernetes) {
-            builder.accept(new TypedVisitor<io.fabric8.kubernetes.api.model.apps.DeploymentBuilder>() {
-                @Override
-                public void visit(io.fabric8.kubernetes.api.model.apps.DeploymentBuilder item) {
-                    item.editOrNewSpec()
-                            .withRevisionHistoryLimit(maxRevisionHistories)
-                            .endSpec();
-                }
-            });
-            builder.accept(new TypedVisitor<io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder>() {
-                @Override
-                public void visit(io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder item) {
-                    item.editOrNewSpec()
-                            .withRevisionHistoryLimit(maxRevisionHistories)
-                            .endSpec();
-                }
-            });
-        } else {
-            builder.accept(new TypedVisitor<DeploymentConfigBuilder>() {
-                @Override
-                public void visit(DeploymentConfigBuilder item) {
-                    item.editOrNewSpec()
-                            .withRevisionHistoryLimit(maxRevisionHistories)
-                            .endSpec();
-                }
-            });
-        }
+        builder.accept(new TypedVisitor<io.fabric8.kubernetes.api.model.apps.DeploymentBuilder>() {
+            @Override
+            public void visit(io.fabric8.kubernetes.api.model.apps.DeploymentBuilder item) {
+                item.editOrNewSpec()
+                    .withRevisionHistoryLimit(maxRevisionHistories)
+                    .endSpec();
+            }
+        });
+        builder.accept(new TypedVisitor<io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder>() {
+            @Override
+            public void visit(io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder item) {
+                item.editOrNewSpec()
+                    .withRevisionHistoryLimit(maxRevisionHistories)
+                    .endSpec();
+            }
+        });
+
+        builder.accept(new TypedVisitor<DeploymentConfigBuilder>() {
+            @Override
+            public void visit(DeploymentConfigBuilder item) {
+                item.editOrNewSpec()
+                    .withRevisionHistoryLimit(maxRevisionHistories)
+                    .endSpec();
+            }
+        });
     }
 }

--- a/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -45,7 +45,6 @@
     # Route exposure
     - jkube-openshift-service-expose
     - jkube-openshift-route
-    - jkube-openshift-deploymentconfig
     - jkube-openshift-project
 
     # Ingress

--- a/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -12,11 +12,13 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-# Default profiles delivered with omp
+# Default profiles delivered with openshift-maven-plugin
 
 # tag::default[]
 # Default profile which is always activated
 - name: default
+  # This profile overrides the default profile in the Kubernetes plugin give a higher priority so it takes precedence
+  order: 10
   enricher:
     # The order given in "includes" is the order in which enrichers are called
     includes:
@@ -42,11 +44,6 @@
     - jkube-configmap-file
     - jkube-secret-file
 
-    # Route exposure
-    - jkube-openshift-service-expose
-    - jkube-openshift-route
-    - jkube-openshift-project
-
     # -----------------------------------------
     # TODO: Document and verify enrichers below
     # Health checks
@@ -59,14 +56,19 @@
     - jkube-healthcheck-docker
     - jkube-healthcheck-webapp
     - jkube-healthcheck-micronaut
+
+    # Route exposure
+    - jkube-openshift-service-expose
+    # DeploymentConfigEnricher converts Deployment into DeploymentConfig
+    - jkube-openshift-deploymentconfig
+    - jkube-openshift-route
+    - jkube-openshift-project
+
     - jkube-prometheus
     - jkube-service-discovery
 
     # Value merge enrichers
     - jkube-container-env-java-options
-
-    # DeploymentConfigEnricher converts Deployment into DeploymentConfig
-    - jkube-openshift-deploymentconfig
 
     # Dependencies shouldn't be enriched anymore, therefore it's last in the list
     - jkube-dependency

--- a/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -45,7 +45,6 @@
     # Route exposure
     - jkube-openshift-service-expose
     - jkube-openshift-route
-    - jkube-openshift-deploymentconfig
     - jkube-openshift-project
 
     # -----------------------------------------
@@ -65,6 +64,9 @@
 
     # Value merge enrichers
     - jkube-container-env-java-options
+
+    # DeploymentConfigEnricher converts Deployment into DeploymentConfig
+    - jkube-openshift-deploymentconfig
 
     # Dependencies shouldn't be enriched anymore, therefore it's last in the list
     - jkube-dependency


### PR DESCRIPTION
## Description

Fix #1295

Right now with DeploymentConfigBuilder, TypedVisitor<ContainerBuilder>
is visiting ContainerBuilder twice instead of visiting it once. This is
generating list with duplicate ContainerBuilder elements.

Move DeploymentConfigEnricher lower than Health Check enrichers in order
to do conversion after health checks have been added to Deployment.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->