### PR TITLE
chore : Generate a preview of jkube documentation for PR if needed (#1251)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,22 @@ jobs:
         paths:
         - ~/.m2
 
+  doc-preview-pr:
+    docker:
+      - image: cimg/openjdk:11.0
+    steps:
+    - checkout
+    - restore_cache:
+        key: jkube-kit-{{ checksum "pom.xml" }}
+    - run: |
+        if [ -n "${CIRCLE_PR_NUMBER}" ]; then
+          ./scripts/generateDoc.sh
+        else
+          echo "No Doc preview run as this is not a pull request"
+        fi
+    - store_artifacts:
+        path: ./docs-generated/
+
 workflows:
   version: 2
   all:
@@ -109,3 +125,4 @@ workflows:
         filters:
           branches:
             only: master
+    - doc-preview-pr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 ### 1.8.0-SNAPSHOT
 * Fix #1201: ThorntailV2Generator works with Gradle Plugins
+* Fix #1251: Generate a preview of jkube documentation for PR if needed
 * Fix #1260: Add documentation for PodAnnotationEnricher
 * Fix #1284: webapp custom generator should not require to set a CMD configuration
 * Fix #1295: Spring Boot actuator endpoints failed to generate automatically if `deployment.yml` resource fragment is used

--- a/scripts/generateDoc.sh
+++ b/scripts/generateDoc.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+trap 'exit' ERR
+
+mkdir docs-generated
+# Kubernetes Gradle Plugin
+mvn -f gradle-plugin/doc -Phtml package
+cp gradle-plugin/doc/target/generated-docs/index.html docs-generated/kubernetes-gradle-plugin.html
+# Kubernetes Maven Plugin
+mvn -f kubernetes-maven-plugin/doc -Phtml package
+cp kubernetes-maven-plugin/doc/target/generated-docs/index.html docs-generated/kubernetes-maven-plugin.html
+# OpenShift Gradle Plugin
+mvn -f gradle-plugin/doc -Phtml package -Dplugin=openshift-gradle-plugin -Dtask-prefix=oc -Dcluster=OpenShift -DpluginExtension=openshift
+cp gradle-plugin/doc/target/generated-docs/index.html docs-generated/openshift-gradle-plugin.html
+# OpenShift Maven Plugin
+mvn -f kubernetes-maven-plugin/doc -Phtml package -Dplugin=openshift-maven-plugin -Dgoal-prefix=oc -Dcluster=OpenShift
+cp kubernetes-maven-plugin/doc/target/generated-docs/index.html docs-generated/openshift-maven-plugin.html
+
+cat << EOF >> docs-generated/index.html
+<html>
+  <head>
+    <meta name="robots" content="noindex" />
+  </head>
+  <body>
+    <ul>
+        <li><a href="./kubernetes-maven-plugin.html">Kubernetes Maven Plugin</a></li>
+        <li><a href="./openshift-maven-plugin.html">OpenShift Maven Plugin</a></li>
+        <li><a href="./kubernetes-gradle-plugin.html">Kubernetes Gradle Plugin</a></li>
+        <li><a href="./openshift-gradle-plugin.html">OpenShift Gradle Plugin</a></li>
+    </ul>
+  </body>
+</html>
+EOF
+
+cat << EOF >> docs-generated/robots.txt
+User-agent: *
+Disallow: /
+
+EOF


### PR DESCRIPTION
## Description

Fix #1251 

~Use surge.sh to generate preview documentation of pull requests. Preview URL would be of format `jkubedocs-pull-$PR_NUMBER-preview.surge.sh`~

Generate documentation in CircleCi workflow and then upload it as circleci build artifacts. This way we won't need any kind of service to host our temporary website pages.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->