### PR TITLE
fix (jkube-kit) : JKubeTarArchiver should always set set TarEntry size to zero for directories (#777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.9.0-SNAPSHOT
+* Fix #777: `k8s:build` with Dockerfile throws `Connection reset by peer` error on old docker daemons
 * Fix #1279: Remove redundant log messages regarding plugin modes
 * Fix #1438: Add configuration option in ServiceAccountEnricher to skip creating ServiceAccounts
 * Fix #1468: Add startup probe in QuarkusHealthCheckEnricher

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiver.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiver.java
@@ -80,8 +80,10 @@ public class JKubeTarArchiver {
         if (fileModeMap.containsKey(currentFile)) {
           tarEntry.setMode(Integer.parseInt(fileModeMap.get(currentFile), 8));
         } else if (currentFile.isDirectory()) {
-          tarEntry.setSize(0L);
           tarEntry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
+        }
+        if (currentFile.isDirectory()) {
+          tarEntry.setSize(0L);
         }
         Optional.ofNullable(tarArchiveEntryCustomizer).ifPresent(tac -> tac.accept(tarEntry));
         tarArchiveOutputStream.putArchiveEntry(tarEntry);


### PR DESCRIPTION
## Description
Fix #777

While fixing tarball issue in #793, we had added this
`tarEntry.setSize(0L)` in JKubeTarArchiver to fix tarball compatibility
with old docker daemons. However, it is set only when the file is not
present in `fileModeMap`.

In case of Dockerfile based builds, `fileModeMap` seems to contain file
modes for different files and directories. Hence, we're not able to set
TarEntry size to zero.

Move `tarEntry.setSize(0L)` out of fileMode related `if-else` block.

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes # (issue)


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
