### PR TITLE
fix (jkube-kit) : ProjectLabelEnricher group and version labels should be configurable (#1268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Usage:
 * Fix #1260: Add documentation for PodAnnotationEnricher
 * Fix #1261: Add documentation for PortNameEnricher
 * Fix #1262: Add docs + gradle integration test for ProjectLabelEnricher
+* Fix #1268: ProjectLabelEnricher group and version labels should be configurable
 * Fix #1284: webapp custom generator should not require to set a CMD configuration
 * Fix #1295: Spring Boot actuator endpoints failed to generate automatically if `deployment.yml` resource fragment is used
 * Fix #1297: ReplicaCountEnricher documentation ported to Gradle plugins

--- a/gradle-plugin/it/src/it/project-label/expected/group/kubernetes.yml
+++ b/gradle-plugin/it/src/it/project-label/expected/group/kubernetes.yml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      expose: "true"
+      app: "project-label"
+      provider: "jkube"
+      version: "@ignore@"
+      group: org.example
+    name: project-label
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: "project-label"
+      provider: "jkube"
+      group: org.example
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: "project-label"
+      provider: "jkube"
+      version: "@ignore@"
+      group: org.example
+    name: project-label
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      matchLabels:
+        app: "project-label"
+        provider: "jkube"
+        group: org.example
+    template:
+      metadata:
+        annotations:
+          jkube.io/git-url: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: "project-label"
+          provider: "jkube"
+          version: "@ignore@"
+          group: org.example
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: repository/project-label:latest
+          imagePullPolicy: IfNotPresent
+          name: repository-project-label
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          securityContext:
+            privileged: false

--- a/gradle-plugin/it/src/it/project-label/expected/group/openshift.yml
+++ b/gradle-plugin/it/src/it/project-label/expected/group/openshift.yml
@@ -1,0 +1,116 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      expose: "true"
+      app: "project-label"
+      provider: "jkube"
+      version: "@ignore@"
+      group: org.example
+    name: project-label
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: "project-label"
+      provider: "jkube"
+      group: org.example
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: "project-label"
+      provider: "jkube"
+      version: "@ignore@"
+      group: org.example
+    name: project-label
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: "project-label"
+      provider: "jkube"
+      group: org.example
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        annotations:
+          app.openshift.io/vcs-ref: "@ignore@"
+          jkube.io/git-url: "@ignore@"
+          app.openshift.io/vcs-uri: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: "project-label"
+          provider: "jkube"
+          version: "@ignore@"
+          group: org.example
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: repository/project-label:latest
+          imagePullPolicy: IfNotPresent
+          name: repository-project-label
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - repository-project-label
+        from:
+          kind: ImageStreamTag
+          name: project-label:latest
+      type: ImageChange
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: "project-label"
+      provider: "jkube"
+      version: "@ignore@"
+      group: org.example
+    name: project-label
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: project-label

--- a/gradle-plugin/it/src/it/project-label/expected/version/kubernetes.yml
+++ b/gradle-plugin/it/src/it/project-label/expected/version/kubernetes.yml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      expose: "true"
+      app: "project-label"
+      provider: "jkube"
+      version: "0.1.0"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: project-label
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: "project-label"
+      provider: "jkube"
+      group: org.eclipse.jkube.integration.tests.gradle
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: "project-label"
+      provider: "jkube"
+      version: "0.1.0"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: project-label
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      matchLabels:
+        app: "project-label"
+        provider: "jkube"
+        group: org.eclipse.jkube.integration.tests.gradle
+    template:
+      metadata:
+        annotations:
+          jkube.io/git-url: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: "project-label"
+          provider: "jkube"
+          version: "0.1.0"
+          group: org.eclipse.jkube.integration.tests.gradle
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: repository/project-label:latest
+          imagePullPolicy: IfNotPresent
+          name: repository-project-label
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          securityContext:
+            privileged: false

--- a/gradle-plugin/it/src/it/project-label/expected/version/openshift.yml
+++ b/gradle-plugin/it/src/it/project-label/expected/version/openshift.yml
@@ -1,0 +1,116 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      expose: "true"
+      app: "project-label"
+      provider: "jkube"
+      version: "0.1.0"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: project-label
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: "project-label"
+      provider: "jkube"
+      group: org.eclipse.jkube.integration.tests.gradle
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: "project-label"
+      provider: "jkube"
+      version: "0.1.0"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: project-label
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: "project-label"
+      provider: "jkube"
+      group: org.eclipse.jkube.integration.tests.gradle
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        annotations:
+          app.openshift.io/vcs-ref: "@ignore@"
+          jkube.io/git-url: "@ignore@"
+          app.openshift.io/vcs-uri: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: "project-label"
+          provider: "jkube"
+          version: "0.1.0"
+          group: org.eclipse.jkube.integration.tests.gradle
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: repository/project-label:latest
+          imagePullPolicy: IfNotPresent
+          name: repository-project-label
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - repository-project-label
+        from:
+          kind: ImageStreamTag
+          name: project-label:latest
+      type: ImageChange
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: "project-label"
+      provider: "jkube"
+      version: "0.1.0"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: project-label
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: project-label

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProjectLabelIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProjectLabelIT.java
@@ -39,7 +39,9 @@ public class ProjectLabelIT {
     return Arrays.asList(
         new Object[] { "default" , new String[] {}},
         new Object[] { "custom" , new String[] {"-Pjkube.enricher.jkube-project-label.useProjectLabel=true", "-Pjkube.enricher.jkube-project-label.provider=custom-provider"}},
-        new Object[] { "app" , new String[] {"-Pjkube.enricher.jkube-project-label.app=custom-app" }}
+        new Object[] { "app" , new String[] {"-Pjkube.enricher.jkube-project-label.app=custom-app" }},
+        new Object[] { "group", new String[] {"-Pjkube.enricher.jkube-project-label.group=org.example"}},
+        new Object[] { "version", new String[] {"-Pjkube.enricher.jkube-project-label.version=0.1.0"}}
     );
   }
 

--- a/jkube-kit/doc/src/main/asciidoc/inc/enricher/project-label/_jkube_project_label.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/enricher/project-label/_jkube_project_label.adoc
@@ -34,6 +34,28 @@ endif::[]
 
 Defaults to `jkube`.
 | `jkube.enricher.jkube-project-label.provider`
+
+| *group*
+| Makes it possible to define a custom `group` label used in the generated resource files used for deployment.
+
+ifeval::["{plugin-type}" == "maven"]
+Defaults to the Maven `project.groupId` property.
+endif::[]
+ifeval::["{plugin-type}" == "gradle"]
+Defaults to the Gradle Project `group` property.
+endif::[]
+| `jkube.enricher.jkube-project-label.group`
+
+| *version*
+| Makes it possible to define a custom `version` label used in the generated resource files used for deployment.
+
+ifeval::["{plugin-type}" == "maven"]
+Defaults to the Maven `project.version` property.
+endif::[]
+ifeval::["{plugin-type}" == "gradle"]
+Defaults to the Gradle Project `version` property.
+endif::[]
+| `jkube.enricher.jkube-project-label.version`
 |===
 
 The project labels which are already specified in the input fragments are not overridden by the enricher.

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
@@ -65,9 +65,11 @@ public class ProjectLabelEnricher extends BaseEnricher {
 
     @AllArgsConstructor
     private enum Config implements Configs.Config {
-      USE_PROJECT_LABEL("useProjectLabel", "false"),
-      APP("app", null),
-      PROVIDER("provider", "jkube");
+        USE_PROJECT_LABEL("useProjectLabel", "false"),
+        APP("app", null),
+        GROUP("group", null),
+        VERSION("version", null),
+        PROVIDER("provider", "jkube");
 
         @Getter
         protected String key;
@@ -199,10 +201,10 @@ public class ProjectLabelEnricher extends BaseEnricher {
             ret.put("app", getConfig(Config.APP, groupArtifactVersion.getArtifactId()));
         }
 
-        ret.put("group", groupArtifactVersion.getGroupId());
+        ret.put("group", getConfig(Config.GROUP, groupArtifactVersion.getGroupId()));
         ret.put(LABEL_PROVIDER, getConfig(Config.PROVIDER));
         if (!withoutVersion) {
-            ret.put("version", groupArtifactVersion.getVersion());
+            ret.put("version", getConfig(Config.VERSION, groupArtifactVersion.getVersion()));
         }
         return ret;
     }


### PR DESCRIPTION
## Description
Fix #1268

Add two new options to ProjectLabelEnricher configuration for allowing
user to customize `group` and `version` labels added to match selectors
by ProjectLabelEnricher

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->