### PR TITLE
fix: gradle plugins are graduated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Usage:
 * Fix #1482: Quarkus Generator and Enricher should be compatible with the Red Hat build
 * Fix #1483: Assembly files with unnormalized paths don't get fileMode changes
 * Fix #1489: Align BaseGenerator's `add` and `tags` config options to work with `jkube.generator.*` properties
+* Fix #1512: Gradle plugins are graduated
 
 ### 1.7.0 (2022-02-25)
 * Fix #1315: Pod Log Service works for Jobs with no selector

--- a/gradle-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
@@ -2,8 +2,6 @@
 [[introduction]]
 = Introduction
 
-IMPORTANT: *This is a preview feature to get early feedback.  Only the set of documented features are available to users.*
-
 The *{plugin}* brings your Gradle Java applications on to
 ifeval::["{task-prefix}" == "k8s"]
 http://kubernetes.io/[Kubernetes].


### PR DESCRIPTION
## Description

fix #1512: gradle plugins are graduated

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->