### PR TITLE
fix: gradle push registry can be configured via property

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesExtension.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesExtension.java
@@ -525,6 +525,10 @@ public abstract class KubernetesExtension {
     return getOrDefaultBoolean("jkube.skip.push", this::getSkipPush, false);
   }
 
+  public String getPushRegistryOrNull() {
+    return getOrDefaultString("jkube.docker.push.registry", this::getPushRegistry, null);
+  }
+
   public boolean getSkipTagOrDefault() {
     return getOrDefaultBoolean("jkube.skip.tag", this::getSkipTag, false);
   }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
@@ -41,24 +41,25 @@ public class KubernetesPushTask extends AbstractJKubeTask {
   @Override
   public void run() {
     try {
-      jKubeServiceHub.getBuildService().push(resolvedImages, kubernetesExtension.getPushRetriesOrDefault(), initRegistryConfig(kubernetesExtension.getPushRegistry().getOrNull()), kubernetesExtension.getSkipTagOrDefault());
+      jKubeServiceHub.getBuildService()
+          .push(resolvedImages, kubernetesExtension.getPushRetriesOrDefault(), initRegistryConfig(), kubernetesExtension.getSkipTagOrDefault());
     } catch (JKubeServiceException e) {
       throw new IllegalStateException("Error in pushing image: " + e.getMessage(), e);
     }
   }
-
 
   @Override
   protected boolean canExecute() {
     return super.canExecute() && !kubernetesExtension.getSkipPushOrDefault();
   }
 
-  private RegistryConfig initRegistryConfig(String specificRegistry) {
+  private RegistryConfig initRegistryConfig() {
+    final String specificRegistry = kubernetesExtension.getPushRegistryOrNull();
     return RegistryConfig.builder()
       .settings(Collections.emptyList())
       .authConfig(kubernetesExtension.authConfig != null ? kubernetesExtension.authConfig.toMap() : null)
       .skipExtendedAuth(kubernetesExtension.getSkipExtendedAuthOrDefault())
-      .registry(specificRegistry != null ? specificRegistry : kubernetesExtension.getRegistry().getOrNull())
+      .registry(specificRegistry != null ? specificRegistry : kubernetesExtension.getRegistryOrDefault())
       .passwordDecryptionMethod(password -> password).build();
   }
 

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionPropertyTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/KubernetesExtensionPropertyTest.java
@@ -74,6 +74,7 @@ public class KubernetesExtensionPropertyTest {
             true },
         new Object[] { "getRollingUpgradePreserveScaleOrDefault", "jkube.rolling.preserveScale", "true", true, false },
         new Object[] { "getSkipPushOrDefault", "jkube.skip.push", "true", true, false },
+        new Object[] { "getPushRegistryOrNull", "jkube.docker.push.registry", "https://custom:5000", "https://custom:5000", null },
         new Object[] { "getSkipTagOrDefault", "jkube.skip.tag", "true", true, false },
         new Object[] { "getPushRetriesOrDefault", "jkube.docker.push.retries", "1337", 1337, 0 },
         new Object[] { "getSkipExtendedAuthOrDefault", "jkube.docker.skip.extendedAuth", "true", true, false },


### PR DESCRIPTION
## Description
fix: gradle push registry can be configured via property

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->