### PR TITLE
deps: bump/refactor Citrus from 2.6.2 to 3.2.1

### DIFF
--- a/gradle-plugin/it/pom.xml
+++ b/gradle-plugin/it/pom.xml
@@ -30,6 +30,8 @@
 
     <properties>
         <jkube.kit.version>${project.version}</jkube.kit.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -53,7 +55,12 @@
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
-        <artifactId>citrus-core</artifactId>
+        <artifactId>citrus-validation-json</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-validation-hamcrest</artifactId>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -36,7 +36,6 @@
   <modules>
     <module>kubernetes</module>
     <module>openshift</module>
-    <module>it</module>
     <module>doc</module>
   </modules>
 
@@ -175,4 +174,15 @@
     </pluginManagement>
   </build>
 
+  <profiles>
+    <profile>
+      <id>java-11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <modules>
+        <module>it</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/jkube-kit/common-test/pom.xml
+++ b/jkube-kit/common-test/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-validation-json</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/jkube-kit/common-test/src/main/java/org/springframework/beans/factory/NoSuchBeanDefinitionException.java
+++ b/jkube-kit/common-test/src/main/java/org/springframework/beans/factory/NoSuchBeanDefinitionException.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.springframework.beans.factory;
+
+// TODO: required by citrus, manually added to avoid a java.lang.NoClassDefFoundError
+//       without the need to depend on Spring
+public class NoSuchBeanDefinitionException extends RuntimeException {
+}

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -47,7 +47,6 @@
     <version.javassist>3.20.0-GA</version.javassist>
     <version.jgit>6.2.0.202206071550-r</version.jgit>
     <version.jnr-unixsocket>0.38.17</version.jnr-unixsocket>
-    <version.json-smart>2.2.1</version.json-smart> <!-- Transitive dependency from com.consol.citrus:citrus-core -->
     <version.jsr305>3.0.2</version.jsr305>
     <version.JUnitParams>1.1.1</version.JUnitParams>
     <version.kubernetes-client>5.11.2</version.kubernetes-client>
@@ -310,44 +309,17 @@
       <!-- == libs ====================================== -->
       <dependency>
         <groupId>com.consol.citrus</groupId>
-        <artifactId>citrus-core</artifactId>
-        <version>${version.citrus-core}</version>
+        <artifactId>citrus-validation-json</artifactId>
+        <version>${version.citrus}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-validation-hamcrest</artifactId>
+        <version>${version.citrus}</version>
         <exclusions>
           <exclusion>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-xml</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-json</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-jsr223</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework.retry</groupId>
-            <artifactId>spring-retry</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework.ws</groupId>
-            <artifactId>spring-xml</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>xerces</groupId>
-            <artifactId>xercesImpl</artifactId>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/kubernetes-maven-plugin/it/pom.xml
+++ b/kubernetes-maven-plugin/it/pom.xml
@@ -40,8 +40,8 @@ for running a single test with mvnDebug.
 
   <properties>
     <jkube.version>${project.version}</jkube.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -55,7 +55,7 @@ for running a single test with mvnDebug.
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-validation-json</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kubernetes-maven-plugin/pom.xml
+++ b/kubernetes-maven-plugin/pom.xml
@@ -35,7 +35,6 @@
 
   <modules>
     <module>plugin</module>
-    <module>it</module>
     <module>doc</module>
   </modules>
 
@@ -114,5 +113,17 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <id>java-11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <modules>
+        <module>it</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>

--- a/openshift-maven-plugin/it/pom.xml
+++ b/openshift-maven-plugin/it/pom.xml
@@ -37,8 +37,8 @@ for running a single test.
 
   <properties>
     <jkube.version>${project.version}</jkube.version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -52,7 +52,7 @@ for running a single test.
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-validation-json</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/openshift-maven-plugin/pom.xml
+++ b/openshift-maven-plugin/pom.xml
@@ -35,7 +35,6 @@
 
   <modules>
     <module>plugin</module>
-    <module>it</module>
   </modules>
 
   <dependencyManagement>
@@ -114,4 +113,15 @@
     </pluginManagement>
   </build>
 
+  <profiles>
+    <profile>
+      <id>java-11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <modules>
+        <module>it</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.asciidoctor-maven-plugin>2.2.1</version.asciidoctor-maven-plugin>
     <version.asciidoctorj>2.2.0</version.asciidoctorj>
-    <version.citrus-core>2.6.2</version.citrus-core>
+    <version.citrus>3.2.1</version.citrus>
     <version.commons-io>2.8.0</version.commons-io>
     <version.gradle>6.1.1</version.gradle>
     <version.groovy>2.4.7</version.groovy>
@@ -92,6 +92,7 @@
     <version.jackson>2.12.4</version.jackson>
     <version.jacoco>0.8.8</version.jacoco>
     <version.jmockit>1.49</version.jmockit>
+    <version.json-smart>2.4.8</version.json-smart> <!-- Transitive dependency  required by citrus -->
     <version.junit5>5.8.2</version.junit5>
     <version.junit>4.13.2</version.junit>
     <version.assertj-core>3.18.0</version.assertj-core>


### PR DESCRIPTION
## Description

Replaced citrus-core module with the more specific `citrus-validation-json` and `citrus-validation-hamcrest`, and bumped to version 3.2.1.

Bumped transitive dependency json-smart from 2.2.1 to 2.4.8 which fixes a critical vulnerability.

n.b. Citrus 3 requires Java 11, I modified the IT modules so that they run only if there's a valid JDK 11 (should be no problem because all of our test pipelines are running on Java 11).


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
