### PR TITLE
feat (jkube-kit/config) : OpenShiftBuildService should also respect multiple tags specified in Image Build Configuration (#1411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 ### 1.9.0-SNAPSHOT
 * Fix #1279: Remove redundant log messages regarding plugin modes
+* Fix #1411: Add support for adding additional ImageStreamTags in OpenShift S2I builds
 * Fix #1438: Add configuration option in ServiceAccountEnricher to skip creating ServiceAccounts
 * Fix #1468: Add startup probe in QuarkusHealthCheckEnricher
 * Fix #1473: Add OpenLibertyHealthCheckEnricher to automatically add health checks in OpenLiberty projects

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamService.java
@@ -259,4 +259,9 @@ public class ImageStreamService {
     protected static String resolveImageStreamName(ImageName name) {
         return name.getSimpleName().replace("/", "-");
     }
+
+    protected static String resolveImageStreamTagName(ImageName name) {
+        return resolveImageStreamName(name) + ":" +
+            (StringUtils.isBlank(name.getTag()) ?  "latest" : name.getTag());
+    }
 }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamServiceTest.java
@@ -38,6 +38,7 @@ import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -166,5 +167,29 @@ public class ImageStreamServiceTest {
 
         // THEN
         Assert.assertEquals(first, resultedTag);
+    }
+
+    @Test
+    public void resolveImageStreamTagName_withTagInImageName_shouldReturnImageStreamTagNameSameAsImageName() {
+        // Given
+        ImageName imageName = new ImageName("quay.io/foo/bar:1.0");
+
+        // When
+        String imageStreamTagName = ImageStreamService.resolveImageStreamTagName(imageName);
+
+        // Then
+        assertThat(imageStreamTagName).isEqualTo("bar:1.0");
+    }
+
+    @Test
+    public void resolveImageStreamTagName_withNoTag_shouldReturnImageStreamTagNameSameLatest() {
+        // Given
+        ImageName imageName = new ImageName("quay.io/foo/bar");
+
+        // When
+        String imageStreamTagName = ImageStreamService.resolveImageStreamTagName(imageName);
+
+        // Then
+        assertThat(imageStreamTagName).isEqualTo("bar:latest");
     }
 }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceIntegrationTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildServiceIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.SerializationFeature;
+import io.fabric8.openshift.api.model.ImageStreamTagBuilder;
 import org.eclipse.jkube.kit.build.api.assembly.AssemblyManager;
 import org.eclipse.jkube.kit.build.api.assembly.BuildDirs;
 import org.eclipse.jkube.kit.build.api.assembly.JKubeBuildTarArchiver;
@@ -190,7 +191,7 @@ public class OpenshiftBuildServiceIntegrationTest {
   @Test
   public void testSuccessfulBuild() throws Exception {
     final BuildServiceConfig config = withBuildServiceConfig(defaultConfig.build());
-    final WebServerEventCollector collector = prepareMockServer(config, true, false, false);
+    final WebServerEventCollector collector = prepareMockServer(config, true, false, false, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -206,7 +207,7 @@ public class OpenshiftBuildServiceIntegrationTest {
   public void build_withAssembly_shouldSucceed() throws Exception {
     // Given
     final BuildServiceConfig config = withBuildServiceConfig(defaultConfig.build());
-    final WebServerEventCollector collector = prepareMockServer(config, true, false, false);
+    final WebServerEventCollector collector = prepareMockServer(config, true, false, false, false);
     image.setBuild(BuildConfiguration.builder()
         .from(projectName)
         .assembly(AssemblyConfiguration.builder()
@@ -252,7 +253,7 @@ public class OpenshiftBuildServiceIntegrationTest {
         .build());
     image.getBuildConfiguration().initAndValidate();
     final WebServerEventCollector collector = prepareMockServer(withBuildServiceConfig(defaultConfig.build()),
-        true, false, false);
+        true, false, false, false);
     // When
     new OpenshiftBuildService(jKubeServiceHub).build(image);
     // Then
@@ -263,7 +264,7 @@ public class OpenshiftBuildServiceIntegrationTest {
   public void testSuccessfulBuildNoS2iSuffix() throws Exception {
     final BuildServiceConfig config = withBuildServiceConfig(defaultConfig.s2iBuildNameSuffix(null).build());
     final WebServerEventCollector collector = prepareMockServer(
-        config, true, false, false);
+        config, true, false, false, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -282,7 +283,7 @@ public class OpenshiftBuildServiceIntegrationTest {
         .s2iBuildNameSuffix("-docker")
         .jKubeBuildStrategy(JKubeBuildStrategy.docker)
         .resourceConfig(mockedResourceConfig).build());
-    final WebServerEventCollector collector = prepareMockServer(dockerConfig, true, false, false);
+    final WebServerEventCollector collector = prepareMockServer(dockerConfig, true, false, false, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -302,7 +303,7 @@ public class OpenshiftBuildServiceIntegrationTest {
         .resourceConfig(mockedResourceConfig).build());
     image.setName("docker.io/registry/component1/component2/name:tag");
     final WebServerEventCollector collector = prepareMockServer("component1-component2-name",
-        dockerConfig, true, false, false);
+        dockerConfig, true, false, false, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -320,7 +321,7 @@ public class OpenshiftBuildServiceIntegrationTest {
         .jKubeBuildStrategy(JKubeBuildStrategy.docker)
         .resourceConfig(mockedResourceConfig)
         .build());
-    final WebServerEventCollector collector = prepareMockServer(dockerConfig, true, false, false);
+    final WebServerEventCollector collector = prepareMockServer(dockerConfig, true, false, false, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -339,7 +340,7 @@ public class OpenshiftBuildServiceIntegrationTest {
         .jKubeBuildStrategy(JKubeBuildStrategy.docker)
         .resourceConfig(mockedResourceConfig)
         .build());
-    final WebServerEventCollector collector = prepareMockServer(dockerConfig, true, false, false);
+    final WebServerEventCollector collector = prepareMockServer(dockerConfig, true, false, false, false);
 
     OpenshiftBuildService service = new OpenshiftBuildService(jKubeServiceHub);
     Map<String,String> fromExt = ImmutableMap.of("name", "app:1.2-1",
@@ -364,7 +365,7 @@ public class OpenshiftBuildServiceIntegrationTest {
   @Test
   public void testSuccessfulBuildSecret() throws Exception {
     final BuildServiceConfig config = withBuildServiceConfig(defaultConfigSecret.build());
-    final WebServerEventCollector collector = prepareMockServer(config, true, false, false);
+    final WebServerEventCollector collector = prepareMockServer(config, true, false, false, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -388,7 +389,7 @@ public class OpenshiftBuildServiceIntegrationTest {
   @Test
   public void testSuccessfulSecondBuild() throws Exception {
     final BuildServiceConfig config = withBuildServiceConfig(defaultConfig.build());
-    final WebServerEventCollector collector = prepareMockServer(config, true, true, true);
+    final WebServerEventCollector collector = prepareMockServer(config, true, true, true, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -404,7 +405,7 @@ public class OpenshiftBuildServiceIntegrationTest {
     when(mockedResourceConfig.getOpenshiftBuildConfig()).thenReturn(OpenshiftBuildConfig.builder().limits(limitsMap).build());
     final BuildServiceConfig config = withBuildServiceConfig(defaultConfig
         .resourceConfig(mockedResourceConfig).build());
-    final WebServerEventCollector collector = prepareMockServer(config, true, false, false);
+    final WebServerEventCollector collector = prepareMockServer(config, true, false, false, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -428,7 +429,7 @@ public class OpenshiftBuildServiceIntegrationTest {
   @Test
   public void testSuccessfulDockerImageOutputBuild() throws Exception {
     final BuildServiceConfig config = withBuildServiceConfig(dockerImageConfig.build());
-    final WebServerEventCollector collector = prepareMockServer(config, true, false, false);
+    final WebServerEventCollector collector = prepareMockServer(config, true, false, false, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -443,7 +444,7 @@ public class OpenshiftBuildServiceIntegrationTest {
   @Test
   public void testSuccessfulDockerImageOutputBuildSecret() throws Exception {
     final BuildServiceConfig config = withBuildServiceConfig(dockerImageConfigSecret.build());
-    final WebServerEventCollector collector = prepareMockServer(config, true, false, false);
+    final WebServerEventCollector collector = prepareMockServer(config, true, false, false, false);
 
     new OpenshiftBuildService(jKubeServiceHub).build(image);
 
@@ -455,13 +456,27 @@ public class OpenshiftBuildServiceIntegrationTest {
     assertFalse(containsRequest("imagestreams"));
   }
 
-  private WebServerEventCollector prepareMockServer(
-      BuildServiceConfig config, boolean success, boolean buildConfigExists, boolean imageStreamExists) {
-    return prepareMockServer(projectName, config, success, buildConfigExists, imageStreamExists);
+  @Test
+  public void build_withAdditionalTags_shouldCreateNewImageStreamTags() throws Exception {
+    // Given
+    final BuildServiceConfig config = withBuildServiceConfig(defaultConfig.build());
+    final WebServerEventCollector collector = prepareMockServer(config, true, false, false, true);
+    image.setBuild(image.getBuild().toBuilder()
+            .tag("t1")
+        .build());
+    // When
+    new OpenshiftBuildService(jKubeServiceHub).build(image);
+    // Then
+    collector.assertEventsRecordedInOrder("build-config-check", "new-build-config", "pushed", "imagestreamtag-get", "imagestreamtag-create");
   }
 
   private WebServerEventCollector prepareMockServer(
-      String resourceName, BuildServiceConfig config, boolean success, boolean buildConfigExists, boolean imageStreamExists) {
+      BuildServiceConfig config, boolean success, boolean buildConfigExists, boolean imageStreamExists, boolean additionalImageStreamTagCreated) {
+    return prepareMockServer(projectName, config, success, buildConfigExists, imageStreamExists, additionalImageStreamTagCreated);
+  }
+
+  private WebServerEventCollector prepareMockServer(
+      String resourceName, BuildServiceConfig config, boolean success, boolean buildConfigExists, boolean imageStreamExists, boolean additionalImageStreamTagCreated) {
     WebServerEventCollector collector = new WebServerEventCollector();
 
     final long buildDelay = 50L;
@@ -581,6 +596,19 @@ public class OpenshiftBuildServiceIntegrationTest {
         .waitFor(buildDelay)
         .andEmit(new WatchEvent(build, "MODIFIED"))
         .done().always();
+
+    if (additionalImageStreamTagCreated) {
+      mockServer.expect().get().withPath("/apis/image.openshift.io/v1/namespaces/ns1/imagestreamtags/" + resourceName + ":latest")
+          .andReply(collector.record("imagestreamtag-get").andReturn(200, new ImageStreamTagBuilder().withNewMetadata().withName(resourceName + ":latest").endMetadata()
+              .withNewImage()
+              .withDockerImageReference("foo-registry.openshift.svc:5000/test/myapp@sha256:1234")
+              .endImage()
+              .build()))
+          .once();
+      mockServer.expect().post().withPath("/apis/image.openshift.io/v1/namespaces/ns1/imagestreamtags")
+          .andReply(collector.record("imagestreamtag-create").andReturn(200, new ImageStreamTagBuilder().withNewMetadata().withName(resourceName + ":t1").endMetadata().build()))
+          .once();
+    }
 
     return collector;
   }


### PR DESCRIPTION
## Description
Fix #1411

Add support for adding multiple ImageStreamTags specified in
`tags` section of image's `build` configuration. After S2I build new
ImageStreamTags as specified in build configuration would get created.
They would point to same image as done by orignal ImageStreamTag output
of S2I build.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
