### PR TITLE
ui : Remove redundant log messages for plugin modes (#1279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.9.0-SNAPSHOT
+* Fix #1279: Remove redundant log messages regarding plugin modes
 
 
 ### 1.8.0 (2022-05-24)

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/AutoTLSIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/AutoTLSIT.java
@@ -35,7 +35,6 @@ public class AutoTLSIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ConfigMapIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ConfigMapIT.java
@@ -37,7 +37,6 @@ public class ConfigMapIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Running generator spring-boot")
         .contains("jkube-controller: Adding a default Deployment")
         .contains("jkube-service: Adding a default service")
@@ -57,7 +56,6 @@ public class ConfigMapIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Running generator spring-boot")
         .contains("jkube-controller: Adding a default Deployment")
         .contains("jkube-service: Adding a default service")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DebugModeIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DebugModeIT.java
@@ -35,7 +35,6 @@ public class DebugModeIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
@@ -51,7 +50,6 @@ public class DebugModeIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DefaultControllerIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DefaultControllerIT.java
@@ -37,7 +37,6 @@ public class DefaultControllerIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "default", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
@@ -54,7 +53,6 @@ public class DefaultControllerIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "default", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DefaultMetadataIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DefaultMetadataIT.java
@@ -35,7 +35,6 @@ public class DefaultMetadataIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
@@ -53,7 +52,6 @@ public class DefaultMetadataIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes-replicaset-controller.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default ReplicaSet")
         .contains("Adding revision history limit to 2")
@@ -69,7 +67,6 @@ public class DefaultMetadataIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DependencyResourcesIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DependencyResourcesIT.java
@@ -40,7 +40,6 @@ public class DependencyResourcesIT {
             "META-INF", "jkube", "kubernetes.yml"),
         gradleRunner.resolveFile("expected", "kubernetes-defaults.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
         .contains("validating");
@@ -58,7 +57,6 @@ public class DependencyResourcesIT {
             "META-INF", "jkube", "kubernetes.yml"),
         gradleRunner.resolveFile("expected", "kubernetes-with-replica-override.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
         .contains("validating");

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DockerfileSimpleIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DockerfileSimpleIT.java
@@ -36,7 +36,6 @@ public class DockerfileSimpleIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-      .contains("Running in Kubernetes mode")
       .contains("Using resource templates from")
       .contains("Adding a default Deployment")
       .contains("Adding revision history limit to 2")
@@ -52,7 +51,6 @@ public class DockerfileSimpleIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
       gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-      .contains("Running in OpenShift mode")
       .contains("Using resource templates from")
       .contains("Adding a default Deployment")
       .contains("Converting Deployment to DeploymentConfig")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/FileSecretIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/FileSecretIT.java
@@ -35,7 +35,6 @@ public class FileSecretIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
         .contains("validating");
@@ -49,7 +48,6 @@ public class FileSecretIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
         .contains("validating");

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/GitAnnotationsIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/GitAnnotationsIT.java
@@ -35,7 +35,6 @@ public class GitAnnotationsIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
@@ -50,7 +49,6 @@ public class GitAnnotationsIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/GroovyDSLImageIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/GroovyDSLImageIT.java
@@ -35,7 +35,6 @@ public class GroovyDSLImageIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-      .contains("Running in Kubernetes mode")
       .contains("Using resource templates from")
       .contains("Adding a default Deployment")
       .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ImageChangeTriggerIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ImageChangeTriggerIT.java
@@ -37,7 +37,6 @@ public class ImageChangeTriggerIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/IngressIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/IngressIT.java
@@ -73,7 +73,6 @@ public class IngressIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", profileName, "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/JavaOptionsEnvMergeIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/JavaOptionsEnvMergeIT.java
@@ -35,7 +35,6 @@ public class JavaOptionsEnvMergeIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
@@ -50,7 +49,6 @@ public class JavaOptionsEnvMergeIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/KubernetesConfiguredControllerIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/KubernetesConfiguredControllerIT.java
@@ -58,7 +58,6 @@ public class KubernetesConfiguredControllerIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", controllerType.toLowerCase(Locale.ROOT), "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default " + controllerType)
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/MultiEnvironmentsIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/MultiEnvironmentsIT.java
@@ -52,26 +52,22 @@ public class MultiEnvironmentsIT {
   @Test
   public void k8sResource_whenRun_generatesK8sManifestsContainingConfigMap() throws IOException, ParseException {
     // When
-    final BuildResult result = gradleRunner.withITProject("multi-environments")
+    gradleRunner.withITProject("multi-environments")
         .withArguments("build", "-Pjkube.environment=" + environment, "k8sResource", "--stacktrace")
         .build();
     // Then
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", expectedDirectory, "kubernetes.yml"));
-    assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode");
   }
 
   @Test
   public void ocResource_whenRun_generatesOpenShiftManifestsContainingConfigMap() throws IOException, ParseException {
     // When
-    final BuildResult result = gradleRunner.withITProject("multi-environments")
+    gradleRunner.withITProject("multi-environments")
         .withArguments("build", "-Pjkube.environment=" + environment, "ocResource", "--stacktrace")
         .build();
     // Then
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", expectedDirectory, "openshift.yml"));
-    assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/NameIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/NameIT.java
@@ -56,7 +56,6 @@ public class NameIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", expectedDir, "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
@@ -73,7 +72,6 @@ public class NameIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", expectedDir, "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/NamespaceIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/NamespaceIT.java
@@ -65,7 +65,6 @@ public class NamespaceIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", expectedDirectory, "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
         .contains("validating");
@@ -83,7 +82,6 @@ public class NamespaceIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", expectedDirectory, "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
         .contains("validating");

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/OpenShiftConfiguredControllerIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/OpenShiftConfiguredControllerIT.java
@@ -58,7 +58,6 @@ public class OpenShiftConfiguredControllerIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", controllerType.toLowerCase(Locale.ROOT), "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default " + controllerType)
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProbesGroovyDSLIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProbesGroovyDSLIT.java
@@ -54,7 +54,6 @@ public class ProbesGroovyDSLIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", probeConfigMode, "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Running generator spring-boot")
         .contains("jkube-controller: Adding a default Deployment")
         .contains("jkube-service: Adding a default service")
@@ -72,7 +71,6 @@ public class ProbesGroovyDSLIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", probeConfigMode, "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Running generator spring-boot")
         .contains("jkube-controller: Adding a default Deployment")
         .contains("jkube-service: Adding a default service")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProjectLabelIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProjectLabelIT.java
@@ -64,7 +64,6 @@ public class ProjectLabelIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", expectedDir, "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
@@ -84,7 +83,6 @@ public class ProjectLabelIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", expectedDir, "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/RevisionHistoryIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/RevisionHistoryIT.java
@@ -61,7 +61,6 @@ public class RevisionHistoryIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", expectedDir, "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to ")
@@ -81,7 +80,6 @@ public class RevisionHistoryIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", expectedDir, "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to ")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/RouteIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/RouteIT.java
@@ -59,7 +59,6 @@ public class RouteIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", expectedDir, "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to ")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceAccountIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceAccountIT.java
@@ -52,7 +52,6 @@ public class ServiceAccountIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
         .contains("validating");
@@ -66,7 +65,6 @@ public class ServiceAccountIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Converting Deployment to DeploymentConfig")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceIT.java
@@ -37,7 +37,6 @@ public class ServiceIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
@@ -54,7 +53,6 @@ public class ServiceIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootIT.java
@@ -38,7 +38,6 @@ public class SpringBootIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Running generator spring-boot")
         .contains("jkube-controller: Adding a default Deployment")
         .contains("jkube-service: Adding a default service")
@@ -58,7 +57,6 @@ public class SpringBootIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Running generator spring-boot")
         .contains("jkube-controller: Adding a default Deployment")
         .contains("jkube-service: Adding a default service")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootWithFragmentIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootWithFragmentIT.java
@@ -37,7 +37,6 @@ public class SpringBootWithFragmentIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Running generator spring-boot")
         .contains("jkube-service: Adding a default service")
         .contains("jkube-healthcheck-spring-boot: Adding readiness probe on port 8080")
@@ -56,7 +55,6 @@ public class SpringBootWithFragmentIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Running generator spring-boot")
         .contains("jkube-service: Adding a default service")
         .contains("jkube-openshift-deploymentconfig: Converting Deployment to DeploymentConfig")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/TriggersAnnotationIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/TriggersAnnotationIT.java
@@ -37,7 +37,6 @@ public class TriggersAnnotationIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding a default ReplicaSet")
         .contains("Adding revision history limit to 2")
@@ -54,7 +53,6 @@ public class TriggersAnnotationIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding a default ReplicaSet")
         .contains("Adding revision history limit to 2")

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/VolumePermissionIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/VolumePermissionIT.java
@@ -57,7 +57,6 @@ public class VolumePermissionIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
         gradleRunner.resolveFile("expected", expectedDirectory, "kubernetes.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in Kubernetes mode")
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
         .contains("validating");
@@ -74,7 +73,6 @@ public class VolumePermissionIT {
     ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
         gradleRunner.resolveFile("expected", expectedDirectory, "openshift.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
-        .contains("Running in OpenShift mode")
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
         .contains("validating");

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -114,7 +114,6 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
   }
 
   private List<ImageConfiguration> customizeConfig(List<ImageConfiguration> configs) {
-    kitLogger.info("Running in [[B]]%s[[B]] mode", kubernetesExtension.getRuntimeMode().getLabel());
     return GeneratorManager.generate(configs, initGeneratorContextBuilder().build(), false);
   }
 

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTaskTest.java
@@ -55,7 +55,6 @@ public class KubernetesLogTaskTest {
     kubernetesLogTask.runTask();
 
     // Then
-    verify(taskEnvironment.logger).lifecycle("k8s: Running in Kubernetes mode");
     verify(taskEnvironment.logger).warn("k8s: No selector detected and no Pod name specified, cannot watch Pods!");
   }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -664,7 +664,6 @@ public abstract class AbstractDockerMojo extends AbstractMojo
      * @return the configuration customized by our generators.
      */
     public List<ImageConfiguration> customizeConfig(List<ImageConfiguration> configs) {
-        log.info("Running in [[B]]%s[[B]] mode", runtimeMode.getLabel());
         if (runtimeMode != RuntimeMode.OPENSHIFT) {
             log.info("Building Docker image in [[B]]Kubernetes[[B]] mode");
         }

--- a/quickstarts/gradle/docker-file-simple/README.md
+++ b/quickstarts/gradle/docker-file-simple/README.md
@@ -18,7 +18,6 @@ docker-file-simple : $ gradle build k8sBUild
 
 > Task :k8sBuild
 k8s: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc: Name or service not known
-k8s: Running in Kubernetes mode
 k8s: Building Docker image in Kubernetes mode
 k8s: Pulling from jkube/jkube-java-binary-s2i
 k8s: Digest: sha256:dd5c9f44a86e19438662d293e180acc8d864887cf19c165c1b24ae703b16c2d4

--- a/quickstarts/gradle/quarkus/README.md
+++ b/quickstarts/gradle/quarkus/README.md
@@ -21,7 +21,6 @@ Generate the cluster manifests by executing the following command:
 $ ./gradlew build k8sResource
 
 > Task :k8sResource
-k8s: Running in Kubernetes mode
 k8s: Running generator quarkus
 k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
 k8s: Using resource templates from /home/anurag/Work/jkube/quickstarts/gradle/quarkus/src/main/jkube
@@ -41,7 +40,6 @@ Start docker build  by hitting the build task.
 $ ./gradlew k8sBuild
 
 > Task :k8sBuild
-k8s: Running in Kubernetes mode
 k8s: Running generator quarkus
 k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
 k8s: Building container image in Kubernetes mode
@@ -59,7 +57,6 @@ Deploy your application on Kubernetes cluster.
 $ ./gradlew k8sApply
 
 > Task :k8sApply
-k8s: Running in Kubernetes mode
 k8s: Running generator quarkus7s]
 k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
 k8s: Using Kubernetes at https://192.168.49.2:8443/ in namespace null with manifest /home/anurag/Work/jkube/quickstarts/gradle/quarkus/build/classes/java/main/META-INF/jkube/kubernetes.yml k8sApply

--- a/quickstarts/gradle/webapp-custom/README.md
+++ b/quickstarts/gradle/webapp-custom/README.md
@@ -22,7 +22,6 @@ You will need the following to run it with Minikube:
 $ ./gradlew build k8sBuild
 
 > Task :k8sBuild
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using tomcat:jdk11-openjdk-slim as base image for webapp
 k8s: Building container image in Kubernetes mode
@@ -42,7 +41,6 @@ kubernetes/webapp-custom                                latest               7d4
 ```
 $ ./gradlew k8sResource -Djkube.createExternalUrls=true -Djkube.domain=$(minikube ip).nip.io
 > Task :k8sResource
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using tomcat:jdk11-openjdk-slim as base image for webapp
 k8s: Using resource templates from /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp-custom/src/main/jkube
@@ -72,7 +70,6 @@ webapp-custom-deployment.yml  webapp-custom-ingress.yml  webapp-custom-service.y
 ./gradlew k8sApply
 
 > Task :k8sApply
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using tomcat:jdk11-openjdk-slim as base image for webapp
 k8s: Using Kubernetes at https://192.168.99.113:8443/ in namespace null with manifest /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp-custom/build/classes/java/main/META-INF/jkube/kubernetes.yml 

--- a/quickstarts/gradle/webapp-jetty/README.md
+++ b/quickstarts/gradle/webapp-jetty/README.md
@@ -24,7 +24,6 @@ You will need the following to run it with Minikube:
 $ ./gradlew build k8sBuild
 
 > Task :k8sBuild
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp [6s]
 k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.13 as base image for webapp
 k8s: Building container image in Kubernetes mode
@@ -48,7 +47,6 @@ kubernetes/webapp-jetty                                 latest     d0d528ec103e 
 ```
 $ ./gradlew k8sResource -Djkube.domain=$(minikube ip).nip.io
 > Task :k8sResource
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.13 as base image for webapp
 k8s: Using resource templates from /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp-jetty/src/main/jkube
@@ -78,7 +76,6 @@ webapp-jetty-deployment.yml  webapp-jetty-ingress.yml  webapp-jetty-service.yml
 ./gradlew k8sApply
 
 > Task :k8sApply
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.13 as base image for webapp
 k8s: Using Kubernetes at https://192.168.99.120:8443/ in namespace null with manifest /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp-jetty/build/classes/java/main/META-INF/jkube/kubernetes.yml 

--- a/quickstarts/gradle/webapp-wildfly/README.md
+++ b/quickstarts/gradle/webapp-wildfly/README.md
@@ -27,7 +27,6 @@ You will need the following to run it with Minikube:
 $ ./gradlew build k8sBuild
 
 > Task :k8sBuild
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using jboss/wildfly:25.0.0.Final as base image for webapp
 k8s: Building container image in Kubernetes mode
@@ -51,7 +50,6 @@ kubernetes/webapp-wildfly                               latest         622fa19f8
 ```
 $ ./gradlew k8sResource -Djkube.domain=$(minikube ip).nip.io
 > Task :k8sResource
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using jboss/wildfly:25.0.0.Final as base image for webapp
 k8s: Using resource templates from /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp-wildfly/src/main/jkube
@@ -82,7 +80,6 @@ webapp-wildfly-deployment.yml  webapp-wildfly-ingress.yml  webapp-wildfly-servic
 ./gradlew k8sApply
 
 > Task :k8sApply
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using jboss/wildfly:25.0.0.Final as base image for webapp
 k8s: Using Kubernetes at https://192.168.99.110:8443/ in namespace null with manifest /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp-wildfly/build/classes/java/main/META-INF/jkube/kubernetes.yml 

--- a/quickstarts/gradle/webapp/README.md
+++ b/quickstarts/gradle/webapp/README.md
@@ -22,7 +22,6 @@ You will need the following to run it with Minikube:
 $ ./gradlew build k8sBuild
 
 > Task :k8sBuild
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using quay.io/jkube/jkube-tomcat9:0.0.13 as base image for webapp
 k8s: Building container image in Kubernetes mode
@@ -58,7 +57,6 @@ Run
 $ ./gradlew build k8sBuild
 
 > Task :k8sBuild
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.13 as base image for webapp
 k8s: Building container image in Kubernetes mode
@@ -77,7 +75,6 @@ It is now using `quay.io/jkube/jkube-jetty9:0.0.13` as base image!
 ```
 $ ./gradlew k8sResource -Djkube.domain=$(minikube ip).nip.io
 > Task :k8sResource
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.13 as base image for webapp
 k8s: Using resource templates from /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp/src/main/jkube
@@ -107,7 +104,6 @@ webapp-deployment.yml  webapp-ingress.yml  webapp-service.yml
 ./gradlew k8sApply
 
 > Task :k8sApply
-k8s: Running in Kubernetes mode
 k8s: Running generator webapp
 k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.13 as base image for webapp
 k8s: Using Kubernetes at https://192.168.99.115:8443/ in namespace null with manifest /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp/build/classes/java/main/META-INF/jkube/kubernetes.yml 

--- a/quickstarts/kit/custom-foo-generator/app/README.md
+++ b/quickstarts/kit/custom-foo-generator/app/README.md
@@ -41,7 +41,6 @@ If you'll run `gradle k8sBuild`, you'll see generator kicks in during the build:
 ```
 $ gradle k8sBuild
 > Task :k8sBuild
-k8s: Running in Kubernetes mode
 k8s: Running generator foo
 k8s: Add Environment variable to ImageConfigurations
 

--- a/quickstarts/kit/custom-istio-enricher-gradle/README.md
+++ b/quickstarts/kit/custom-istio-enricher-gradle/README.md
@@ -29,7 +29,6 @@ Once the project is built, you can generate the cluster manifests by executing t
 If everything is successful, you should see the following output:
 ```
 > Task :app:k8sResource
-k8s: Running in Kubernetes mode
 k8s: istio-enricher: Added dummy networking.istio.io/v1alpha3 Gateway
 k8s: istio-enricher: Exiting Istio Enricher
 k8s: compile-time-enricher: This is the compile-time-enricher running

--- a/quickstarts/maven/docker-file-simple/README.md
+++ b/quickstarts/maven/docker-file-simple/README.md
@@ -29,7 +29,6 @@ $ mvn package k8s:build
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:build (default-cli) @ docker-file-simple ---
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: [jkube/docker-file-simple:latest]: Created docker-build.tar in 261 milliseconds
 [INFO] k8s: [jkube/docker-file-simple:latest]: Built image sha256:52d46

--- a/quickstarts/maven/hello-world/README.md
+++ b/quickstarts/maven/hello-world/README.md
@@ -56,7 +56,6 @@ Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
 [INFO] Installing /home/rohaan/work/repos/jkube/quickstarts/maven/hello-world/pom.xml to /home/rohaan/.m2/repository/org/eclipse/jkube/samples/jkube-sample-helloworld/0.1.1-SNAPSHOT/jkube-sample-helloworld-0.1.1-SNAPSHOT.pom
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:0.1.1-SNAPSHOT:build (default-cli) @ jkube-sample-helloworld ---
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: [helloworld-java:0.1.1-SNAPSHOT] "hello-world": Created docker-build.tar in 34 milliseconds
 [INFO] k8s: [helloworld-java:0.1.1-SNAPSHOT] "hello-world": Built image sha256:9baee

--- a/quickstarts/maven/ibm-javaee8-webprofile-liberty/README.md
+++ b/quickstarts/maven/ibm-javaee8-webprofile-liberty/README.md
@@ -99,7 +99,6 @@ $ mvn -P'integration-tests' clean verify -DtestProxyHost=$(minikube ip)
 [INFO] Building war: /home/user/00-MN/projects/forks/jkube/quickstarts/maven/ibm-javaee8-webprofile-liberty/javaee8-webprofile-liberty-app/target/javaee8-webprofile-liberty-app.war
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:build (build-images) @ javaee8-webprofile-liberty-app ---
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: [jkube/javaee8-webprofile-liberty-app:1.0.0-SNAPSHOT] "meeting-reservation-service": Created docker-build.tar in 57 milliseconds
 [INFO] k8s: [jkube/javaee8-webprofile-liberty-app:1.0.0-SNAPSHOT] "meeting-reservation-service": Built image sha256:b53cf
@@ -141,7 +140,6 @@ $ mvn -P'integration-tests' clean verify -DtestProxyHost=$(minikube ip)
 [INFO] Building jar: /home/user/00-MN/projects/forks/jkube/quickstarts/maven/ibm-javaee8-webprofile-liberty/javaee8-webprofile-liberty-app-it/target/javaee8-webprofile-liberty-app-it-1.0.0-SNAPSHOT.jar
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:build (build-images) @ javaee8-webprofile-liberty-app-it ---
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:apply (integration-test) @ javaee8-webprofile-liberty-app-it ---

--- a/quickstarts/maven/quarkus-customized-image/README.md
+++ b/quickstarts/maven/quarkus-customized-image/README.md
@@ -60,7 +60,6 @@ $ mvn clean package oc:build oc:resource oc:apply
 [INFO] 
 [INFO] --- openshift-maven-plugin:1.0.0-SNAPSHOT:build (default-cli) @ quarkus-customized-image ---
 [INFO] oc: Using OpenShift build with strategy S2I
-[INFO] oc: Running in OpenShift mode
 [INFO] oc: [org.eclipse.jkube.quickstarts.maven/quarkus-customized-image:latest]: Created docker source tar /home/user/00-MN/projects/forks/jkube/quickstarts/maven/quarkus-customized-image/target/docker/org.eclipse.jkube.quickstarts.maven/quarkus-customized-image/tmp/docker-build.tar
 [INFO] oc: Adding to Secret 12819530-ocp42-exposed-env-pull-secret-pull-secret
 [INFO] oc: Using Secret 12819530-ocp42-exposed-env-pull-secret-pull-secret

--- a/quickstarts/maven/quarkus/README.md
+++ b/quickstarts/maven/quarkus/README.md
@@ -29,7 +29,6 @@ $ mvn package k8s:build
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.3.0:build (default-cli) @ quarkus ---
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator quarkus
 [INFO] k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder

--- a/quickstarts/maven/spring-boot-with-jib/README.md
+++ b/quickstarts/maven/spring-boot-with-jib/README.md
@@ -32,7 +32,6 @@ To build project issue this command:
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:build (default-cli) @ eclipse-jkube-sample-spring-boot-jib ---
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator spring-boot
 [INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
@@ -86,7 +85,6 @@ Once we add this property we need to do `mvn k8s:build -PJib-Zero-Config` again 
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:build (default-cli) @ eclipse-jkube-sample-spring-boot-jib ---
 [WARNING] k8s: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc: Name or service not known
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator spring-boot
 [INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
@@ -122,7 +120,6 @@ JIB> [==============================] 100.0% complete
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:push (default-cli) @ eclipse-jkube-sample-spring-boot-jib ---
 [WARNING] k8s: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc: Name or service not known
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator spring-boot
 [INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
@@ -258,7 +255,6 @@ Now to build you need to issue same build goal but with different profile, build
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:build (default-cli) @ eclipse-jkube-sample-spring-boot-jib ---
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: JIB image build started
 JIB> Base image 'fabric8/java-centos-openjdk8-jdk:1.5.6' does not use a specific image digest - build may not be reproducible
@@ -306,7 +302,6 @@ Pushing image to docker hub in this case, you can provide registry credentials i
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:push (default-cli) @ eclipse-jkube-sample-spring-boot-jib ---
-[INFO] k8s: Running in Kubernetes mode
 JIB> Containerizing application with the following files:                                                                    
 JIB> Retrieving registry credentials for registry-1.docker.io...                                                             
 JIB> Container program arguments set to [java, -jar, /deployments/eclipse-jkube-sample-spring-boot-jib-1.0.0-SNAPSHOT.jar] (inherited from base image)

--- a/quickstarts/maven/webapp-wildfly-datasource/README.md
+++ b/quickstarts/maven/webapp-wildfly-datasource/README.md
@@ -59,7 +59,6 @@ WARNING: All illegal access operations will be denied in a future release
 [INFO] Building war: /home/sunix/github/eclipse/jkube/quickstarts/maven/webapp-wildfly-2/target/webapp-wildfly-datasource.war
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.6.0:build (default-cli) @ webapp-wildfly-datasource ---
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator webapp
 [INFO] k8s: webapp: Using jboss/wildfly:25.0.0.Final as base image for webapp

--- a/quickstarts/maven/webapp-wildfly/README.md
+++ b/quickstarts/maven/webapp-wildfly/README.md
@@ -10,7 +10,6 @@
 [INFO] --------------------------------[ war ]---------------------------------
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:build (default-cli) @ jkube-maven-sample-webapp-wildfly ---
-[INFO] k8s: Running in Kubernetes mode
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator webapp
 [INFO] k8s: webapp: Using jboss/wildfly:25.0.0.Final as base image for webapp


### PR DESCRIPTION

## Description
Fix #1279

Remove log messages `Running in Kubernetes mode` which is redundant now
that we've separate plugins for Kubernetes and OpenShift.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->