### PR TITLE
feat(webapp-generator): env variables configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 ### 1.8.0-SNAPSHOT
 * Fix #1201: ThorntailV2Generator works with Gradle Plugins
+* Fix #1208: Allow env variables to be passed to a webapp generator s2i builder
 * Fix #1251: Generate a preview of jkube documentation for PR if needed
 * Fix #1259: Add integration test and docs for NameEnricher
 * Fix #1260: Add documentation for PodAnnotationEnricher

--- a/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
@@ -77,4 +77,12 @@ In addition to the  <<generator-options-common, common generator options>> this 
 | Comma separated list of ports to expose in the image and which eventually are translated later to Kubernetes services.
   The ports depend on the base image and are selected automatically. But they can be overridden here.
 | `jkube.generator.webapp.ports`
+
+| *env*
+| Environment variable to be set to the image builder environment. Should be set in the format `ENV_NAME=environment value`. You can inject multiple env variables by adding a new line for each variable.
+ifeval::["{goal-prefix}" == "oc"]
+
+This may be required for Wildfly webapp s2i build to compose a `WildFly` server with Galleon layers. See https://docs.wildfly.org/21/Galleon_Guide.html#wildfly_foundational_galleon_layers and https://github.com/wildfly/wildfly-s2i#environment-variables-to-be-used-at-s2i-build-time/.
+endif::[]
+| `jkube.generator.webapp.env`
 |===

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
@@ -171,7 +171,7 @@ public class WebAppGenerator extends BaseGenerator {
       return Collections.emptyMap();
     }
 
-    return Pattern.compile("\\s+").splitAsStream(envConfigValue) // "envName1=value1 envName2=value2"
+    return Pattern.compile("\\n\\s*").splitAsStream(envConfigValue) // "envName1=value1\n   envName2=value2"
         .map(envNameValue -> envNameValue.split("=")) //
         .filter(e -> e.length == 2) //
         .collect(Collectors.toMap(e -> e[0], e -> e[1]));

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
@@ -203,9 +203,11 @@ public class WebAppGeneratorTest {
         .hasFieldOrPropertyWithValue("cmd", null);
   }
 
-  public void extractEnvVariables_withMultipleEnvVariableSpaceSeparator_shouldExtractThemAll() {
+  @Test
+  public void extractEnvVariables_withMultipleEnvVariable_shouldExtractThemAll() {
     // Given
-    String envConfig = "GALLEON_PROVISION_LAYERS=web-server,ejb-lite,jsf,jpa,h2-driver IMAGE_STREAM_NAMESPACE=myproject";
+    String envConfig = "GALLEON_PROVISION_LAYERS=web-server,ejb-lite,jsf,jpa,h2-driver\n" + //
+        "\t\t\t\t\t\t\t IMAGE_STREAM_NAMESPACE=myproject";
     // when
     Map<String, String> extractedVariables = WebAppGenerator.extractEnvVariables(envConfig);
     // then
@@ -224,14 +226,17 @@ public class WebAppGeneratorTest {
   }
 
   @Test
-  public void extractEnvVariables_withMultipleEnvVariableCRSeparator_shouldExtractThemAll() {
+  public void extractEnvVariables_withMultipleEnvVariableWithSpacesSemicolonAndCommas_shouldExtractThemAll() {
     // Given
-    String envConfig = "GALLEON_PROVISION_LAYERS=web-server,ejb-lite,jsf,jpa,h2-driver\nIMAGE_STREAM_NAMESPACE=myproject";
+    String envConfig = "ENV_WITH_SPACES=This is an environment variable with spaces\n" + //
+        "               ENV_WITH_SEMICOLON=/path;/other/path\n" + //
+        "               ENV_WITH_COMMAS=layer1,layer2";
     // when
     Map<String, String> extractedVariables = WebAppGenerator.extractEnvVariables(envConfig);
     // then
-    assertEquals("web-server,ejb-lite,jsf,jpa,h2-driver", extractedVariables.get("GALLEON_PROVISION_LAYERS"));
-    assertEquals("myproject", extractedVariables.get("IMAGE_STREAM_NAMESPACE"));
+    assertEquals("This is an environment variable with spaces", extractedVariables.get("ENV_WITH_SPACES"));
+    assertEquals("/path;/other/path", extractedVariables.get("ENV_WITH_SEMICOLON"));
+    assertEquals("layer1,layer2", extractedVariables.get("ENV_WITH_COMMAS"));
   }
 
   @Test

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.eclipse.jkube.generator.api.GeneratorContext;
@@ -36,6 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
@@ -200,4 +202,46 @@ public class WebAppGeneratorTest {
         .hasFieldOrPropertyWithValue("env", Collections.singletonMap("DEPLOY_DIR", "/usr/local/tomcat/webapps"))
         .hasFieldOrPropertyWithValue("cmd", null);
   }
+
+  public void extractEnvVariables_withMultipleEnvVariableSpaceSeparator_shouldExtractThemAll() {
+    // Given
+    String envConfig = "GALLEON_PROVISION_LAYERS=web-server,ejb-lite,jsf,jpa,h2-driver IMAGE_STREAM_NAMESPACE=myproject";
+    // when
+    Map<String, String> extractedVariables = WebAppGenerator.extractEnvVariables(envConfig);
+    // then
+    assertEquals("web-server,ejb-lite,jsf,jpa,h2-driver", extractedVariables.get("GALLEON_PROVISION_LAYERS"));
+    assertEquals("myproject", extractedVariables.get("IMAGE_STREAM_NAMESPACE"));
+  }
+
+  @Test
+  public void extractEnvVariables_withSingleEnvVariable_shouldExtractIt() {
+    // Given
+    String envConfig = "GALLEON_PROVISION_LAYERS=web-server,ejb-lite,jsf,jpa,h2-driver";
+    // when
+    Map<String, String> extractedVariables = WebAppGenerator.extractEnvVariables(envConfig);
+    // then
+    assertEquals("web-server,ejb-lite,jsf,jpa,h2-driver", extractedVariables.get("GALLEON_PROVISION_LAYERS"));
+  }
+
+  @Test
+  public void extractEnvVariables_withMultipleEnvVariableCRSeparator_shouldExtractThemAll() {
+    // Given
+    String envConfig = "GALLEON_PROVISION_LAYERS=web-server,ejb-lite,jsf,jpa,h2-driver\nIMAGE_STREAM_NAMESPACE=myproject";
+    // when
+    Map<String, String> extractedVariables = WebAppGenerator.extractEnvVariables(envConfig);
+    // then
+    assertEquals("web-server,ejb-lite,jsf,jpa,h2-driver", extractedVariables.get("GALLEON_PROVISION_LAYERS"));
+    assertEquals("myproject", extractedVariables.get("IMAGE_STREAM_NAMESPACE"));
+  }
+
+  @Test
+  public void extractEnvVariables_withEnvNull_shouldReturnAnEmptyMap() {
+    // Given
+    String envConfig = null;
+    // when
+    Map<String, String> extractedVariables = WebAppGenerator.extractEnvVariables(envConfig);
+    // then
+    assertTrue(extractedVariables.isEmpty());
+  }
+
 }

--- a/quickstarts/gradle/webapp-wildfly/README.md
+++ b/quickstarts/gradle/webapp-wildfly/README.md
@@ -4,6 +4,13 @@ Demonstrates how to create a container image with an embedded WildFly server usi
 WildFly is used instead of Apache Tomcat because there is a WildFly persistence.xml and -ds.xml configuration.
 Eclipse JKube detects this file and chooses a WildFly specific base container image.
 
+We just added to the project
+- the plugins `kubernetes-gradle-plugin` (for vanilla Kubernetes) and `openshit-gradle-plugin` (for openshift)
+- `gradle.properties` file with `jkube.createExternalUrls=true` to create an Ingress or a Route.
+
+
+# Minikube
+
 ## Prerequisites
 You will need the following to run it with Minikube:
 - minikube installed and running on your computer
@@ -42,7 +49,7 @@ kubernetes/webapp-wildfly                               latest         622fa19f8
 
 ## Generate Kubernetes Manifests
 ```
-$ ./gradlew k8sResource -Djkube.createExternalUrls=true -Djkube.domain=$(minikube ip).nip.io
+$ ./gradlew k8sResource -Djkube.domain=$(minikube ip).nip.io
 > Task :k8sResource
 k8s: Running in Kubernetes mode
 k8s: Running generator webapp
@@ -117,3 +124,17 @@ $ lynx --dump webapp-wildfly.192.168.99.110.nip.io
    sunix        Sun        Tan
 ```
 
+# Red Hat Developer Sandbox
+
+## Prerequisites
+- Create an account here: https://developers.redhat.com/developer-sandbox/get-started
+- Install `oc`
+- Login with `oc` see https://developers.redhat.com/blog/2021/04/21/access-your-developer-sandbox-for-red-hat-openshift-from-the-command-line#
+
+## Adding the JKube plugin
+One line deploy:
+
+    $ ./gradlew clean build ocBuild ocResource ocApply
+
+
+Check in the `topology` view to retrieve the URL.

--- a/quickstarts/gradle/webapp-wildfly/build.gradle
+++ b/quickstarts/gradle/webapp-wildfly/build.gradle
@@ -1,7 +1,8 @@
 plugins {
     id 'java'
     id 'war'
-    id 'org.eclipse.jkube.kubernetes' version '1.7.0'
+    id 'org.eclipse.jkube.kubernetes' version '1.8.0-SNAPSHOT'
+    id 'org.eclipse.jkube.openshift' version '1.8.0-SNAPSHOT'
 }
 
 repositories {
@@ -35,4 +36,14 @@ compileJava {
 
 compileTestJava {
     options.encoding = 'UTF-8'
+}
+
+openshift {
+    generator {
+        config {
+            'webapp' {
+                env = "GALLEON_PROVISION_LAYERS=web-server,ejb-lite,jsf,jpa,h2-driver"
+            }
+        }
+    }
 }

--- a/quickstarts/gradle/webapp-wildfly/gradle.properties
+++ b/quickstarts/gradle/webapp-wildfly/gradle.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+#Gradle properties
+jkube.createExternalUrls=true


### PR DESCRIPTION
## Description
This is allowing passing env variable to the webapp gen build.
For instance, for a gradle wildfly webapp project
```
openshift {
    generator {
        config {
            'webapp' {
                env = "GALLEON_PROVISION_LAYERS=web-server,ejb-lite,jsf,jpa,h2-driver"
            }
        }
    }
}
```
will pass the right `GALLEON_PROVISION_LAYERS` to the s2i build and generate the right layers.

This is part of https://github.com/eclipse/jkube/issues/1208

I also provided to this PR an update of the gradle webapp-wildfly quickstart with an example of how to have it working in openshift by injecting `GALLEON_PROVISION_LAYERS`.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->