### PR TITLE
More readable, efficient code for buildServiceTest

### DIFF
--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/BuildServiceTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/BuildServiceTest.java
@@ -70,7 +70,7 @@ public class BuildServiceTest {
     buildService.buildImage(imageConfiguration, mockedImagePullManager, mockedJKubeConfiguration);
 
     // Then
-    verify(mockedDockerAccess, times(1))
+    verify(mockedDockerAccess)
         .buildImage(eq("image-name"), any(), any());
   }
 
@@ -94,8 +94,8 @@ public class BuildServiceTest {
     buildService.tagImage("image-name", imageConfiguration);
 
     // Then
-    verify(mockedDockerAccess, times(1))
-        .tag(eq("image-name"), eq("image-name:latest"), eq(true));
+    verify(mockedDockerAccess)
+        .tag("image-name", "image-name:latest", true);
   }
 
 }

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/HealthCheckConfigTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/HealthCheckConfigTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.kit.config.image.build;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -92,65 +93,66 @@ public class HealthCheckConfigTest {
                 .validate();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadHealthCheck1() {
-        HealthCheckConfiguration.builder()
+        HealthCheckConfiguration healthCheckConfiguration = HealthCheckConfiguration.builder()
                 .mode(HealthCheckMode.none)
                 .interval("2s")
-                .build()
-                .validate();
+                .build();
+        Assert.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadHealthCheck2() {
-        HealthCheckConfiguration.builder()
+        HealthCheckConfiguration healthCheckConfiguration = HealthCheckConfiguration.builder()
                 .mode(HealthCheckMode.none)
                 .retries(1)
-                .build()
-                .validate();
+                .build();
+        Assert.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadHealthCheck3() {
-        HealthCheckConfiguration.builder()
+        HealthCheckConfiguration healthCheckConfiguration = HealthCheckConfiguration.builder()
                 .mode(HealthCheckMode.none)
                 .timeout("3s")
-                .build()
-                .validate();
+                .build();
+        Assert.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
+
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadHealthCheck4() {
-        HealthCheckConfiguration.builder()
+        HealthCheckConfiguration healthCheckConfiguration = HealthCheckConfiguration.builder()
                 .mode(HealthCheckMode.none)
                 .startPeriod("30s")
                 .cmd(Arguments.builder().shell("echo a").build())
-                .build()
-                .validate();
+                .build();
+        Assert.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadHealthCheck5() {
-        HealthCheckConfiguration.builder()
+        HealthCheckConfiguration healthCheckConfiguration = HealthCheckConfiguration.builder()
                 .mode(HealthCheckMode.none)
                 .cmd(Arguments.builder().shell("echo a").build())
-                .build()
-                .validate();
+                .build();
+        Assert.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadHealthCheck6() {
-        HealthCheckConfiguration.builder()
-                .build()
-                .validate();
+        HealthCheckConfiguration healthCheckConfiguration = HealthCheckConfiguration.builder()
+                .build();
+        Assert.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadHealthCheck7() {
-        HealthCheckConfiguration.builder()
+        HealthCheckConfiguration healthCheckConfiguration = HealthCheckConfiguration.builder()
                 .mode(HealthCheckMode.cmd)
-                .build()
-                .validate();
+                .build();
+        Assert.assertThrows(IllegalArgumentException.class, healthCheckConfiguration::validate);
     }
 
 }


### PR DESCRIPTION
## Description
Simplified  verify() call to remove argument matchers and to be more readable.
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
Let me know if there is any thing more I can do to help ;)