### PR TITLE
Define metadata labels and annotations to Route objects 

### DIFF
--- a/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
@@ -567,6 +567,11 @@ endif::[]
 
 | *serviceAccount*
 | Labels and annotations applied to `ServiceAccount` objects.
+ifeval::["{task-prefix}" == "oc"]
+
+| *route*
+| Labels and annotations applied to `Route` objects.
+endif::[]
 |===
 
 [[controller-resource-groovy-configuration]]

--- a/gradle-plugin/it/src/it/metadata/build.gradle
+++ b/gradle-plugin/it/src/it/metadata/build.gradle
@@ -110,6 +110,9 @@ openshift {
             serviceAccount {
                 keyinserviceaccount = 'valueinserviceaccount'
             }
+            route {
+                keyinroute = 'valueinroute'
+            }
         }
         annotations {
             all {
@@ -132,6 +135,9 @@ openshift {
             }
             serviceAccount {
                 keyinserviceaccount = 'valueinserviceaccount'
+            }
+            route {
+                keyinroute = 'valueinroute'
             }
         }
         serviceAccounts = [{

--- a/gradle-plugin/it/src/it/metadata/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/metadata/expected/openshift.yml
@@ -129,9 +129,11 @@ items:
       app.openshift.io/vcs-uri: "@ignore@"
       jkube.io/git-commit: "@ignore@"
       keyinall: valueinall
+      keyinroute: valueinroute
       jkube.io/git-branch: "@ignore@"
     labels:
       keyinall: valueinall
+      keyinroute: valueinroute
       app: metadata
       provider: jkube
       version: "@ignore@"

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/MetaDataConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/MetaDataConfig.java
@@ -66,4 +66,9 @@ public class MetaDataConfig {
    * Labels or annotations for Service Account
    */
   private Properties serviceAccount;
+
+  /**
+   * Labels or annotations for OpenShift routes
+   */
+  private Properties route;
 }

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/visitor/MetadataVisitor.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/visitor/MetadataVisitor.java
@@ -70,6 +70,9 @@ import io.fabric8.openshift.api.model.DeploymentConfigFluentImpl;
 import io.fabric8.openshift.api.model.ImageStreamBuilder;
 import io.fabric8.openshift.api.model.ImageStreamFluent;
 import io.fabric8.openshift.api.model.ImageStreamFluentImpl;
+import io.fabric8.openshift.api.model.RouteBuilder;
+import io.fabric8.openshift.api.model.RouteFluent;
+import io.fabric8.openshift.api.model.RouteFluentImpl;
 import lombok.AllArgsConstructor;
 
 import static org.eclipse.jkube.kit.common.util.PropertiesUtil.toMap;
@@ -256,6 +259,12 @@ public class MetadataVisitor<T extends VisitableBuilder> extends TypedVisitor<T>
         ServiceAccountBuilder.class,
         getAnnotations(resourceConfig)::getServiceAccount, getLabels(resourceConfig)::getServiceAccount,
         ServiceAccountFluentImpl::editOrNewMetadata, omf -> ((ServiceAccountFluent.MetadataNested<?>) omf)::endMetadata);
+  }
+
+  public static MetadataVisitor<RouteBuilder> route(ResourceConfig resourceConfig) {
+    return new MetadataVisitor<>(RouteBuilder.class, 
+        getAnnotations(resourceConfig)::getRoute, getLabels(resourceConfig)::getRoute,
+        RouteFluentImpl::editOrNewMetadata, omf -> ((RouteFluent.MetadataNested<?>) omf)::endMetadata);
   }
 
 }

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/visitor/MetadataVisitorTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/visitor/MetadataVisitorTest.java
@@ -34,6 +34,7 @@ import io.fabric8.openshift.api.model.BuildBuilder;
 import io.fabric8.openshift.api.model.BuildConfigBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import io.fabric8.openshift.api.model.ImageStreamBuilder;
+import io.fabric8.openshift.api.model.RouteBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,6 +55,7 @@ public class MetadataVisitorTest {
         .replicaSet(new Properties())
         .service(new Properties())
         .serviceAccount(new Properties())
+        .route(new Properties())
         .build();
     annotations.getAll().put("this-is-all", 1);
     annotations.getDeployment().put("deployment", "Yay");
@@ -62,6 +64,7 @@ public class MetadataVisitorTest {
     annotations.getReplicaSet().put("replica-set", "Yay");
     annotations.getService().put("service", "Yay");
     annotations.getServiceAccount().put("service-account", "Yay");
+    annotations.getRoute().put("route", "Yay");
     final Properties labelsAll = (Properties) annotations.getAll().clone();
     labelsAll.put("super-label", "S");
     final MetaDataConfig labels = annotations.toBuilder()
@@ -333,5 +336,16 @@ public class MetadataVisitorTest {
     // Then
     assertThat(sa.build().getMetadata().getAnnotations()).containsOnly( entry("service-account", "Yay"));
     assertThat(sa.build().getMetadata().getLabels()).containsOnly(entry("service-account", "Yay"));
+  }
+
+  @Test
+  public void route() {
+    // Given
+    final RouteBuilder route = new RouteBuilder();
+    // When
+    MetadataVisitor.route(resourceConfig).visit(route);
+    // Then
+    assertThat(route.build().getMetadata().getAnnotations()).containsOnly( entry("route", "Yay"));
+    assertThat(route.build().getMetadata().getLabels()).containsOnly(entry("route", "Yay"));
   }
 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultMetadataEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultMetadataEnricher.java
@@ -49,6 +49,7 @@ public class DefaultMetadataEnricher extends BaseEnricher {
             MetadataVisitor.ingressV1beta1(resourceConfig),
             MetadataVisitor.ingressV1(resourceConfig),
             MetadataVisitor.serviceAccount(resourceConfig),
+            MetadataVisitor.route(resourceConfig),
             // Apply last: Other MetadataVisitor might initiate the metadata field for the item
             MetadataVisitor.metadata(resourceConfig)
         };

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultMetadataEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultMetadataEnricherTest.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
 import io.fabric8.kubernetes.api.model.extensions.DeploymentBuilder;
+import io.fabric8.openshift.api.model.RouteBuilder;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.eclipse.jkube.kit.config.resource.MetaDataConfig;
@@ -47,6 +48,7 @@ public class DefaultMetadataEnricherTest {
   private io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder ingressV1;
   private io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder ingressV1beta1;
   private ServiceAccountBuilder serviceAccount;
+  private RouteBuilder route;
   private KubernetesListBuilder klb;
 
   @Before
@@ -58,12 +60,14 @@ public class DefaultMetadataEnricherTest {
                 .deployment(properties("deployment", "Deployment"))
                 .ingress(properties("ingress", "Ingress"))
                 .serviceAccount(properties("service-account", "ServiceAccount"))
+                .route(properties("route", "Route"))
                 .build())
             .labels(MetaDataConfig.builder()
                 .all(properties("all-label", 10L))
                 .deployment(properties("deployment-label", "Deployment"))
                 .ingress(properties("ingress-label", "Ingress"))
                 .serviceAccount(properties("service-account-label", "ServiceAccount"))
+                .route(properties("route-label", "Route"))
                 .build())
             .build())
         .build();
@@ -79,9 +83,10 @@ public class DefaultMetadataEnricherTest {
     ingressV1 = new io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder();
     ingressV1beta1 = new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder();
     serviceAccount = new ServiceAccountBuilder();
+    route = new RouteBuilder();
     klb = new KubernetesListBuilder().addToItems(configMap).addToItems(deployment)
         .addToItems(genericResource).addToItems(ingressV1).addToItems(ingressV1beta1)
-        .addToItems(serviceAccount);
+        .addToItems(serviceAccount).addToItems(route);
 
   }
 
@@ -145,6 +150,17 @@ public class DefaultMetadataEnricherTest {
         .containsOnly(entry("all-annotation", "1"), entry("service-account", "ServiceAccount"));
     assertThat(serviceAccount.build().getMetadata().getLabels())
         .containsOnly(entry("all-label", "10"), entry("service-account-label", "ServiceAccount"));
+  }
+
+  @Test
+  public void route() {
+    // When
+    defaultMetadataEnricher.enrich(PlatformMode.kubernetes, klb);
+    // Then
+    assertThat(route.build().getMetadata().getAnnotations())
+        .containsOnly(entry("all-annotation", "1"), entry("route", "Route"));
+    assertThat(route.build().getMetadata().getLabels())
+        .containsOnly(entry("all-label", "10"), entry("route-label", "Route"));
   }
 
   private static Properties properties(Object... keyValuePairs) {

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -105,6 +105,11 @@ endif::[]
 
 | *serviceAccount*
 | Labels and annotations applied to `ServiceAccount` objects.
+ifeval::["{goal-prefix}" == "oc"]
+
+| *route*
+| Labels and annotations applied to `Route` objects.
+endif::[]
 |===
 
 [[controller-resource-generation]]


### PR DESCRIPTION
## Description

Allow the DefaultMetadataEnricher to define labels and annotations to the OpenShift Route objects from the Resource configuration.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] ~~I tested my code in Kubernetes~~
 - [X] I tested my code in OpenShift