### PR TITLE
feat (jkube-kit/config) : Support for Startup Probes via XML/DSL configuration (#1322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Usage:
 * Fix #1310: Add documentation + gradle integration test for ImageChangeTriggerEnricher
 * Fix #1311: Add documentation for OpenShift ProjectEnricher
 * Fix #1312: Add documentation + gradle integration test for RouteEnricher
+* Fix #1322: Support for Startup probes via XML/DSL configuration
 * Fix #1325: `jkube.enricher.jkube-name.name` doesn't modify `.metadata.name` for generated manifests
 * Fix #1328: Provide guidance when the final project packaged file is not found
 * Fix #1336: Add documentation and quickstart for using custom generators with Gradle Plugins

--- a/gradle-plugin/doc/src/main/asciidoc/inc/getting-started/_groovy.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/getting-started/_groovy.adoc
@@ -228,7 +228,12 @@ kubernetes {
       initialDelaySeconds = "3"
       timeoutSeconds = "3"
     }
-    volumes = [{ //<7>
+    startup { //<7>
+      periodSeconds = 30
+      failureThreshold = 1
+      getUrl = "http://:8080/actuator/health"
+    }
+    volumes = [{ //<8>
       name = "scratch"
       type = "emptyDir"
       medium = "Memory"
@@ -243,8 +248,9 @@ kubernetes {
 <3> Setting https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod[Security Context] of all application Pods.
 <4> Configure how images would be updated. Can be one of `IfNotPresent`, `Always` or `Never`. Read https://kubernetes.io/docs/concepts/containers/images/#updating-images[Kubernetes Images docs] for more details.
 <5> Number of replicas of pods we want to have in our application
-<6> Define an HTTP liveness request, see https://kubernetes.io/docs/concepts/containers/images/#updating-images[Kubernetes Liveness/Readiness probes] for more details.
-<7> Mounting an EmptyDir Volume to your application pods
+<6> Define an HTTP liveness request, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/[Kubernetes Liveness/Readiness probes] for more details.
+<7> Define an HTTP startup request, see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/[Kubernetes Startup probes] for more details.
+<8> Mounting an EmptyDir Volume to your application pods
 
 See <<controller-resource-groovy-configuration, Kubernetes Controller Configuration>> for more details.
 

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/build.gradle
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/build.gradle
@@ -1,0 +1,88 @@
+plugins {
+    id 'org.springframework.boot' version '2.6.6'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'org.eclipse.jkube.kubernetes' version "${jKubeVersion}"
+    id 'org.eclipse.jkube.openshift' version "${jKubeVersion}"
+    id 'java'
+}
+
+group = 'org.eclipse.jkube.it.gradle.probes.groovy.dsl'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+}
+
+kubernetes {
+    offline = true
+    if (probeConfigMode.contains("liveness-readiness")) {
+        resources {
+            liveness {
+                initialDelaySeconds = 0
+                timeoutSeconds = 10
+                periodSeconds = 30
+                failureThreshold = 1
+                successThreshold = 1
+                getUrl = "http://:8080/health/live"
+                httpHeaders = [Accept: "application/json", "User-agent": "MyUserAgent"]
+            }
+            readiness {
+                initialDelaySeconds = 0
+                timeoutSeconds = 10
+                periodSeconds = 30
+                failureThreshold = 1
+                successThreshold = 1
+                getUrl = "http://:8080/health/ready"
+                httpHeaders = [Accept: "application/json", "User-agent": "MyUserAgent"]
+            }
+        }
+    }
+    if (probeConfigMode.equals("startup")) {
+        resources {
+            startup {
+                periodSeconds = 30
+                failureThreshold = 1
+                getUrl = "http://:8080/liveness/startup"
+            }
+        }
+    }
+}
+
+openshift {
+    offline = true
+    if (probeConfigMode.equals("liveness-readiness")) {
+        resources {
+            liveness {
+                initialDelaySeconds = 0
+                timeoutSeconds = 10
+                periodSeconds = 30
+                failureThreshold = 1
+                successThreshold = 1
+                getUrl = "http://:8080/health/live"
+                httpHeaders = [Accept: "application/json", "User-agent": "MyUserAgent"]
+            }
+            readiness {
+                initialDelaySeconds = 0
+                timeoutSeconds = 10
+                periodSeconds = 30
+                failureThreshold = 1
+                successThreshold = 1
+                getUrl = "http://:8080/health/ready"
+                httpHeaders = [Accept: "application/json", "User-agent": "MyUserAgent"]
+            }
+        }
+    }
+    if (probeConfigMode.equals("startup")) {
+        resources {
+            startup {
+                periodSeconds = 30
+                failureThreshold = 1
+                getUrl = "http://:8080/liveness/startup"
+            }
+        }
+    }
+}

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/liveness-readiness/kubernetes.yml
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/liveness-readiness/kubernetes.yml
@@ -1,17 +1,3 @@
-#
-# Copyright (c) 2019 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at:
-#
-#     https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 ---
 apiVersion: v1
 kind: List
@@ -20,17 +6,19 @@ items:
   kind: Service
   metadata:
     annotations:
-      jkube.io/git-commit: "@ignore@"
-      prometheus.io/scrape: "true"
+      prometheus.io/path: /metrics
       jkube.io/git-branch: "@ignore@"
       prometheus.io/port: "9779"
+      prometheus.io/scrape: "true"
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
     labels:
       expose: "true"
+      app: probes-groovy-dsl-config
       provider: jkube
-      app: jkube-maven-sample-xml-probe-config
       version: "@ignore@"
-      group: org.eclipse.jkube
-    name: jkube-maven-sample-xml-probe-config
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
   spec:
     ports:
     - name: http
@@ -38,38 +26,42 @@ items:
       protocol: TCP
       targetPort: 8080
     selector:
-      app: jkube-maven-sample-xml-probe-config
+      app: probes-groovy-dsl-config
       provider: jkube
-      group: org.eclipse.jkube
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     annotations:
+      jkube.io/git-url: "@ignore@"
       jkube.io/git-commit: "@ignore@"
       jkube.io/git-branch: "@ignore@"
     labels:
+      app: probes-groovy-dsl-config
       provider: jkube
-      app: jkube-maven-sample-xml-probe-config
       version: "@ignore@"
-      group: org.eclipse.jkube
-    name: jkube-maven-sample-xml-probe-config
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
   spec:
     replicas: 1
+    revisionHistoryLimit: 2
     selector:
       matchLabels:
-        app: jkube-maven-sample-xml-probe-config
+        app: probes-groovy-dsl-config
         provider: jkube
-        group: org.eclipse.jkube
+        group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
     template:
       metadata:
         annotations:
+          jkube.io/git-url: "@ignore@"
           jkube.io/git-commit: "@ignore@"
           jkube.io/git-branch: "@ignore@"
         labels:
+          app: probes-groovy-dsl-config
           provider: jkube
-          app: jkube-maven-sample-xml-probe-config
           version: "@ignore@"
-          group: org.eclipse.jkube
+          group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+        name: probes-groovy-dsl-config
       spec:
         containers:
         - env:
@@ -77,8 +69,28 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: "@matches('jkube/jkube-maven-sample-xml-probe-config:.*$')@"
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: dsl/probes-groovy-dsl-config:latest
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              host: ""
+              httpHeaders:
+              - name: Accept
+                value: application/json
+              - name: User-agent
+                value: MyUserAgent
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
           name: spring-boot
           ports:
           - containerPort: 8080
@@ -90,43 +102,21 @@ items:
           - containerPort: 8778
             name: jolokia
             protocol: TCP
-          securityContext:
-            privileged: false
           readinessProbe:
             failureThreshold: 1
             httpGet:
-              httpHeaders:
-              - name: Accept
-                value: application/json
-              - name: User-agent
-                value: MyUserAgent
-              path: /actuator/health
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 0
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 10  
-          livenessProbe:
-            failureThreshold: 1
-            httpGet:
-              httpHeaders:
-              - name: Accept
-                value: application/json
-              - name: User-agent
-                value: MyUserAgent
-              path: /actuator/health
-              port: 8080
-              scheme: HTTP
-            initialDelaySeconds: 0
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 10    
-          startupProbe:
-            failureThreshold: 30
-            httpGet:
               host: ""
-              path: /actuator/health
+              httpHeaders:
+              - name: Accept
+                value: application/json
+              - name: User-agent
+                value: MyUserAgent
+              path: /health/ready
               port: 8080
               scheme: HTTP
-            periodSeconds: 10
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          securityContext:
+            privileged: false

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/liveness-readiness/openshift.yml
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/liveness-readiness/openshift.yml
@@ -1,0 +1,158 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      prometheus.io/path: /metrics
+      jkube.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+      prometheus.io/scrape: "true"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+    labels:
+      expose: "true"
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        annotations:
+          app.openshift.io/vcs-ref: "@ignore@"
+          jkube.io/git-url: "@ignore@"
+          app.openshift.io/vcs-uri: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: probes-groovy-dsl-config
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+        name: probes-groovy-dsl-config
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: probes-groovy-dsl-config:latest
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              host: ""
+              httpHeaders:
+              - name: Accept
+                value: application/json
+              - name: User-agent
+                value: MyUserAgent
+              path: /health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 1
+            httpGet:
+              host: ""
+              httpHeaders:
+              - name: Accept
+                value: application/json
+              - name: User-agent
+                value: MyUserAgent
+              path: /health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - spring-boot
+        from:
+          kind: ImageStreamTag
+          name: probes-groovy-dsl-config:latest
+      type: ImageChange
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: probes-groovy-dsl-config

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/none/kubernetes.yml
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/none/kubernetes.yml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      prometheus.io/path: /metrics
+      jkube.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+      prometheus.io/scrape: "true"
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+    labels:
+      expose: "true"
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      matchLabels:
+        app: probes-groovy-dsl-config
+        provider: jkube
+        group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    template:
+      metadata:
+        annotations:
+          jkube.io/git-url: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: probes-groovy-dsl-config
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+        name: probes-groovy-dsl-config
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: dsl/probes-groovy-dsl-config:latest
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/none/openshift.yml
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/none/openshift.yml
@@ -1,0 +1,126 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      prometheus.io/path: /metrics
+      jkube.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+      prometheus.io/scrape: "true"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+    labels:
+      expose: "true"
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        annotations:
+          app.openshift.io/vcs-ref: "@ignore@"
+          jkube.io/git-url: "@ignore@"
+          app.openshift.io/vcs-uri: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: probes-groovy-dsl-config
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+        name: probes-groovy-dsl-config
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: probes-groovy-dsl-config:latest
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - spring-boot
+        from:
+          kind: ImageStreamTag
+          name: probes-groovy-dsl-config:latest
+      type: ImageChange
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: probes-groovy-dsl-config

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/startup/kubernetes.yml
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/startup/kubernetes.yml
@@ -1,0 +1,98 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      prometheus.io/path: /metrics
+      jkube.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+      prometheus.io/scrape: "true"
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+    labels:
+      expose: "true"
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.io/git-url: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      matchLabels:
+        app: probes-groovy-dsl-config
+        provider: jkube
+        group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    template:
+      metadata:
+        annotations:
+          jkube.io/git-url: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: probes-groovy-dsl-config
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+        name: probes-groovy-dsl-config
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: dsl/probes-groovy-dsl-config:latest
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false
+          startupProbe:
+            failureThreshold: 1
+            httpGet:
+              host: ""
+              path: /liveness/startup
+              port: 8080
+              scheme: HTTP
+            periodSeconds: 30

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/startup/openshift.yml
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/startup/openshift.yml
@@ -1,0 +1,134 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      prometheus.io/path: /metrics
+      jkube.io/git-branch: "@ignore@"
+      prometheus.io/port: "9779"
+      prometheus.io/scrape: "true"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+    labels:
+      expose: "true"
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        annotations:
+          app.openshift.io/vcs-ref: "@ignore@"
+          jkube.io/git-url: "@ignore@"
+          app.openshift.io/vcs-uri: "@ignore@"
+          jkube.io/git-commit: "@ignore@"
+          jkube.io/git-branch: "@ignore@"
+        labels:
+          app: probes-groovy-dsl-config
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+        name: probes-groovy-dsl-config
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: probes-groovy-dsl-config:latest
+          imagePullPolicy: IfNotPresent
+          name: spring-boot
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 9779
+            name: prometheus
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          securityContext:
+            privileged: false
+          startupProbe:
+            failureThreshold: 1
+            httpGet:
+              host: ""
+              path: /liveness/startup
+              port: 8080
+              scheme: HTTP
+            periodSeconds: 30
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - spring-boot
+        from:
+          kind: ImageStreamTag
+          name: probes-groovy-dsl-config:latest
+      type: ImageChange
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.io/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.io/git-commit: "@ignore@"
+      jkube.io/git-branch: "@ignore@"
+    labels:
+      app: probes-groovy-dsl-config
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.it.gradle.probes.groovy.dsl
+    name: probes-groovy-dsl-config
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: probes-groovy-dsl-config

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/src/main/java/org/eclipse/jkube/it/gradle/probes/groovy/dsl/probesgroovydslconfig/ProbesGroovyDSLConfigResource.java
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/src/main/java/org/eclipse/jkube/it/gradle/probes/groovy/dsl/probesgroovydslconfig/ProbesGroovyDSLConfigResource.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.it.gradle.probes.groovy.dsl.probesgroovydslconfig;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProbesGroovyDSLConfigResource {
+  @GetMapping(value = "/liveness/startup")
+  public String getStartup() {
+    return "OK";
+  }
+
+  @GetMapping(value = "/health/ready")
+  public String getReady() {
+    return "OK";
+  }
+
+  @GetMapping(value = "/health/live")
+  public String getLiveness() {
+    return "OK";
+  }
+}

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/src/main/java/org/eclipse/jkube/it/gradle/probes/groovy/dsl/probesgroovydslconfig/ProbesGroovyDslConfigApplication.java
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/src/main/java/org/eclipse/jkube/it/gradle/probes/groovy/dsl/probesgroovydslconfig/ProbesGroovyDslConfigApplication.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.it.gradle.probes.groovy.dsl.probesgroovydslconfig;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ProbesGroovyDslConfigApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(ProbesGroovyDslConfigApplication.class, args);
+  }
+}

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProbesGroovyDSLIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProbesGroovyDSLIT.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.tests;
+
+import net.minidev.json.parser.ParseException;
+import org.eclipse.jkube.kit.common.ResourceVerify;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(Parameterized.class)
+public class ProbesGroovyDSLIT {
+  @Rule
+  public final ITGradleRunner gradleRunner = new ITGradleRunner();
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] { "startup" },
+        new Object[] { "liveness-readiness" },
+        new Object[] { "none" }
+    );
+  }
+
+  @Parameterized.Parameter
+  public String probeConfigMode;
+
+  @Test
+  public void k8sResource_whenRun_generatesK8sManifestsWithProbes() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("probes-groovy-dsl-config")
+        .withArguments("build", "k8sResource", "-PprobeConfigMode=" + probeConfigMode, "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
+        gradleRunner.resolveFile("expected", probeConfigMode, "kubernetes.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Running in Kubernetes mode")
+        .contains("Running generator spring-boot")
+        .contains("jkube-controller: Adding a default Deployment")
+        .contains("jkube-service: Adding a default service")
+        .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
+        .contains("jkube-revision-history: Adding revision history limit to 2");
+  }
+
+  @Test
+  public void ocResource_whenRun_generatesOpenShiftManifests() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("probes-groovy-dsl-config")
+        .withArguments("build", "ocResource", "-PprobeConfigMode=" + probeConfigMode, "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
+        gradleRunner.resolveFile("expected", probeConfigMode, "openshift.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Running in OpenShift mode")
+        .contains("Running generator spring-boot")
+        .contains("jkube-controller: Adding a default Deployment")
+        .contains("jkube-service: Adding a default service")
+        .contains("jkube-openshift-deploymentconfig: Converting Deployment to DeploymentConfig")
+        .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
+        .contains("jkube-revision-history: Adding revision history limit to 2");
+  }
+}

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
@@ -49,6 +49,7 @@ public class ResourceConfig {
   private ConfigMap configMap;
   private ProbeConfig liveness;
   private ProbeConfig readiness;
+  private ProbeConfig startup;
   private MetricsConfig metrics;
 
   /**

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandler.java
@@ -64,6 +64,7 @@ public class ContainerHandler {
             if (imageConfig.getBuildConfiguration() != null) {
                 Probe livenessProbe = probeHandler.getProbe(config.getLiveness());
                 Probe readinessProbe = probeHandler.getProbe(config.getReadiness());
+                Probe startupProbe = probeHandler.getProbe(config.getStartup());
 
                 Container container = new ContainerBuilder()
                     .withName(KubernetesResourceUtil.extractContainerName(this.groupArtifactVersion, imageConfig))
@@ -75,6 +76,7 @@ public class ContainerHandler {
                     .withVolumeMounts(getVolumeMounts(config))
                     .withLivenessProbe(livenessProbe)
                     .withReadinessProbe(readinessProbe)
+                    .withStartupProbe(startupProbe)
                     .build();
                 ret.add(container);
             }

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/AbstractHealthCheckEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/AbstractHealthCheckEnricher.java
@@ -75,6 +75,14 @@ public abstract class AbstractHealthCheckEnricher extends BaseEnricher {
                     container.withLivenessProbe(probe);
                 }
             }
+
+            if (Boolean.FALSE.equals(container.hasStartupProbe())) {
+                Probe probe = getStartupProbe(container);
+                if (probe != null) {
+                    log.info("Adding startup " + describe(probe));
+                    container.withStartupProbe(probe);
+                }
+            }
         }
     }
 
@@ -182,4 +190,11 @@ public abstract class AbstractHealthCheckEnricher extends BaseEnricher {
         return null;
     }
 
+    protected Probe getStartupProbe(ContainerBuilder containerBuilder) {
+        return getStartupProbe();
+    }
+
+    protected Probe getStartupProbe() {
+        return null;
+    }
 }

--- a/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/AbstractHealthCheckEnricherTest.java
+++ b/jkube-kit/enricher/specific/src/test/java/org/eclipse/jkube/kit/enricher/specific/AbstractHealthCheckEnricherTest.java
@@ -67,6 +67,7 @@ public class AbstractHealthCheckEnricherTest {
             public void visit(ContainerBuilder container) {
                 assertNotNull(container.build().getLivenessProbe());
                 assertNotNull(container.build().getReadinessProbe());
+                assertNotNull(container.build().getStartupProbe());
                 containerFound.incrementAndGet();
             }
         });
@@ -102,10 +103,12 @@ public class AbstractHealthCheckEnricherTest {
                 if (container.getName().equals("app")) {
                     assertNotNull(container.build().getLivenessProbe());
                     assertNotNull(container.build().getReadinessProbe());
+                    assertNotNull(container.build().getStartupProbe());
                     containerFound.incrementAndGet();
                 } else if (container.getName().equals("sidecar")) {
                     assertNull(container.build().getLivenessProbe());
                     assertNull(container.build().getReadinessProbe());
+                    assertNull(container.build().getStartupProbe());
                     containerFound.incrementAndGet();
                 }
             }
@@ -150,12 +153,14 @@ public class AbstractHealthCheckEnricherTest {
                     case "app":
                         assertNull(container.build().getLivenessProbe());
                         assertNull(container.build().getReadinessProbe());
+                        assertNull(container.build().getStartupProbe());
                         containerFound.incrementAndGet();
                         break;
                     case "app2":
                     case "app3":
                         assertNotNull(container.build().getLivenessProbe());
                         assertNotNull(container.build().getReadinessProbe());
+                        assertNotNull(container.build().getStartupProbe());
                         containerFound.incrementAndGet();
                         break;
                 }
@@ -196,10 +201,12 @@ public class AbstractHealthCheckEnricherTest {
                 if (container.getName().equals("app")) {
                     assertNotNull(container.build().getLivenessProbe());
                     assertNotNull(container.build().getReadinessProbe());
+                    assertNotNull(container.build().getStartupProbe());
                     containerFound.incrementAndGet();
                 } else if (container.getName().equals("app2")) {
                     assertNotNull(container.build().getLivenessProbe());
                     assertNotNull(container.build().getReadinessProbe());
+                    assertNotNull(container.build().getStartupProbe());
                     containerFound.incrementAndGet();
                 }
             }
@@ -224,6 +231,11 @@ public class AbstractHealthCheckEnricherTest {
         AbstractHealthCheckEnricher enricher = new AbstractHealthCheckEnricher(context, "basic") {
             @Override
             protected Probe getLivenessProbe() {
+                return getReadinessProbe();
+            }
+
+            @Override
+            protected Probe getStartupProbe() {
                 return getReadinessProbe();
             }
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
@@ -321,7 +321,12 @@ An extract of the plugin configuration is shown below:
       <initialDelaySeconds>3</initialDelaySeconds>
       <timeoutSeconds>3</timeoutSeconds>
     </liveness>
-    <remotes> <!--14-->
+    <startup> <!--14-->
+      <failureThreshold>30</failureThreshold>
+      <periodSeconds>10</periodSeconds>
+      <getUrl>http://:8080/actuator/health</getUrl>
+    </startup>
+    <remotes> <!--15-->
        <remote>https://gist.githubusercontent.com/lordofthejars/ac2823cec7831697d09444bbaa76cd50/raw/e4b43f1b6494766dfc635b5959af7730c1a58a93/deployment.yaml</remote>
     </remotes>
   </resources>
@@ -340,7 +345,8 @@ An extract of the plugin configuration is shown below:
 <11> ConfigMap data entry as a string key value pair
 <12> ConfigMap data entry with value as file path, file's contents are loaded into ConfigMap as key value
 <13> Liveness Probe to be added in PodTemplateSpec of Controller resource
-<14> Remote files used as resource fragments.
+<14> Startup Probe to be added in PodTemplateSpec of Controller resource
+<15> Remote files used as resource fragments.
 
 The XML resource configuration is based on plain Kubernetes resource objects. When targeting OpenShift, Kubernetes resource descriptors will be automatically converted to their OpenShift counterparts, e.g. a Kubernetes http://kubernetes.io/docs/user-guide/deployments/[Deployment] will be converted to an OpenShift https://docs.openshift.com/container-platform/4.1/applications/deployments/what-deployments-are.html#deployments-and-deploymentconfigs_what-deployments-are[DeploymentConfig].
 

--- a/kubernetes-maven-plugin/it/src/it/probes-xml-config/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/probes-xml-config/pom.xml
@@ -74,6 +74,11 @@
                 <User-agent>MyUserAgent</User-agent>
               </httpHeaders>
             </readiness>
+            <startup>
+              <failureThreshold>30</failureThreshold>
+              <periodSeconds>10</periodSeconds>
+              <getUrl>http://:8080/actuator/health</getUrl>
+            </startup>
           </resources>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description
Fix #1322 

Add new startup probe field in resource configuration which should be
available in XML maven plugin configuration/ Groovy DSL configuration in
maven and gradle plugins respectively.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->