### PR TITLE
doc(maven-openshift): Fix openshift global parameter names in documentation for oc:build

### DIFF
--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-build.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-build.adoc
@@ -265,7 +265,7 @@ the URL is:
 | `jkube.profile`
 
 ifeval::["{goal-prefix}" == "oc"]
-| *pullSecret*
+| *openshiftPullSecret*
 | The name to use for naming pullSecret to be created to pull the base image in case pulling from a private registry
    which requires authentication for OpenShift.
 
@@ -274,7 +274,7 @@ ifeval::["{goal-prefix}" == "oc"]
 endif::[]
 
 ifeval::["{goal-prefix}" == "oc"]
-| *pushSecret*
+| *openshiftPushSecret*
 | The name of pushSecret to be used to push the final image in case pushing from a
   protected registry which requires authentication.
 
@@ -283,7 +283,7 @@ endif::[]
 
 
 ifeval::["{goal-prefix}" == "oc"]
-| *jkube.build.buildOutput.kind*
+| *buildOutputKind*
 |  Allow to specify in which registry to push the container image at the end of the build.
    If the output kind is ImageStreamTag, then the image will be pushed to the internal OpenShift registry.
    If the output is of type DockerImage, then the name of the output reference will be used as a Docker push specification.


### PR DESCRIPTION
## Description
Fixes the names of the parameters openshiftPullSecret, openshiftPushSecret, buildOutputKind in the `oc:build` section of the openshift-maven-plugin documentation.

The names in the doc do not correspond by the name of the properties on the codebase that it is using them [OpenshiftBuildMojo.java](https://github.com/eclipse/jkube/blob/479858aa6719ffaabe8320c87ec43d129c78ffe6/openshift-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenshiftBuildMojo.java).

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] ~~I Added [CHANGELOG](../CHANGELOG.md) entry~~
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] ~~I tested my code in Kubernetes~~
 - [ ] ~~I tested my code in OpenShift~~
