### PR TITLE
fix (jkube-kit) : Assembly files with unnormalized paths don't get fileMode changes (#1483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Usage:
 * Fix #1362: VolumePermissionEnricher : Replace iteration with bulk Collection.addAll call
 * Fix #1382: Docker Build ARGS not replaced properly
 * Fix #1324: Support legacy javaee as well as jakartaee projects in the Tomcat webapp generator
+* Fix #1483: Assembly files with unnormalized paths don't get fileMode changes
 
 ### 1.7.0 (2022-02-25)
 * Fix #1315: Pod Log Service works for Jobs with no selector

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtils.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtils.java
@@ -46,7 +46,7 @@ public class AssemblyFileUtils {
           .resolve(assemblyFile.getOutputDirectory().toPath())
           .toFile();
     }
-    return outputDirectory;
+    return outputDirectory.toPath().normalize().toFile();
   }
 
   public static File resolveSourceFile(File baseDirectory, AssemblyFile assemblyFile) {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtilsTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileUtilsTest.java
@@ -109,6 +109,22 @@ public class AssemblyFileUtilsTest {
   }
 
   @Test
+  public void getAssemblyFileOutputDirectory_withOutputDirectory_shouldReturnNormalizedDir() throws IOException {
+    // Given
+    final AssemblyFile af = AssemblyFile.builder().outputDirectory(new File("build/./camel-quarkus-demo-1.0.0-runner")).build();
+    final File outputDirectoryForRelativePaths = temporaryFolder.newFile("output");
+    final Assembly layer = Assembly.builder().id("layer-1").build();
+    final AssemblyConfiguration ac = AssemblyConfiguration.builder().targetDir("/project").build();
+
+    // When
+    final File result = getAssemblyFileOutputDirectory(af, outputDirectoryForRelativePaths, layer, ac);
+
+    // Then
+    assertEquals(new File(outputDirectoryForRelativePaths, "layer-1/project/build/camel-quarkus-demo-1.0.0-runner").getAbsolutePath(),
+        result.getAbsolutePath());
+  }
+
+  @Test
   public void resolveSourceFileAbsoluteFileShouldReturnSame() throws IOException {
     // Given
     assumeFalse(isWindows());


### PR DESCRIPTION
## Description

Fix #1483

Normalize output directory returned by AssemblyFileUtils

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->