### PR TITLE
doc : Add documentation for ReplicaCountEnricher (#1297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Usage:
 * Fix #1262: Add docs + gradle integration test for ProjectLabelEnricher
 * Fix #1284: webapp custom generator should not require to set a CMD configuration
 * Fix #1295: Spring Boot actuator endpoints failed to generate automatically if `deployment.yml` resource fragment is used
+* Fix #1297: ReplicaCountEnricher documentation ported to Gradle plugins
 * Fix #1325: `jkube.enricher.jkube-name.name` doesn't modify `.metadata.name` for generated manifests
 
 ### 1.7.0 (2022-02-25)

--- a/jkube-kit/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -87,6 +87,9 @@ by other enrichers, {plugin-configuration-type} configuration or fragment.
 | <<jkube-project-label>>
 | Add {plugin-type} coordinates as labels to all objects.
 
+| <<jkube-replicas>>
+| Override number of replicas for any controller processed by JKube.
+
 | <<jkube-secret-file>>
 | Add Secret elements defined as annotation.
 
@@ -111,9 +114,6 @@ ifeval::["{plugin-type}" == "maven"]
 
 | <<jkube-prometheus>>
 | Add Prometheus annotations.
-
-| <<jkube-replicas>>
-| Override number of replicas for any controller processed by JKube.
 
 | <<jkube-revision-history-enricher>>
 | Add revision history limit (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit[Kubernetes doc]) as a deployment spec property to the Kubernetes/OpenShift resources.
@@ -159,6 +159,8 @@ include::enricher/pod-annotation/_jkube_pod_annotation.adoc[]
 include::enricher/port-name/_jkube_port_name.adoc[]
 
 include::enricher/project-label/_jkube_project_label.adoc[]
+
+include::enricher/replicacount/_jkube_replicacount.adoc[]
 
 include::enricher/secret-file/_jkube_secret_file.adoc[]
 

--- a/jkube-kit/doc/src/main/asciidoc/inc/enricher/replicacount/_jkube_replicacount.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/enricher/replicacount/_jkube_replicacount.adoc
@@ -1,0 +1,4 @@
+[[jkube-replicas]]
+==== jkube-replicas
+
+This enricher fixes replica count for Kubernetes/Openshift resources whenever a `-Djkube.replicas=n` parameter is provided.


### PR DESCRIPTION
## Description
Fix #1297 

ReplicaCountEnricher Asciidoc should be available in both maven and gradle plugin docs.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->