### PR TITLE
fix: Splited findProfile unit test into two separate unit tests (#1092)

### DIFF
--- a/jkube-kit/profile/src/test/java/org/eclipse/jkube/kit/profile/ProfileUtilTest.java
+++ b/jkube-kit/profile/src/test/java/org/eclipse/jkube/kit/profile/ProfileUtilTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 /**
  * @author roland
@@ -86,14 +86,16 @@ public class ProfileUtilTest {
     }
 
     @Test
-    public void findProfile() throws URISyntaxException, IOException {
+    public void findProfile_whenValidProfileArg_returnsValidProfile() throws URISyntaxException, IOException {
+
         assertNotNull(ProfileUtil.findProfile("simple", getProfileDir()));
-        try {
-            ProfileUtil.findProfile("not-there", getProfileDir());
-            fail();
-        } catch (IllegalArgumentException exp) {
-            assertTrue(exp.getMessage().contains("not-there"));
-        }
+
+    }
+
+    @Test
+    public void findProfile_whenNonExistentProfileArg_throwsException () throws URISyntaxException {
+
+        assertTrue(assertThrows(IllegalArgumentException.class, () -> ProfileUtil.findProfile("not-there", getProfileDir())).getMessage().contains("not-there"));
 
     }
 


### PR DESCRIPTION
## Description
I have fixed #1092 in this PR.
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
Let me know if anythings up ;)