### PR TITLE
GoTimeUtilTest : Use assertThat(actual).contains(expected) instead of fetching and comparing optional

### DIFF
--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/GoTimeUtilTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/GoTimeUtilTest.java
@@ -13,15 +13,12 @@
  */
 package org.eclipse.jkube.kit.enricher.api.util;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class GoTimeUtilTest {
 
@@ -33,28 +30,24 @@ public class GoTimeUtilTest {
         List<Integer> expectations = Arrays.asList(23, 0, 0, 0, 1, 123, 3663, 1810, -15, 30);
 
         for (int i = 0; i < inputs.size(); i++) {
-            // When
-            Optional<Integer> result = GoTimeUtil.durationSeconds(inputs.get(i));
-
-            // Then
-            assertTrue(result.isPresent());
-            Assertions.assertThat(result.get()).isEqualTo(expectations.get(i).intValue());
+            assertThat(GoTimeUtil.durationSeconds(inputs.get(i)))
+                    .contains(expectations.get(i));
         }
     }
 
     @Test
     public void testNull() {
-        assertEquals(Optional.empty(), GoTimeUtil.durationSeconds(null));
+        assertThat(GoTimeUtil.durationSeconds(null)).isEmpty();
     }
 
     @Test
     public void testEmpty() {
-        assertEquals(Optional.empty(), GoTimeUtil.durationSeconds(""));
+        assertThat(GoTimeUtil.durationSeconds("")).isEmpty();
     }
 
     @Test
     public void testBlankSpace() {
-        assertEquals(Optional.empty(), GoTimeUtil.durationSeconds(" "));
+        assertThat(GoTimeUtil.durationSeconds(" ")).isEmpty();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -76,7 +69,4 @@ public class GoTimeUtilTest {
     public void testErrorUnparsable() {
         GoTimeUtil.durationSeconds("ms");
     }
-
-
-
 }


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
--> GoTimeUtilTest : Use assertThat(actual).contains(expected) instead of fetching and comparing optional #1378 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->