### PR TITLE
fix: route doesn't use the service "normalizePort"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Usage:
 * Fix #1362: VolumePermissionEnricher : Replace iteration with bulk Collection.addAll call
 * Fix #1382: Docker Build ARGS not replaced properly
 * Fix #1324: Support legacy javaee as well as jakartaee projects in the Tomcat webapp generator
+* Fix #1460: Route doesn't use the service "normalizePort"
 * Fix #1482: Quarkus Generator and Enricher should be compatible with the Red Hat build
 * Fix #1483: Assembly files with unnormalized paths don't get fileMode changes
 * Fix #1489: Align BaseGenerator's `add` and `tags` config options to work with `jkube.generator.*` properties

--- a/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass/openshift.yml
+++ b/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass/openshift.yml
@@ -146,7 +146,7 @@ items:
     name: jkube-docker-registry
   spec:
     port:
-      targetPort: 5000
+      targetPort: 80
     to:
       kind: Service
       name: jkube-docker-registry

--- a/gradle-plugin/it/src/it/volume-permission/expected/default/openshift.yml
+++ b/gradle-plugin/it/src/it/volume-permission/expected/default/openshift.yml
@@ -144,7 +144,7 @@ items:
     name: jkube-docker-registry
   spec:
     port:
-      targetPort: 5000
+      targetPort: 80
     to:
       kind: Service
       name: jkube-docker-registry

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
@@ -38,9 +38,8 @@ import org.eclipse.jkube.kit.config.resource.ServiceConfig;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
-import org.eclipse.jkube.kit.enricher.handler.HandlerHub;
-import org.eclipse.jkube.kit.enricher.handler.ServiceHandler;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -613,5 +612,24 @@ public class DefaultServiceEnricher extends BaseEnricher {
             return "TCP";
         }
         return protocol;
+    }
+
+    public static Integer getPortToExpose(ServiceBuilder serviceBuilder) {
+        ServiceSpec spec = serviceBuilder.buildSpec();
+        if (spec != null) {
+            final List<ServicePort> ports = spec.getPorts();
+            if (ports != null && !ports.isEmpty()) {
+                for (ServicePort port : ports) {
+                    if (Objects.equals(port.getName(), "http") || Objects.equals(port.getProtocol(), "http") ) {
+                        return port.getPort();
+                    }
+                }
+                ServicePort servicePort = ports.iterator().next();
+                if (servicePort.getPort() != null) {
+                    return servicePort.getPort();
+                }
+            }
+        }
+        return null;
     }
 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
@@ -104,25 +104,6 @@ public class IngressEnricher extends BaseEnricher {
         return ingressMetadataBuilder.build();
     }
 
-    static Integer getServicePort(ServiceBuilder serviceBuilder) {
-        ServiceSpec spec = serviceBuilder.buildSpec();
-        if (spec != null) {
-            List<ServicePort> ports = spec.getPorts();
-            if (ports != null && !ports.isEmpty()) {
-                for (ServicePort port : ports) {
-                    if (port.getName().equals("http") || port.getProtocol().equals("http")) {
-                        return port.getPort();
-                    }
-                }
-                ServicePort servicePort = ports.get(0);
-                if (servicePort != null) {
-                    return servicePort.getPort();
-                }
-            }
-        }
-        return 0;
-    }
-
     /**
      * Returns true if we already have an ingress created for the given name
      */

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NetworkingV1IngressGenerator.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NetworkingV1IngressGenerator.java
@@ -42,8 +42,8 @@ import org.eclipse.jkube.kit.config.resource.IngressTlsConfig;
 import java.util.List;
 import java.util.Objects;
 
+import static org.eclipse.jkube.enricher.generic.DefaultServiceEnricher.getPortToExpose;
 import static org.eclipse.jkube.enricher.generic.IngressEnricher.getIngressMetadata;
-import static org.eclipse.jkube.enricher.generic.IngressEnricher.getServicePort;
 import static org.eclipse.jkube.enricher.generic.IngressEnricher.hasIngress;
 import static org.eclipse.jkube.enricher.generic.IngressEnricher.resolveIngressHost;
 import static org.eclipse.jkube.enricher.generic.IngressEnricher.shouldCreateExternalURLForService;
@@ -61,7 +61,7 @@ public class NetworkingV1IngressGenerator {
             Objects.requireNonNull(serviceMetadata);
             String serviceName = serviceMetadata.getName();
             if (!hasIngress(listBuilder, serviceName)) {
-                Integer servicePort = getServicePort(serviceBuilder);
+                Integer servicePort = getPortToExpose(serviceBuilder);
                 if (servicePort != null) {
                     return new IngressBuilder()
                             .withMetadata(getIngressMetadata(serviceMetadata))

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
@@ -14,7 +14,6 @@
 package org.eclipse.jkube.enricher.generic.openshift;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -41,6 +40,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 
+import static org.eclipse.jkube.enricher.generic.DefaultServiceEnricher.getPortToExpose;
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.isExposedService;
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.mergeMetadata;
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.mergeSimpleFields;
@@ -127,19 +127,10 @@ public class RouteEnricher extends BaseEnricher {
 
     private static RoutePort createRoutePort(ServiceBuilder serviceBuilder) {
         RoutePort routePort = null;
-        ServiceSpec spec = serviceBuilder.buildSpec();
-        if (spec != null) {
-            List<ServicePort> ports = spec.getPorts();
-            if (ports != null && !ports.isEmpty()) {
-                ServicePort servicePort = ports.get(0);
-                if (servicePort != null) {
-                    Integer servicePortNumber = servicePort.getPort();
-                    if (servicePortNumber != null) {
-                        routePort = new RoutePort();
-                        routePort.setTargetPort(new IntOrString(servicePortNumber));
-                    }
-                }
-            }
+        final Integer servicePort = getPortToExpose(serviceBuilder);
+        if (servicePort != null) {
+            routePort = new RoutePort();
+            routePort.setTargetPort(new IntOrString(servicePort));
         }
         return routePort;
     }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
@@ -133,10 +133,10 @@ public class RouteEnricher extends BaseEnricher {
             if (ports != null && !ports.isEmpty()) {
                 ServicePort servicePort = ports.get(0);
                 if (servicePort != null) {
-                    IntOrString targetPort = servicePort.getTargetPort();
-                    if (targetPort != null) {
+                    Integer servicePortNumber = servicePort.getPort();
+                    if (servicePortNumber != null) {
                         routePort = new RoutePort();
-                        routePort.setTargetPort(targetPort);
+                        routePort.setTargetPort(new IntOrString(servicePortNumber));
                     }
                 }
             }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/IngressEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/IngressEnricherTest.java
@@ -17,11 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.TreeMap;
 
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
-import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
-import io.fabric8.kubernetes.api.model.networking.v1.IngressSpec;
-import io.fabric8.kubernetes.api.model.networking.v1.IngressTLSBuilder;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.IngressConfig;
@@ -33,18 +28,22 @@ import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
+import org.eclipse.jkube.kit.enricher.api.model.Configuration;
 
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressSpec;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressTLSBuilder;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.eclipse.jkube.kit.enricher.api.model.Configuration;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -220,52 +219,6 @@ public class IngressEnricherTest {
             .element(1).asInstanceOf(InstanceOfAssertFactories.type(Ingress.class))
             .isEqualTo(providedIngress)
             .isNotSameAs(providedIngress);
-    }
-
-    @Test
-    public void testGetServicePortWithHttpPort() {
-        // Given
-        ServiceBuilder serviceBuilder = initTestService();
-
-        // When
-        int port = IngressEnricher.getServicePort(serviceBuilder);
-
-        // Then
-        assertThat(port).isEqualTo(8080);
-    }
-
-    @Test
-    public void testGetServiceWithNoHttpPort() {
-        // Given
-        ServiceBuilder serviceBuilder = initTestService()
-                .editSpec()
-                .withPorts(new ServicePortBuilder()
-                        .withName("p1")
-                        .withProtocol("TCP")
-                        .withPort(9001)
-                        .build())
-                .endSpec();
-
-        // When
-        int port = IngressEnricher.getServicePort(serviceBuilder);
-
-        // Then
-        assertThat(port).isEqualTo(9001);
-    }
-
-    @Test
-    public void testGetServiceWithNoPort() {
-        // Given
-        ServiceBuilder serviceBuilder = initTestService()
-                .editSpec()
-                .withPorts(Collections.emptyList())
-                .endSpec();
-
-        // When
-        int port = IngressEnricher.getServicePort(serviceBuilder);
-
-        // Then
-        assertThat(port).isZero();
     }
 
     @Test


### PR DESCRIPTION
## Description
fix #1460 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->