### PR TITLE
feat (jkube-kit/generator) : Add configuration option in BaseGenerator to add tags (#1188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.8.0-SNAPSHOT
+* Fix #1188: Add support for specifying multiple tags in Zero configuration mode
 * Fix #1194: jkube controller name configuration ignored when using resource fragments
 * Fix #1201: ThorntailV2Generator works with Gradle Plugins
 * Fix #1208: Allow env variables to be passed to a webapp generator s2i builder

--- a/jkube-kit/doc/src/main/asciidoc/inc/generator/_options_common.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/generator/_options_common.adoc
@@ -45,6 +45,10 @@ or already added by a generator which has been run previously.
 | *registry*
 | A optional Docker registry used when doing Docker builds. It has no effect for OpenShift S2I builds.
 | `jkube.generator.registry`
+
+| *tags*
+| A comma separated list of additional tags you want to tag your image with
+| `jkube.generator.tags`
 |===
 
 When used as properties they can be directly referenced with the property names above.

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
@@ -15,10 +15,12 @@ package org.eclipse.jkube.generator.api.support;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.jkube.generator.api.FromSelector;
 import org.eclipse.jkube.generator.api.Generator;
@@ -74,7 +76,10 @@ public abstract class BaseGenerator implements Generator {
         FROM_MODE("fromMode", null),
 
         // Optional registry
-        REGISTRY("registry", null);
+        REGISTRY("registry", null),
+
+        // Tags
+        TAGS("tags", null);
 
         @Getter
         protected String key;
@@ -224,6 +229,16 @@ public abstract class BaseGenerator implements Generator {
     protected void addLatestTagIfSnapshot(BuildConfiguration.BuildConfigurationBuilder buildBuilder) {
         if (getProject().getVersion().endsWith("-SNAPSHOT")) {
             buildBuilder.tags(Collections.singletonList("latest"));
+        }
+    }
+
+    protected void addTagsFromConfig(BuildConfiguration.BuildConfigurationBuilder buildConfigurationBuilder) {
+        String commaSeparatedTags = getConfig(Config.TAGS);
+        if (StringUtils.isNotBlank(commaSeparatedTags)) {
+            List<String> tags = Arrays.stream(commaSeparatedTags.split(","))
+                .map(String::trim)
+                .collect(Collectors.toList());
+            buildConfigurationBuilder.tags(tags);
         }
     }
 

--- a/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/support/BaseGeneratorTest.java
+++ b/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/support/BaseGeneratorTest.java
@@ -36,8 +36,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.AssertionsForClassTypes.entry;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -351,6 +351,22 @@ public class BaseGeneratorTest {
     List<String> tags = config.getTags();
     assertEquals(1, tags.size());
     assertTrue(tags.get(0).endsWith("latest"));
+  }
+
+  @Test
+  public void addTagsFromConfig() {
+    new Expectations() {{
+        ctx.getProject();
+        result = project;
+    }};
+    BuildConfiguration.BuildConfigurationBuilder builder = BuildConfiguration.builder();
+    properties.put("jkube.generator.test-generator.tags", " tag-1, tag-2 , other-tag");
+    BaseGenerator generator = createGenerator(null);
+    generator.addTagsFromConfig(builder);
+    BuildConfiguration config = builder.build();
+    assertThat(config.getTags())
+        .hasSize(3)
+        .containsExactlyInAnyOrder("tag-1", "tag-2", "other-tag");
   }
 
   public void inKubernetes() {

--- a/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
+++ b/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
@@ -154,6 +154,7 @@ public class JavaExecGenerator extends BaseGenerator {
       addPrometheusPort(buildBuilder);
 
       addLatestTagIfSnapshot(buildBuilder);
+      addTagsFromConfig(buildBuilder);
       buildBuilder.workdir(getBuildWorkdir());
       buildBuilder.entryPoint(getBuildEntryPoint());
       return buildBuilder;

--- a/jkube-kit/generator/karaf/src/main/java/org/eclipse/jkube/generator/karaf/KarafGenerator.java
+++ b/jkube-kit/generator/karaf/src/main/java/org/eclipse/jkube/generator/karaf/KarafGenerator.java
@@ -76,6 +76,7 @@ public class KarafGenerator extends BaseGenerator {
       buildBuilder.assembly(createDefaultAssembly());
     }
     addLatestTagIfSnapshot(buildBuilder);
+    addTagsFromConfig(buildBuilder);
     imageBuilder
         .name(getImageName())
         .alias(getAlias())

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
@@ -128,6 +128,7 @@ public class WebAppGenerator extends BaseGenerator {
       buildBuilder.assembly(createAssembly(handler));
     }
     addLatestTagIfSnapshot(buildBuilder);
+    addTagsFromConfig(buildBuilder);
     imageBuilder
         .name(getImageName())
         .alias(getAlias())


### PR DESCRIPTION
## Description

Fix #1188

Right now there isn't a way to add tags to BuildConfiguration while
using zero config mode in generators. Adding a configuration field in
BaseGenerator which would expect comma separated tags which can be
picked up by Generator while building opinionated Image configuration

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->