### PR TITLE
fix : `jkube.enricher.jkube-name.name` doesn't modify `.metadata.name` for generated manifests (#1325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Usage:
 * Fix #1262: Add docs + gradle integration test for ProjectLabelEnricher
 * Fix #1284: webapp custom generator should not require to set a CMD configuration
 * Fix #1295: Spring Boot actuator endpoints failed to generate automatically if `deployment.yml` resource fragment is used
+* Fix #1325: `jkube.enricher.jkube-name.name` doesn't modify `.metadata.name` for generated manifests
 
 ### 1.7.0 (2022-02-25)
 * Fix #1315: Pod Log Service works for Jobs with no selector

--- a/gradle-plugin/kubernetes/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/gradle-plugin/kubernetes/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -21,7 +21,6 @@
     # The order given in "includes" is the order in which enrichers are called
     includes:
       - jkube-metadata
-      - jkube-name
       - jkube-controller
       - jkube-controller-from-configuration
       - jkube-service
@@ -75,6 +74,7 @@
       - jkube-triggers-annotation
       - jkube-openshift-imageChangeTrigger
 
+      - jkube-name
       # ReplicaCountEnricher overrides .spec.replicas field of any resource (even dependencies)
       - jkube-replicas
 

--- a/gradle-plugin/openshift/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/gradle-plugin/openshift/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -23,7 +23,6 @@
     # The order given in "includes" is the order in which enrichers are called
     includes:
     - jkube-metadata
-    - jkube-name
     - jkube-controller
     - jkube-controller-from-configuration
     - jkube-service
@@ -77,6 +76,7 @@
     - jkube-triggers-annotation
     - jkube-openshift-imageChangeTrigger
 
+    - jkube-name
       # ReplicaCountEnricher overrides .spec.replicas field of any resource (even dependencies)
     - jkube-replicas
 

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NameEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NameEnricher.java
@@ -48,11 +48,14 @@ public class NameEnricher extends BaseEnricher {
 
   @Override
   public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
-    final String defaultName = getConfig(Config.NAME, JKubeProjectUtil.createDefaultResourceName(getContext().getGav().getSanitizedArtifactId()));
+    final String configuredName = getConfig(Config.NAME);
+    final String defaultName = JKubeProjectUtil.createDefaultResourceName(getContext().getGav().getSanitizedArtifactId());
     builder.accept(new TypedVisitor<ObjectMetaBuilder>() {
       @Override
       public void visit(ObjectMetaBuilder resource) {
-        if (StringUtils.isBlank(resource.getName())) {
+        if (StringUtils.isNotBlank(configuredName)) {
+          resource.withName(configuredName);
+        } else if (StringUtils.isBlank(resource.getName())) {
           resource.withName(defaultName);
         }
       }

--- a/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/kubernetes-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -21,7 +21,6 @@
     # The order given in "includes" is the order in which enrichers are called
     includes:
     - jkube-metadata
-    - jkube-name
     - jkube-controller
     - jkube-controller-from-configuration
     - jkube-service
@@ -75,6 +74,7 @@
     - jkube-triggers-annotation
     - jkube-openshift-imageChangeTrigger
 
+    - jkube-name
     # ReplicaCountEnricher overrides .spec.replicas field of any resource (even dependencies)
     - jkube-replicas
 

--- a/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
+++ b/openshift-maven-plugin/plugin/src/main/resources/META-INF/jkube/profiles-default.yml
@@ -23,7 +23,6 @@
     # The order given in "includes" is the order in which enrichers are called
     includes:
     - jkube-metadata
-    - jkube-name
     - jkube-controller
     - jkube-controller-from-configuration
     - jkube-service
@@ -77,6 +76,7 @@
     - jkube-triggers-annotation
     - jkube-openshift-imageChangeTrigger
 
+    - jkube-name
       # ReplicaCountEnricher overrides .spec.replicas field of any resource (even dependencies)
     - jkube-replicas
 


### PR DESCRIPTION
## Description
Fix #1325 

Change ordering of NameEnricher and modify it's logic to override name in
case of custom enricher configuration

Signed-off-by: Rohan Kumar <rohaan@redhat.com>
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->