### PR TITLE
fix(kubernetes-maven-plugin): add Apple M1 CPU support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Usage:
 * Fix #1382: Docker Build ARGS not replaced properly
 * Fix #1324: Support legacy javaee as well as jakartaee projects in the Tomcat webapp generator
 * Fix #1460: Route doesn't use the service "normalizePort"
+* Fix #1470: Add support for Apple M1 CPUs
 * Fix #1482: Quarkus Generator and Enricher should be compatible with the Red Hat build
 * Fix #1483: Assembly files with unnormalized paths don't get fileMode changes
 * Fix #1489: Align BaseGenerator's `add` and `tags` config options to work with `jkube.generator.*` properties

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/unix/UnixSocket.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/unix/UnixSocket.java
@@ -159,13 +159,13 @@ final class UnixSocket extends Socket {
     }
 
     @Override
-    public synchronized void setSoTimeout(int timeout) {
-        channel.setSoTimeout(timeout);
+    public synchronized void setSoTimeout(int timeout) throws SocketException {
+        channel.socket().setSoTimeout(timeout);
     }
 
     @Override
-    public synchronized int getSoTimeout() {
-        return channel.getSoTimeout();
+    public synchronized int getSoTimeout() throws SocketException {
+        return channel.socket().getSoTimeout();
     }
 
     @Override
@@ -213,13 +213,13 @@ final class UnixSocket extends Socket {
     }
 
     @Override
-    public void setKeepAlive(boolean on) {
-        channel.setKeepAlive(on);
+    public void setKeepAlive(boolean on) throws SocketException {
+        channel.socket().setKeepAlive(on);
     }
 
     @Override
-    public boolean getKeepAlive() {
-        return channel.getKeepAlive();
+    public boolean getKeepAlive() throws SocketException {
+        return channel.socket().getKeepAlive();
     }
 
     @Override

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/unix/UnixSocketTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/unix/UnixSocketTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.build.service.docker.access.hc.unix;
+
+import jnr.unixsocket.UnixSocketChannel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.net.SocketException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+public class UnixSocketTest {
+    private static final int SO_TIMEOUT = 60;
+    private static final boolean KEEP_ALIVE = true;
+
+    private MockedStatic<UnixSocketChannel> unixSocketChannel;
+    private UnixSocketChannel socketChannel;
+    private jnr.unixsocket.UnixSocket socket;
+
+    @Before
+    public void setUp() {
+        socketChannel = mock(UnixSocketChannel.class);
+        socket = mock(jnr.unixsocket.UnixSocket.class);
+        doReturn(socket).when(socketChannel).socket();
+        unixSocketChannel = mockStatic(UnixSocketChannel.class);
+        unixSocketChannel.when(() -> UnixSocketChannel.open()).thenReturn(socketChannel);
+    }
+
+    @After
+    public void close() {
+        unixSocketChannel.close();
+    }
+
+    @Test
+    public void shouldReturnValuesFromSocket() throws IOException {
+        // GIVEN
+        UnixSocket unixSocket = new UnixSocket();
+        doReturn(KEEP_ALIVE).when(socket).getKeepAlive();
+        doReturn(SO_TIMEOUT).when(socket).getSoTimeout();
+
+        // WHEN
+        boolean keepAlive = unixSocket.getKeepAlive();
+        int soTimeout = unixSocket.getSoTimeout();
+
+        // THEN
+        assertThat(keepAlive).isEqualTo(KEEP_ALIVE);
+        assertThat(soTimeout).isEqualTo(SO_TIMEOUT);
+    }
+
+    @Test
+    public void shouldPassExceptionsFromSocket() throws IOException {
+        // GIVEN
+        UnixSocket unixSocket = new UnixSocket();
+        doThrow(new SocketException()).when(socket).getKeepAlive();
+        doThrow(new SocketException()).when(socket).getSoTimeout();
+
+        // WHEN & THEN
+        assertThatThrownBy(() -> unixSocket.getKeepAlive()).isInstanceOf(SocketException.class);
+        assertThatThrownBy(() -> unixSocket.getSoTimeout()).isInstanceOf(SocketException.class);
+    }
+
+    @Test
+    public void shouldForwardValuesToSocket() throws IOException {
+        // GIVEN
+        UnixSocket unixSocket = new UnixSocket();
+
+        // WHEN
+        unixSocket.setKeepAlive(KEEP_ALIVE);
+        unixSocket.setSoTimeout(SO_TIMEOUT);
+
+        // THEN
+        verify(socket).setKeepAlive(KEEP_ALIVE);
+        verify(socket).setSoTimeout(SO_TIMEOUT);
+    }
+}

--- a/jkube-kit/build/service/docker/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/jkube-kit/build/service/docker/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.jansi>2.3.3</version.jansi>
     <version.javassist>3.20.0-GA</version.javassist>
     <version.jgit>5.12.0.202106070339-r</version.jgit>
-    <version.jnr-unixsocket>0.12</version.jnr-unixsocket>
+    <version.jnr-unixsocket>0.38.17</version.jnr-unixsocket>
     <version.json-smart>2.2.1</version.json-smart> <!-- Transitive dependency from com.consol.citrus:citrus-core -->
     <version.jsr305>3.0.2</version.jsr305>
     <version.JUnitParams>1.1.1</version.JUnitParams>
@@ -66,6 +66,7 @@
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.validation-api>2.0.1.Final</version.validation-api>
     <version.wagon-ssh-external>2.3</version.wagon-ssh-external>
+    <version.ow2.asm>5.0.3</version.ow2.asm>
 
     <!-- =======================================================  -->
     <version.image.jkube-images>0.0.15</version.image.jkube-images>
@@ -558,6 +559,12 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${version.slf4j-api}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>${version.ow2.asm}</version>
       </dependency>
 
       <!-- == maven ===================================== -->


### PR DESCRIPTION
## Description 
Fix #1470 

The `jnr-unixsocket` was updated to the latest version and added some fixes due to the breaking API changes in their code 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift