### PR TITLE
Joined multiple assertions subject to one assertion chain in FileDataSecretEnrichTest

### DIFF
--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/FileDataSecretEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/FileDataSecretEnricherTest.java
@@ -80,9 +80,6 @@ public class FileDataSecretEnricherTest {
 
         final Map<String, String> data = secret.getData();
         assertThat(data)
-            .containsKey(TEST_APPLICATION_PROPERTIES);
-
-        assertThat(data)
             .containsEntry(TEST_APPLICATION_PROPERTIES, Base64Util
                 .encodeToString(Files.readAllBytes(Paths.get(TEST_APPLICATION_PROPERTIES_PATH))));
 


### PR DESCRIPTION
Joined two assertions together. Removed first one and just used .containsEntry assertion
This PR is the fix for #1372
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
Let me know if there is any thing more I can do to help ;)