### PR TITLE
fix (jkube-kit/enricher) : Configure surefire to run tests in english locale (#1469)

### DIFF
--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -874,6 +874,9 @@
             <argLine>
               -javaagent:"${settings.localRepository}/org/jmockit/jmockit/${version.jmockit}/jmockit-${version.jmockit}.jar"
             </argLine>
+            <environmentVariables>
+              <LC_ALL>en_EN.UTF-8</LC_ALL>
+           </environmentVariables>
           </configuration>
           <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,9 @@
                 <!-- JaCoCo runtime must know where to dump coverage: -->
                 <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
               </systemPropertyVariables>
+              <environmentVariables>
+                <LC_ALL>en_EN.UTF-8</LC_ALL>
+              </environmentVariables>
             </configuration>
           </plugin>
 


### PR DESCRIPTION
## Description

Fix #1469

KubernetesResourceUtilTest seems to be failing on non-english locale
systems due to an assertion which is verifying exception message in
english. This causes problems on systems where language is other than
english like in case of #1469

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have implemented unit tests to cover my changes
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->