### PR TITLE
doc (jkube-kit/doc) : Add documentation for DeploymentConfigEnricher (#1308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Usage:
 * Fix #1284: webapp custom generator should not require to set a CMD configuration
 * Fix #1295: Spring Boot actuator endpoints failed to generate automatically if `deployment.yml` resource fragment is used
 * Fix #1297: ReplicaCountEnricher documentation ported to Gradle plugins
+* Fix #1308: Add documentation for DeploymentConfigEnricher
 * Fix #1325: `jkube.enricher.jkube-name.name` doesn't modify `.metadata.name` for generated manifests
 
 ### 1.7.0 (2022-02-25)

--- a/jkube-kit/doc/src/main/asciidoc/inc/_enricher.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/_enricher.adoc
@@ -78,6 +78,13 @@ by other enrichers, {plugin-configuration-type} configuration or fragment.
 | <<jkube-namespace>>
 | Set the _Namespace_ of the generated and processed Kubernetes resources metadata and optionally create a new Namespace
 
+ifeval::["{goal-prefix}" == "oc"]
+include::enricher/deploymentconfig/_jkube_openshift_deploymentconfig_entry.adoc[]
+endif::[]
+ifeval::["{task-prefix}" == "oc"]
+include::enricher/deploymentconfig/_jkube_openshift_deploymentconfig_entry.adoc[]
+endif::[]
+
 | <<jkube-pod-annotation>>
 | Copy over annotations from a `Deployment` to a `Pod`
 
@@ -153,6 +160,13 @@ include::enricher/ingress/_jkube_ingress.adoc[]
 include::enricher/metadata/_jkube_metadata.adoc[]
 
 include::enricher/namespace/_jkube_namespace.adoc[]
+
+ifeval::["{goal-prefix}" == "oc"]
+include::enricher/deploymentconfig/_jkube_openshift_deploymentconfig.adoc[]
+endif::[]
+ifeval::["{task-prefix}" == "oc"]
+include::enricher/deploymentconfig/_jkube_openshift_deploymentconfig.adoc[]
+endif::[]
 
 include::enricher/pod-annotation/_jkube_pod_annotation.adoc[]
 

--- a/jkube-kit/doc/src/main/asciidoc/inc/enricher/deploymentconfig/_jkube_openshift_deploymentconfig.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/enricher/deploymentconfig/_jkube_openshift_deploymentconfig.adoc
@@ -1,0 +1,9 @@
+
+[[jkube-openshift-deploymentconfig]]
+==== jkube-openshift-deploymentconfig
+
+This enricher converts Kubernetes `Deployment` object(`extensions/v1beta1` or `apps/v1`) to OpenShift equivalent `DeploymentConfig`.
+
+It's applicable only for OpenShift.
+
+Note that this won't be enabled if you've set `jkube.build.switchToDeployment` to `true` or you've configured <<jkube-controller, DefaultControllerEnricher>> to generate a controller of type `DeploymentConfig`

--- a/jkube-kit/doc/src/main/asciidoc/inc/enricher/deploymentconfig/_jkube_openshift_deploymentconfig_entry.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/enricher/deploymentconfig/_jkube_openshift_deploymentconfig_entry.adoc
@@ -1,0 +1,2 @@
+| <<jkube-openshift-deploymentconfig>>
+| Enriches that converts existing Deployment object to DeploymentConfig.


### PR DESCRIPTION
Fix #1308

Add asciidoc documentation for DeploymentConfigEnricher which should
show up in both maven and gradle plugin docs.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->