### PR TITLE
fix (jkube-kit) : Generate yaml files for different environments (#1218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Usage:
 * Fix #1194: jkube controller name configuration ignored when using resource fragments
 * Fix #1201: ThorntailV2Generator works with Gradle Plugins
 * Fix #1208: Allow env variables to be passed to a webapp generator s2i builder
+* Fix #1218: Generate yaml files for different environments
 * Fix #1251: Generate a preview of jkube documentation for PR if needed
 * Fix #1259: Add integration test and docs for NameEnricher
 * Fix #1260: Add documentation for PodAnnotationEnricher

--- a/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
@@ -314,7 +314,7 @@ Defaults to 0.
 
 | *resourceEnvironment*
 | Environment name where resources are placed. For example, if you set this property to dev and resourceDir is the
-default one, plugin will look at `src/main/jkube/dev`.
+default one, plugin will look at `src/main/jkube/dev`. Multiple environments can also be provided in form of comma separated strings.  Resource fragments in these directories will be combined while generating resources.
 
   Defaults to `null`.
 | `jkube.environment`

--- a/gradle-plugin/it/src/it/multi-environments/build.gradle
+++ b/gradle-plugin/it/src/it/multi-environments/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'org.eclipse.jkube.kubernetes' version "${jKubeVersion}"
+    id 'org.eclipse.jkube.openshift' version "${jKubeVersion}"
+    id 'java'
+}
+
+group = 'org.eclipse.jkube.integration.tests.gradle'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '11'
+
+repositories {
+    mavenCentral()
+}
+
+kubernetes {
+    offline = true
+}
+
+openshift {
+    offline = true
+}

--- a/gradle-plugin/it/src/it/multi-environments/expected/common-and-dev/kubernetes.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/common-and-dev/kubernetes.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: common
+  data:
+    type: common
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: dev
+  data:
+    type: dev

--- a/gradle-plugin/it/src/it/multi-environments/expected/common-and-dev/openshift.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/common-and-dev/openshift.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: common
+  data:
+    type: common
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: dev
+  data:
+    type: dev

--- a/gradle-plugin/it/src/it/multi-environments/expected/common-and-prod/kubernetes.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/common-and-prod/kubernetes.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: common
+  data:
+    type: common
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: prod
+  data:
+    type: prod

--- a/gradle-plugin/it/src/it/multi-environments/expected/common-and-prod/openshift.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/common-and-prod/openshift.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: common
+  data:
+    type: common
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: prod
+  data:
+    type: prod

--- a/gradle-plugin/it/src/it/multi-environments/expected/common/kubernetes.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/common/kubernetes.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: common
+  data:
+    type: common

--- a/gradle-plugin/it/src/it/multi-environments/expected/common/openshift.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/common/openshift.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: common
+  data:
+    type: common

--- a/gradle-plugin/it/src/it/multi-environments/expected/dev/kubernetes.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/dev/kubernetes.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: dev
+  data:
+    type: dev

--- a/gradle-plugin/it/src/it/multi-environments/expected/dev/openshift.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/dev/openshift.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: dev
+  data:
+    type: dev

--- a/gradle-plugin/it/src/it/multi-environments/expected/prod/kubernetes.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/prod/kubernetes.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: prod
+  data:
+    type: prod

--- a/gradle-plugin/it/src/it/multi-environments/expected/prod/openshift.yml
+++ b/gradle-plugin/it/src/it/multi-environments/expected/prod/openshift.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: multi-environments
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: prod
+  data:
+    type: prod

--- a/gradle-plugin/it/src/it/multi-environments/src/main/jkube/common/common-configmap.yml
+++ b/gradle-plugin/it/src/it/multi-environments/src/main/jkube/common/common-configmap.yml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+data:
+  type: common

--- a/gradle-plugin/it/src/it/multi-environments/src/main/jkube/dev/dev-configmap.yml
+++ b/gradle-plugin/it/src/it/multi-environments/src/main/jkube/dev/dev-configmap.yml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+data:
+  type: dev

--- a/gradle-plugin/it/src/it/multi-environments/src/main/jkube/prod/prod-configmap.yml
+++ b/gradle-plugin/it/src/it/multi-environments/src/main/jkube/prod/prod-configmap.yml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+data:
+  type: prod

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/MultiEnvironmentsIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/MultiEnvironmentsIT.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.tests;
+
+import net.minidev.json.parser.ParseException;
+import org.eclipse.jkube.kit.common.ResourceVerify;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(Parameterized.class)
+public class MultiEnvironmentsIT {
+  @Rule
+  public final ITGradleRunner gradleRunner = new ITGradleRunner();
+
+  @Parameterized.Parameters(name = "environment {0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] { "common" , "common"},
+        new Object[] { "dev" , "dev"},
+        new Object[] { "prod" , "prod"},
+        new Object[] { "common,dev", "common-and-dev"},
+        new Object[] { "common,prod", "common-and-prod"}
+    );
+  }
+
+  @Parameterized.Parameter
+  public String environment;
+
+  @Parameterized.Parameter (1)
+  public String expectedDirectory;
+
+  @Test
+  public void k8sResource_whenRun_generatesK8sManifestsContainingConfigMap() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("multi-environments")
+        .withArguments("build", "-Pjkube.environment=" + environment, "k8sResource", "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
+        gradleRunner.resolveFile("expected", expectedDirectory, "kubernetes.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Running in Kubernetes mode");
+  }
+
+  @Test
+  public void ocResource_whenRun_generatesOpenShiftManifestsContainingConfigMap() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("multi-environments")
+        .withArguments("build", "-Pjkube.environment=" + environment, "ocResource", "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
+        gradleRunner.resolveFile("expected", expectedDirectory, "openshift.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Running in OpenShift mode");
+  }
+}

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -163,15 +163,15 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
         System.getProperties(), kubernetesExtension.javaProject.getProperties()).build();
   }
 
-  protected final File resolveResourceSourceDirectory() {
-    return ResourceUtil.getFinalResourceDir(kubernetesExtension.getResourceSourceDirectoryOrDefault(),
+  protected final List<File> resolveResourceSourceDirectory() {
+    return ResourceUtil.getFinalResourceDirs(kubernetesExtension.getResourceSourceDirectoryOrDefault(),
         kubernetesExtension.getResourceEnvironmentOrNull());
   }
 
 
   protected ProcessorConfig extractGeneratorConfig() {
     try {
-      return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.GENERATOR_CONFIG, kubernetesExtension.getProfileOrNull(), kubernetesExtension.getResourceTargetDirectoryOrDefault(), kubernetesExtension.generator);
+      return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.GENERATOR_CONFIG, kubernetesExtension.getProfileOrNull(), ResourceUtil.getFinalResourceDirs(kubernetesExtension.getResourceSourceDirectoryOrDefault(), kubernetesExtension.getResourceEnvironmentOrNull()), kubernetesExtension.generator);
     } catch (IOException e) {
       throw new IllegalArgumentException("Cannot extract generator config: " + e, e);
     }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTask.java
@@ -41,7 +41,7 @@ public class KubernetesHelmTask extends AbstractJKubeTask {
         kubernetesExtension.helm).build();
       jKubeServiceHub.getHelmService().generateHelmCharts(helm);
     } catch (IOException exception) {
-      throw new IllegalStateException(exception.getMessage());
+      throw new IllegalStateException(exception.getMessage(), exception);
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTask.java
@@ -56,7 +56,7 @@ public class KubernetesResourceTask extends AbstractJKubeTask {
     }
     final ResourceServiceConfig resourceServiceConfig = ResourceServiceConfig.builder()
         .project(kubernetesExtension.javaProject)
-        .resourceDir(resolveResourceSourceDirectory())
+        .resourceDirs(resolveResourceSourceDirectory())
         .targetDir(kubernetesExtension.getResourceTargetDirectoryOrDefault())
         .resourceFileType(kubernetesExtension.getResourceFileTypeOrDefault())
         .resourceConfig(resourceConfig)

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
@@ -14,7 +14,6 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
-import org.eclipse.jkube.kit.common.util.ResourceUtil;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 
 import javax.inject.Inject;
@@ -41,10 +40,9 @@ public class KubernetesUndeployTask extends AbstractJKubeTask {
           .filter(s -> !s.isEmpty())
           .orElse(null))
         .build();
-      final File environmentResourceDir = ResourceUtil.getFinalResourceDir(resolveResourceSourceDirectory(),
-          kubernetesExtension.getResourceEnvironmentOrNull());
+      final List<File> environmentResourceDirs = resolveResourceSourceDirectory();
       jKubeServiceHub.getUndeployService()
-        .undeploy(environmentResourceDir, resources, findManifestsToUndeploy().toArray(new File[0]));
+        .undeploy(environmentResourceDirs, resources, findManifestsToUndeploy().toArray(new File[0]));
     } catch (IOException e) {
       throw new IllegalStateException(e.getMessage(), e);
     }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
@@ -91,7 +91,7 @@ public class KubernetesWatchTask extends AbstractJKubeTask {
 
   private ProcessorConfig extractWatcherConfig() {
     try {
-      return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.WATCHER_CONFIG, kubernetesExtension.getProfileOrNull(), ResourceUtil.getFinalResourceDir(kubernetesExtension.getResourceSourceDirectoryOrDefault(), kubernetesExtension.getResourceEnvironmentOrNull()), kubernetesExtension.watcher);
+      return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.WATCHER_CONFIG, kubernetesExtension.getProfileOrNull(), ResourceUtil.getFinalResourceDirs(kubernetesExtension.getResourceSourceDirectoryOrDefault(), kubernetesExtension.getResourceEnvironmentOrNull()), kubernetesExtension.watcher);
     } catch (IOException e) {
       throw new IllegalArgumentException("Cannot extract watcher config: " + e, e);
     }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmPushTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmPushTaskTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.mockito.MockedConstruction;
 
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -58,7 +59,9 @@ public class KubernetesHelmPushTaskTest {
 
     // Then
     assertThat(illegalStateException)
-      .hasMessageContaining("META-INF/jkube/kubernetes (No such file or directory)");
+        .hasMessageContaining("META-INF/jkube/kubernetes")
+        .getCause()
+        .isInstanceOf(NoSuchFileException.class);
   }
 
   @Test

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTaskTest.java
@@ -13,16 +13,18 @@
  */
 package org.eclipse.jkube.gradle.plugin.task;
 
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.gradle.plugin.TestKubernetesExtension;
 import org.eclipse.jkube.kit.resource.helm.HelmService;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.MockedConstruction;
-
-import java.io.IOException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -57,7 +59,9 @@ public class KubernetesHelmTaskTest {
 
     // Then
     assertThat(illegalStateException)
-      .hasMessageContaining("META-INF/jkube/kubernetes (No such file or directory)");
+      .hasMessageContaining("META-INF/jkube/kubernetes")
+        .getCause()
+        .isInstanceOf(NoSuchFileException.class);
   }
 
   @Test

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTaskTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.gradle.plugin.task;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.gradle.plugin.TestKubernetesExtension;
@@ -91,8 +92,8 @@ public class KubernetesUndeployTaskTest {
     assertThat(kubernetesUndeployServiceMockedConstruction.constructed()).hasSize(1);
     verify(kubernetesUndeployServiceMockedConstruction.constructed().iterator().next(), times(1))
       .undeploy(
-            taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
-                .toFile(),
+            Collections.singletonList(taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
+                .toFile()),
             ResourceConfig.builder().build(), taskEnvironment.getRoot().toPath()
                 .resolve(Paths.get("build", "classes", "java", "main", "META-INF", "jkube", "kubernetes.yml")).toFile()
       );

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftHelmPushTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftHelmPushTaskTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.mockito.MockedConstruction;
 
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -57,7 +58,9 @@ public class OpenShiftHelmPushTaskTest {
 
     // Then
     assertThat(illegalStateException)
-      .hasMessageContaining("META-INF/jkube/openshift (No such file or directory)");
+        .hasMessageContaining("META-INF/jkube/openshift")
+        .getCause()
+        .isInstanceOf(NoSuchFileException.class);
   }
 
   @Test

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftHelmTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftHelmTaskTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.mockito.MockedConstruction;
 
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -56,7 +57,9 @@ public class OpenShiftHelmTaskTest {
 
     // Then
     assertThat(illegalStateException)
-      .hasMessageContaining("META-INF/jkube/openshift (No such file or directory)");
+        .hasMessageContaining("META-INF/jkube/openshift")
+        .getCause()
+        .isInstanceOf(NoSuchFileException.class);
   }
 
   @Test

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftUndeployTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftUndeployTaskTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.gradle.plugin.task;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
 import org.eclipse.jkube.gradle.plugin.TestOpenShiftExtension;
@@ -91,8 +92,8 @@ public class OpenShiftUndeployTaskTest {
     assertThat(openshiftUndeployServiceMockedConstruction.constructed()).hasSize(1);
     verify(openshiftUndeployServiceMockedConstruction.constructed().iterator().next(), times(1))
       .undeploy(
-            taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
-                .toFile(),
+            Collections.singletonList(taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
+                .toFile()),
             ResourceConfig.builder().build(), taskEnvironment.getRoot().toPath()
                 .resolve(Paths.get("build", "classes", "java", "main", "META-INF", "jkube", "openshift.yml")).toFile(),
             taskEnvironment.getRoot().toPath().resolve(Paths.get("build", "test-project-is.yml")).toFile()

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/ResourceUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/ResourceUtil.java
@@ -14,9 +14,9 @@
 package org.eclipse.jkube.kit.common.util;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -77,7 +77,7 @@ public class ResourceUtil {
             return Collections.emptyList();
         }
         final List<HasMetadata> kubernetesResources = new ArrayList<>();
-        try (InputStream fis = new FileInputStream(manifest)) {
+        try (InputStream fis = Files.newInputStream(manifest.toPath())) {
             kubernetesResources.addAll(split(Serialization.unmarshal(fis, Collections.emptyMap())));
         }
         return kubernetesResources;
@@ -104,7 +104,7 @@ public class ResourceUtil {
     }
 
     public static <T extends KubernetesResource> T load(File file, Class<T> clazz) throws IOException {
-        return Serialization.unmarshal(new FileInputStream(file), clazz);
+        return Serialization.unmarshal(Files.newInputStream(file.toPath()), clazz);
     }
 
     public static File save(File file, Object data) throws IOException {
@@ -137,7 +137,7 @@ public class ResourceUtil {
     public static List<File> getFinalResourceDirs(File resourceDir, String environmentAsCommaSeparateStr) {
         List<File> resourceDirs = new ArrayList<>();
 
-        if (resourceDir != null && StringUtils.isNotEmpty(environmentAsCommaSeparateStr)) {
+        if (resourceDir != null && StringUtils.isNotBlank(environmentAsCommaSeparateStr)) {
             String[] environments = environmentAsCommaSeparateStr.split(",");
             for (String environment : environments) {
                 resourceDirs.add(new File(resourceDir, environment.trim()));

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/ResourceUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/ResourceUtil.java
@@ -134,11 +134,18 @@ public class ResourceUtil {
                 .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
     }
 
-    public static File getFinalResourceDir(File resourceDir, String environment) {
-        if (resourceDir != null && StringUtils.isNotEmpty(environment)) {
-            return new File(resourceDir, environment);
+    public static List<File> getFinalResourceDirs(File resourceDir, String environmentAsCommaSeparateStr) {
+        List<File> resourceDirs = new ArrayList<>();
+
+        if (resourceDir != null && StringUtils.isNotEmpty(environmentAsCommaSeparateStr)) {
+            String[] environments = environmentAsCommaSeparateStr.split(",");
+            for (String environment : environments) {
+                resourceDirs.add(new File(resourceDir, environment.trim()));
+            }
+        } else if (StringUtils.isBlank(environmentAsCommaSeparateStr)) {
+            resourceDirs.add(resourceDir);
         }
-        return resourceDir;
+        return resourceDirs;
     }
 
 

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -81,7 +81,7 @@ public class KubernetesHelperTest {
         File localResourceDir = new File(getClass().getResource("/util/fragments").getPath());
 
         // When & Then
-        assertLocalFragments(KubernetesHelper.listResourceFragments(localResourceDir, null, logger), 2);
+        assertLocalFragments(KubernetesHelper.listResourceFragments(null, logger, localResourceDir), 2);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class KubernetesHelperTest {
         File localResourceDir = new File(getClass().getResource("/util/fragments").getPath());
 
         // When
-        File[] fragments = KubernetesHelper.listResourceFragments(localResourceDir, remoteStrList, logger);
+        File[] fragments = KubernetesHelper.listResourceFragments(remoteStrList, logger, localResourceDir);
 
         // Then
         assertLocalFragments(fragments, 4);

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/ResourceUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/ResourceUtilTest.java
@@ -277,4 +277,46 @@ public class ResourceUtilTest {
         assertThat(file).hasSameTextualContentAs(
             new File(ResourceUtilTest.class.getResource( "/util/resource-util/expected/config-map-placeholders.yml").getFile()));
     }
+
+    @Test
+    public void getFinalResourceDirs_withMultipleEnvs_shouldReturnEnvResourceDirList() throws IOException {
+        // Given
+        File resourceDir = temporaryFolder.newFolder("src", "main", "jkube");
+
+        // When
+        List<File> finalResourceDirs = ResourceUtil.getFinalResourceDirs(resourceDir, "common,dev");
+
+        // Then
+        assertThat(finalResourceDirs)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(new File(resourceDir, "common"), new File(resourceDir, "dev"));
+    }
+
+    @Test
+    public void getFinalResourceDirs_withNullEnv_shouldReturnResourceDir() throws IOException {
+        // Given
+        File resourceDir = temporaryFolder.newFolder("src", "main", "jkube");
+
+        // When
+        List<File> finalResourceDirs = ResourceUtil.getFinalResourceDirs(resourceDir, null);
+
+        // Then
+        assertThat(finalResourceDirs)
+            .hasSize(1)
+            .containsExactly(resourceDir);
+    }
+
+    @Test
+    public void getFinalResourceDirs_withEmptyEnv_shouldReturnResourceDir() throws IOException {
+        // Given
+        File resourceDir = temporaryFolder.newFolder("src", "main", "jkube");
+
+        // When
+        List<File> finalResourceDirs = ResourceUtil.getFinalResourceDirs(resourceDir, "");
+
+        // Then
+        assertThat(finalResourceDirs)
+            .hasSize(1)
+            .containsExactly(resourceDir);
+    }
 }

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceServiceConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceServiceConfig.java
@@ -14,7 +14,9 @@
 package org.eclipse.jkube.kit.config.resource;
 
 import java.io.File;
+import java.util.List;
 
+import lombok.Singular;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.ResourceFileType;
 
@@ -35,7 +37,8 @@ import lombok.NoArgsConstructor;
 public class ResourceServiceConfig {
 
   private JavaProject project;
-  private File resourceDir;
+  @Singular
+  private List<File> resourceDirs;
   private File targetDir;
   private ResourceFileType resourceFileType;
   private ResourceConfig resourceConfig;

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/UndeployService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/UndeployService.java
@@ -17,8 +17,9 @@ import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 public interface UndeployService {
 
-  void undeploy(File resourceDir, ResourceConfig resourceConfig, File... manifestFiles) throws IOException;
+  void undeploy(List<File> resourceDir, ResourceConfig resourceConfig, File... manifestFiles) throws IOException;
 }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
@@ -50,7 +50,7 @@ public class KubernetesUndeployService implements UndeployService {
   }
 
   @Override
-  public void undeploy(File resourceDir, ResourceConfig resourceConfig, File... manifestFiles) throws IOException {
+  public void undeploy(List<File> resourceDirs, ResourceConfig resourceConfig, File... manifestFiles) throws IOException {
     final String fallbackNamespace = KubernetesClientUtil.resolveFallbackNamespace(resourceConfig, jKubeServiceHub.getClusterAccess());
     final List<File> manifests = Stream.of(manifestFiles)
         .filter(Objects::nonNull).filter(File::exists).filter(File::isFile)

--- a/jkube-kit/profile/src/test/java/org/eclipse/jkube/kit/profile/ProfileUtilTest.java
+++ b/jkube-kit/profile/src/test/java/org/eclipse/jkube/kit/profile/ProfileUtilTest.java
@@ -87,9 +87,7 @@ public class ProfileUtilTest {
 
     @Test
     public void findProfile_whenValidProfileArg_returnsValidProfile() throws URISyntaxException, IOException {
-
         assertNotNull(ProfileUtil.findProfile("simple", getProfileDir()));
-
     }
 
     @Test
@@ -100,7 +98,16 @@ public class ProfileUtilTest {
         IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> ProfileUtil.findProfile("not-there", profileDirs));
 
         assertTrue(illegalArgumentException.getMessage().contains("not-there"));
+    }
 
+    @Test
+    public void findProfile_whenProfileUsedWithInvalidParent_thenThrowsException() throws URISyntaxException {
+        // Given
+        File profileDir = getProfileDir();
+        // When
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> ProfileUtil.findProfile("invalid-parent", profileDir));
+        // Then
+        assertEquals("No parent profile 'i-dont-exist' defined", illegalArgumentException.getMessage());
     }
 
     @Test
@@ -143,17 +150,5 @@ public class ProfileUtilTest {
         assertTrue(aProfile.getEnricherConfig().use("default.service"));
         assertTrue(aProfile.getGeneratorConfig().use("spring.swarm"));
         assertFalse(aProfile.getGeneratorConfig().use("java.app"));
-    }
-
-    @Test
-    public void findProfile_whenProfileUsedWithInvalidParent_thenThrowsException() throws URISyntaxException {
-        // Given
-        File profileDir = getProfileDir();
-
-        // When
-        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> ProfileUtil.findProfile("invalid-parent", profileDir));
-
-        // Then
-        assertEquals("No parent profile 'i-dont-exist' defined", illegalArgumentException.getMessage());
     }
 }

--- a/jkube-kit/profile/src/test/resources/jkube/config/profiles-lookup-dir/profiles.yaml
+++ b/jkube-kit/profile/src/test/resources/jkube/config/profiles-lookup-dir/profiles.yaml
@@ -40,3 +40,5 @@
       - jkube-project
       - jkube-debug
       - jkube-ingress
+- name: invalid-parent
+  extends: i-dont-exist

--- a/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/DefaultResourceService.java
+++ b/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/DefaultResourceService.java
@@ -16,7 +16,6 @@ package org.eclipse.jkube.kit.resource.service;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.validation.ConstraintViolationException;
@@ -83,7 +82,10 @@ public class DefaultResourceService implements ResourceService {
 
     final ResourceConfig resourceConfig = resourceServiceConfig.getResourceConfig();
     try {
-      File[] resourceFiles = aggregateResourceFragments(resourceServiceConfig.getResourceDirs(), resourceConfig, log);
+      File[] resourceFiles = listResourceFragments(
+          resourceConfig != null ? resourceConfig.getRemotes() : null, log, resourceServiceConfig.getResourceDirs());
+      resourceServiceConfig.getResourceDirs()
+          .forEach(resourceDir -> log.info("Using resource templates from %s", resourceDir));
       final File[] processedResource = processResourceFiles(resourceFiles);
       KubernetesListBuilder builder = processResourceFragments(platformMode, processedResource);
 
@@ -148,18 +150,6 @@ public class DefaultResourceService implements ResourceService {
       return resourceServiceConfig.getResourceFilesProcessor().processResources(resourceFiles);
     }
     return resourceFiles;
-  }
-
-  private File[] aggregateResourceFragments(List<File> resourceDirs, ResourceConfig resourceConfig, KitLogger log) {
-    List<File> fragments = new ArrayList<>();
-    for (File resourceDir : resourceDirs) {
-      log.info("Using resource templates from %s", resourceDir);
-      File[] resourceFiles = listResourceFragments(resourceDir, resourceConfig !=null ? resourceConfig.getRemotes() : null, log);
-      if (resourceFiles != null && resourceFiles.length > 0) {
-        fragments.addAll(Arrays.asList(resourceFiles));
-      }
-    }
-    return fragments.toArray(new File[0]);
   }
 
 }

--- a/jkube-kit/resource/service/src/test/resources/jkube/common/common-configmap.yml
+++ b/jkube-kit/resource/service/src/test/resources/jkube/common/common-configmap.yml
@@ -1,0 +1,2 @@
+data:
+  type: common

--- a/jkube-kit/resource/service/src/test/resources/jkube/common/profiles.yml
+++ b/jkube-kit/resource/service/src/test/resources/jkube/common/profiles.yml
@@ -1,0 +1,2 @@
+- name: test
+  order: 10

--- a/jkube-kit/resource/service/src/test/resources/jkube/common/test/test-configmap.yml
+++ b/jkube-kit/resource/service/src/test/resources/jkube/common/test/test-configmap.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-profile
+data:
+  type: test

--- a/jkube-kit/resource/service/src/test/resources/jkube/dev/dev-configmap.yml
+++ b/jkube-kit/resource/service/src/test/resources/jkube/dev/dev-configmap.yml
@@ -1,0 +1,2 @@
+data:
+  type: dev

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-apply.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-apply.adoc
@@ -111,7 +111,7 @@ endif::[]
 
 | *environment*
 | Environment name where resources are placed. For example, if you set this property to dev and resourceDir is the
-  default one, jkube will look at `src/main/jkube/dev`.
+  default one, jkube will look at `src/main/jkube/dev`.  Multiple environments can also be provided in form of comma separated strings. Resource fragments in these directories will be combined while generating resources.
 
   Defaults to `null`.
 | `jkube.environment`

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/goals/build/_jkube-resource.adoc
@@ -893,7 +893,7 @@ endif::[]
 
 | *environment*
 | Environment name where resources are placed. For example, if you set this property to dev and resourceDir is the
-  default one, plugin will look at `src/main/jkube/dev`.
+  default one, plugin will look at `src/main/jkube/dev`.  Multiple environments can also be provided in form of comma separated strings.  Resource fragments in these directories will be combined while generating resources.
 
   Defaults to `null`.
 | `jkube.environment`

--- a/kubernetes-maven-plugin/it/pom.xml
+++ b/kubernetes-maven-plugin/it/pom.xml
@@ -16,10 +16,12 @@
 -->
 <!--
 Use
-
 mvn clean install -Dinvoker.test=<directory of single test>
-
 for running a single test.
+
+Use
+mvn -Dinvoker.mavenExecutable=mvnDebug clean verify -Dinvoker.test=configmap
+for running a single test with mvnDebug.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -712,7 +712,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo
     // Get generator config
     protected ProcessorConfig extractGeneratorConfig() {
         try {
-            return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.GENERATOR_CONFIG, profile, ResourceUtil.getFinalResourceDir(resourceDir, environment), generator);
+            return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.GENERATOR_CONFIG, profile, ResourceUtil.getFinalResourceDirs(resourceDir, environment), generator);
         } catch (IOException e) {
             throw new IllegalArgumentException("Cannot extract generator config: " + e, e);
         }
@@ -721,7 +721,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo
     // Get enricher config
     protected ProcessorConfig extractEnricherConfig() {
         try {
-            return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.ENRICHER_CONFIG, profile, ResourceUtil.getFinalResourceDir(resourceDir, environment), enricher);
+            return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.ENRICHER_CONFIG, profile, ResourceUtil.getFinalResourceDirs(resourceDir, environment), enricher);
         } catch (IOException e) {
             throw new IllegalArgumentException("Cannot extract enricher config: " + e, e);
         }

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
@@ -182,7 +182,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
     protected MavenProjectHelper projectHelper;
 
     // resourceDir when environment has been applied
-    private File realResourceDir;
+    private List<File> realResourceDirs;
 
 
 
@@ -230,10 +230,10 @@ public class ResourceMojo extends AbstractJKubeMojo {
 
     @Override
     protected JKubeServiceHub.JKubeServiceHubBuilder initJKubeServiceHubBuilder(JavaProject javaProject) {
-        realResourceDir = ResourceUtil.getFinalResourceDir(resourceDir, environment);
+        realResourceDirs = ResourceUtil.getFinalResourceDirs(resourceDir, environment);
         final ResourceServiceConfig resourceServiceConfig = ResourceServiceConfig.builder()
             .project(javaProject)
-            .resourceDir(realResourceDir)
+            .resourceDirs(realResourceDirs)
             .targetDir(targetDir)
             .resourceFileType(resourceFileType)
             .resourceConfig(resources)
@@ -310,11 +310,11 @@ public class ResourceMojo extends AbstractJKubeMojo {
     }
 
     private ProcessorConfig extractEnricherConfig() throws IOException {
-        return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.ENRICHER_CONFIG, profile, realResourceDir, enricher);
+        return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.ENRICHER_CONFIG, profile, realResourceDirs, enricher);
     }
 
     private ProcessorConfig extractGeneratorConfig() throws IOException {
-        return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.GENERATOR_CONFIG, profile, realResourceDir, generator);
+        return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.GENERATOR_CONFIG, profile, realResourceDirs, generator);
     }
 
     // ==================================================================================
@@ -370,7 +370,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
     }
 
     private boolean hasJKubeDir() {
-        return realResourceDir.isDirectory();
+        return !realResourceDirs.isEmpty() && realResourceDirs.get(0).isDirectory();
     }
 
     private boolean isPomProject() {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
@@ -93,7 +93,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
      * Folder where to find project specific files
      */
     @Parameter(property = "jkube.resourceDir", defaultValue = "${basedir}/src/main/jkube")
-    private File resourceDir;
+    protected File resourceDir;
 
     /**
      * Environment name where resources are placed. For example, if you set this property to dev and resourceDir is the default one, plugin will look at src/main/jkube/dev
@@ -176,7 +176,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
     private Boolean mergeWithDekorate;
 
     @Parameter(property="jkube.interpolateTemplateParameters", defaultValue = "true")
-    private Boolean interpolateTemplateParameters;
+    protected Boolean interpolateTemplateParameters;
 
     @Component
     protected MavenProjectHelper projectHelper;

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
@@ -72,9 +72,9 @@ public class UndeployMojo extends AbstractJKubeMojo implements ManifestProvider 
   }
 
   protected void undeploy() throws IOException {
-    final File environmentResourceDir = ResourceUtil.getFinalResourceDir(resourceDir, environment);
+    final List<File> environmentResourceDirs = ResourceUtil.getFinalResourceDirs(resourceDir, environment);
     jkubeServiceHub.getUndeployService()
-        .undeploy(environmentResourceDir, resources, getManifestsToUndeploy().toArray(new File[0]));
+        .undeploy(environmentResourceDirs, resources, getManifestsToUndeploy().toArray(new File[0]));
   }
 
   protected List<File> getManifestsToUndeploy() {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
@@ -154,7 +154,7 @@ public class WatchMojo extends AbstractDockerMojo implements ManifestProvider {
     // Get watcher config
     private ProcessorConfig extractWatcherConfig() {
         try {
-            return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.WATCHER_CONFIG, profile, ResourceUtil.getFinalResourceDir(resourceDir, environment), watcher);
+            return ProfileUtil.blendProfileWithConfiguration(ProfileUtil.WATCHER_CONFIG, profile, ResourceUtil.getFinalResourceDirs(resourceDir, environment), watcher);
         } catch (IOException e) {
             throw new IllegalArgumentException("Cannot extract watcher config: " + e, e);
         }

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojoTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.maven.plugin.mojo.develop;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Properties;
 
 import org.eclipse.jkube.kit.common.util.MavenUtil;
@@ -95,7 +96,7 @@ public class UndeployMojoTest {
   private void assertUndeployServiceUndeployWasCalled() throws Exception {
     // @formatter:off
     new Verifications() {{
-      jKubeServiceHub.getUndeployService().undeploy(mockResourceDir, withNotNull(), mockManifest);
+      jKubeServiceHub.getUndeployService().undeploy(Collections.singletonList(mockResourceDir), withNotNull(), mockManifest);
       times = 1;
     }};
     // @formatter:on


### PR DESCRIPTION
## Description
Fix #1218 

Modify ResourceServiceConfig to recieve a list of files as resourceDirs
instead of receiving a single resourceDir. Resource fragments in these
files can be combined while generating resources.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->