### PR TITLE
fix : webapp custom generator should not require to set a CMD configuration (#1284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.8.0-SNAPSHOT
-* Fix #1260: Add documentation for PodAnnotationEnricher
-* Fix #1295: Spring Boot actuator endpoints failed to generate automatically if `deployment.yml` resource fragment is used
 * Fix #1201: ThorntailV2Generator works with Gradle Plugins
+* Fix #1260: Add documentation for PodAnnotationEnricher
+* Fix #1284: webapp custom generator should not require to set a CMD configuration
+* Fix #1295: Spring Boot actuator endpoints failed to generate automatically if `deployment.yml` resource fragment is used
 
 ### 1.7.0 (2022-02-25)
 * Fix #1315: Pod Log Service works for Jobs with no selector

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
@@ -108,8 +108,12 @@ public class WebAppGenerator extends BaseGenerator {
 
     buildBuilder.from(getFrom(handler))
         .ports(handler.exposedPorts())
-        .cmd(Arguments.builder().shell(getDockerRunCommand(handler)).build())
         .env(getEnv(handler));
+
+    String dockerRunCommand = getDockerRunCommand(handler);
+    if (dockerRunCommand != null) {
+      buildBuilder.cmd(Arguments.builder().shell(dockerRunCommand).build());
+    }
 
     handler.runCmds().forEach(buildBuilder::runCmd);
 

--- a/quickstarts/gradle/webapp-custom/build.gradle
+++ b/quickstarts/gradle/webapp-custom/build.gradle
@@ -33,7 +33,6 @@ kubernetes {
             'webapp' {
                 from = "tomcat:jdk11-openjdk-slim"
                 targetDir = "/usr/local/tomcat/webapps"
-                cmd = "catalina.sh run"
             }
         }
     }


### PR DESCRIPTION

## Description
Fix #1284

Only set cmd while building ImageConfiguration when inferred docker run command is not null. Right now we were building invalid Argument object with everything null which gets rejected later during `ConfigHelper.initAndValidate` call

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->