### PR TITLE
fix: FileAssertions related unit test failures

### DIFF
--- a/jkube-kit/common-test/src/main/java/org/eclipse/jkube/kit/common/assertj/FileAssertions.java
+++ b/jkube-kit/common-test/src/main/java/org/eclipse/jkube/kit/common/assertj/FileAssertions.java
@@ -42,7 +42,7 @@ public class FileAssertions extends AbstractFileAssert<FileAssertions> {
   public AbstractListAssert<ListAssert<String>, List<? extends String>, String, ObjectAssert<String>> fileTree()
       throws IOException {
 
-    final Path actualPath = actual.toPath().normalize();
+    final Path actualPath = actual.toPath().normalize().toRealPath();
     final List<String> paths = new ArrayList<>();
     try (Stream<Path> pathStream = Files.walk(actualPath)) {
       for (Path temp : pathStream


### PR DESCRIPTION
## Description
Fix https://github.com/eclipse/jkube/issues/1409
Unit tests that use FileAssertions:fileTree is failing due to invalid expected file paths.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->