### PR TITLE
fix: NPE when building images with missing build configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Usage:
 * Fix #1468: Add startup probe in QuarkusHealthCheckEnricher
 * Fix #1473: Add OpenLibertyHealthCheckEnricher to automatically add health checks in OpenLiberty projects
 * Fix #1537: Registry not set up in `oc:build`
+* Fix #1654: images with missing build configuration should not be built
 
 
 ### 1.8.0 (2022-05-24)

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/AbstractImageBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/AbstractImageBuildService.java
@@ -49,6 +49,8 @@ public abstract class AbstractImageBuildService implements BuildService {
       for (ImageConfiguration imageConfiguration : imageConfigurations) {
         if (imageConfiguration.getBuildConfiguration() != null && imageConfiguration.getBuildConfiguration().getSkip()) {
           jKubeServiceHub.getLog().info("%s : %s", imageConfiguration.getDescription(), skipMessage);
+        } else if (imageConfiguration.getBuildConfiguration() == null) {
+          jKubeServiceHub.getLog().info("%s : %s (Image configuration has no build settings)", imageConfiguration.getDescription(), skipMessage);
         } else {
           imageConfigurationConsumer.process(imageConfiguration);
         }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildServiceTest.java
@@ -71,6 +71,18 @@ public class DockerBuildServiceTest {
   }
 
   @Test
+  public void build_withInvalidConfiguration_shouldNotBuildAndTag() throws Exception {
+    // When
+    image.setBuild(null);
+    new DockerBuildService(mockedJKubeServiceHub).build(image);
+    // Then
+    verify(mockedDockerBuildService, times(0))
+        .buildImage(eq(image), any(), any());
+    verify(mockedDockerBuildService, times(0))
+        .tagImage(anyString(), eq(image));
+  }
+
+  @Test
   public void build_withValidConfiguration_shouldBuildAndTag() throws Exception {
     // When
     new DockerBuildService(mockedJKubeServiceHub).build(image);

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
@@ -213,6 +213,18 @@ public class JibBuildServiceTest {
     }
 
     @Test
+    public void build_withImageMissingBuildConfiguration_shouldNotBuildImage() throws JKubeServiceException {
+        // Given
+        imageConfiguration = ImageConfiguration.builder()
+            .name("test/foo:latest")
+            .build();
+        // When
+        new JibBuildService(mockedServiceHub).build(imageConfiguration);
+        // Then
+        jibServiceUtilMockedStatic.verify(() -> JibServiceUtil.buildContainer(any(), any(), any()), times(0));
+    }
+
+    @Test
     public void build_withImageBuildConfigurationSkipTrue_shouldNotBuildImage() throws JKubeServiceException {
         // Given
         imageConfiguration = ImageConfiguration.builder()

--- a/quickstarts/maven/ibm-javaee8-webprofile-liberty/pom.xml
+++ b/quickstarts/maven/ibm-javaee8-webprofile-liberty/pom.xml
@@ -49,6 +49,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <javaee.api.version>8.0</javaee.api.version>
         <jersey.version>2.26</jersey.version>
+        <junit.version>4.13.2</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -62,12 +63,12 @@
             <dependency>
                 <groupId>javax</groupId>
                 <artifactId>javaee-api</artifactId>
-                <version>8.0</version>
+                <version>${javaee.api.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.11</version>
+                <version>${junit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
@@ -108,12 +109,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>2.22.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>2.22.2</version>
                 </plugin>
                 <plugin>
                     <groupId>net.wasdev.wlp.maven.plugins</groupId>
@@ -123,7 +124,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Description
- fix #1654 - ImageConfiguration with missing build configuration should not be built
- bump dependencies for javaee8-webprofile-liberty quickstart


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my code
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
