### PR TITLE
fix : Build ARGS not replaced properly (#1382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Usage:
 * Fix #1325: `jkube.enricher.jkube-name.name` doesn't modify `.metadata.name` for generated manifests
 * Fix #1336: Add documentation and quickstart for using custom generators with Gradle Plugins
 * Fix #1362: VolumePermissionEnricher : Replace iteration with bulk Collection.addAll call
+* Fix #1382: Docker Build ARGS not replaced properly
 
 ### 1.7.0 (2022-02-25)
 * Fix #1315: Pod Log Service works for Jobs with no selector

--- a/jkube-kit/build/api/src/test/resources/org/eclipse/jkube/kit/build/api/helper/Dockerfile_multi_stage_with_args
+++ b/jkube-kit/build/api/src/test/resources/org/eclipse/jkube/kit/build/api/helper/Dockerfile_multi_stage_with_args
@@ -2,3 +2,6 @@ ARG VERSION:latest
 FROM fabric8/s2i-java:$VERSION AS BUILD
 ARG FULL_IMAGE=busybox:latest
 FROM $FULL_IMAGE AS DEPLOYABLE
+ARG REPO_1:docker.io/library
+ARG IMAGE-1:openjdk
+FROM $REPO_1/${IMAGE-1}:$VERSION


### PR DESCRIPTION
## Description
Fix #1382  

Port https://github.com/fabric8io/docker-maven-plugin/pull/1490 from
Docker Maven Plugin to JKube in order to fix build ARG resolution issue
while pulling images

I've tested with Dockerfile provided in the issue. This seems to fix the issue reported in #1382 

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->