### PR TITLE
fix (jkube-kit/config/service) : OpenShiftBuildService doesn't consider registry in ImageConfiguration (#1532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Usage:
 * Fix #1438: Add configuration option in ServiceAccountEnricher to skip creating ServiceAccounts
 * Fix #1468: Add startup probe in QuarkusHealthCheckEnricher
 * Fix #1473: Add OpenLibertyHealthCheckEnricher to automatically add health checks in OpenLiberty projects
+* Fix #1537: Registry not set up in `oc:build`
 
 
 ### 1.8.0 (2022-05-24)


### PR DESCRIPTION
## Description
Fixes #1537

OpenShiftBuildService doesn't consider registry in ImageConfiguration
while building image. This causes problems when BuildOutput kind is set
DockerImage and no registry name can be inferred from ImageName,
eventually causing authentication failure.

Add logic to append registry in ImageName before building image.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
