### PR TITLE
refactor (jkube-kit) : Move `QuarkusUtils.isVersionAtLeast` to jkube-kit/common

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/SemanticVersionUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/SemanticVersionUtil.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class SemanticVersionUtil {
+  private SemanticVersionUtil() { }
+
+  public static boolean isVersionAtLeast(int majorVersion, int minorVersion, String version) {
+    if (StringUtils.isNotBlank(version) && version.contains(".")) {
+      final String[] versionParts = version.split("\\.");
+      final int parsedMajorVersion = parseInt(versionParts[0]);
+      if (parsedMajorVersion > majorVersion) {
+        return true;
+      } else if (parsedMajorVersion == majorVersion) {
+        return parseInt(versionParts[1]) >= minorVersion;
+      }
+    }
+    return false;
+  }
+
+  private static int parseInt(String toParse) {
+    try {
+      return Integer.parseInt(toParse);
+    } catch (NumberFormatException ex) {
+      return -1;
+    }
+  }
+}

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/SemanticVersionUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/SemanticVersionUtilTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.eclipse.jkube.kit.common.util.SemanticVersionUtil.isVersionAtLeast;
+
+public class SemanticVersionUtilTest {
+  @Test
+  public void isVersionAtLeast_withLargerMajorVersion_shouldBeFalse() {
+    assertThat(isVersionAtLeast(2, 1, "1.13.7.Final")).isFalse();
+  }
+
+  @Test
+  public void isVersionAtLeast_withSameMajorAndLargerMinorVersion_shouldBeFalse() {
+    assertThat(isVersionAtLeast(1, 14, "1.13.7.Final")).isFalse();
+  }
+
+  @Test
+  public void isVersionAtLeast_withSameMajorAndMinorVersion_shouldBeTrue() {
+    assertThat(isVersionAtLeast(1, 13, "1.13.7.Final")).isTrue();
+  }
+
+  @Test
+  public void isVersionAtLeast_withSameMajorAndSmallerMinorVersion_shouldBeTrue() {
+    assertThat(isVersionAtLeast(1, 12, "1.13.7.Final")).isTrue();
+  }
+
+  @Test
+  public void isVersionAtLeast_withSmallerMajorMinorVersion_shouldBeTrue() {
+    assertThat(isVersionAtLeast(0, 12, "1.13.7.Final")).isTrue();
+  }
+
+  @Test
+  public void isVersionAtLeast_withSmallerMajorAndIncompleteVersion_shouldBeTrue() {
+    assertThat(isVersionAtLeast(0, 12, "1.Final")).isTrue();
+  }
+
+}

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/QuarkusUtils.java
@@ -30,6 +30,7 @@ import static org.eclipse.jkube.kit.common.util.FileUtil.stripPrefix;
 import static org.eclipse.jkube.kit.common.util.JKubeProjectUtil.getClassLoader;
 import static org.eclipse.jkube.kit.common.util.PropertiesUtil.getPropertiesFromResource;
 import static org.eclipse.jkube.kit.common.util.PropertiesUtil.toMap;
+import static org.eclipse.jkube.kit.common.util.SemanticVersionUtil.isVersionAtLeast;
 import static org.eclipse.jkube.kit.common.util.YamlUtil.getPropertiesFromYamlResource;
 
 public class QuarkusUtils {
@@ -206,27 +207,6 @@ public class QuarkusUtils {
   static String findQuarkusVersion(JavaProject javaProject) {
     return Optional.ofNullable(JKubeProjectUtil.getAnyDependencyVersionWithGroupId(javaProject, QUARKUS_GROUP_ID))
         .orElse(null);
-  }
-
-  static boolean isVersionAtLeast(int majorVersion, int minorVersion, String version) {
-    if (StringUtils.isNotBlank(version) && version.contains(".")) {
-      final String[] versionParts = version.split("\\.");
-      final int parsedMajorVersion = parseInt(versionParts[0]);
-      if (parsedMajorVersion > majorVersion) {
-        return true;
-      } else if (parsedMajorVersion == majorVersion) {
-        return parseInt(versionParts[1]) >= minorVersion;
-      }
-    }
-    return false;
-  }
-
-  private static int parseInt(String toParse) {
-    try {
-      return Integer.parseInt(toParse);
-    } catch (NumberFormatException ex) {
-      return -1;
-    }
   }
 
   private static boolean isAbsolutePath(String path) {

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/QuarkusUtilsTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/QuarkusUtilsTest.java
@@ -33,7 +33,6 @@ import static org.eclipse.jkube.quarkus.QuarkusUtils.concatPath;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.extractPort;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.findQuarkusVersion;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusConfiguration;
-import static org.eclipse.jkube.quarkus.QuarkusUtils.isVersionAtLeast;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.resolveCompleteQuarkusHealthRootPath;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.resolveQuarkusLivenessPath;
 
@@ -281,36 +280,6 @@ public class QuarkusUtilsTest {
 
     // Then
     assertThat(resolvedHealthPath).isNotEmpty().isEqualTo("liveness");
-  }
-
-  @Test
-  public void isVersionAtLeast_withLargerMajorVersion_shouldBeFalse() {
-    assertThat(isVersionAtLeast(2, 1, "1.13.7.Final")).isFalse();
-  }
-
-  @Test
-  public void isVersionAtLeast_withSameMajorAndLargerMinorVersion_shouldBeFalse() {
-    assertThat(isVersionAtLeast(1, 14, "1.13.7.Final")).isFalse();
-  }
-
-  @Test
-  public void isVersionAtLeast_withSameMajorAndMinorVersion_shouldBeTrue() {
-    assertThat(isVersionAtLeast(1, 13, "1.13.7.Final")).isTrue();
-  }
-
-  @Test
-  public void isVersionAtLeast_withSameMajorAndSmallerMinorVersion_shouldBeTrue() {
-    assertThat(isVersionAtLeast(1, 12, "1.13.7.Final")).isTrue();
-  }
-
-  @Test
-  public void isVersionAtLeast_withSmallerMajorMinorVersion_shouldBeTrue() {
-    assertThat(isVersionAtLeast(0, 12, "1.13.7.Final")).isTrue();
-  }
-
-  @Test
-  public void isVersionAtLeast_withSmallerMajorAndIncompleteVersion_shouldBeTrue() {
-    assertThat(isVersionAtLeast(0, 12, "1.Final")).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Description

`QuarkusUtils.isVersionAtLeast` seems to be generic semantic version
utility which can be used to check whether given framework's version is more than
a given version.

Once this gets merged, we can use this method in #1541 and #1492

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

Related to #1473 


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
