### PR TITLE
ci : fix intermittent failures of doc-preview-pr CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,6 @@ jobs:
       - image: cimg/openjdk:11.0
     steps:
     - checkout
-    - restore_cache:
-        key: jkube-kit-{{ checksum "pom.xml" }}
     - run: |
         if [ -n "${CIRCLE_PR_NUMBER}" ]; then
           ./scripts/generateDoc.sh

--- a/scripts/generateDoc.sh
+++ b/scripts/generateDoc.sh
@@ -15,6 +15,7 @@
 
 trap 'exit' ERR
 
+mvn clean install -DskipTests
 mkdir docs-generated
 # Kubernetes Gradle Plugin
 mvn -f gradle-plugin/doc -Phtml package


### PR DESCRIPTION
## Description

doc-preview-pr CircleCI workflow seems to be intermittently failing
sometimes due to jkube-kit-parent pom not found in circleci maven cache.
Removing load cache step and adding a build without tests step in
generateDoc script.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->