### PR TITLE
fix (jkube-kit/watcher) : Fix DockerImageWatcher under copy mode (#1704)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 ### 1.10-SNAPSHOT
 * Fix #443: Add health check enricher for SmallRye Health
 * Fix #1684: Podman builds with errors are correctly processed and reported 
+* Fix #1704: `k8s:watch` in `jkube.watch.mode=copy` doesn't work
 * Fix #1888: KubernetesExtension has helper method to add image with builder
 
 ### 1.9.1 (2022-09-14)

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/WatchService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/WatchService.java
@@ -138,7 +138,7 @@ public class WatchService {
                          File changedFilesArchive = archiveService.createChangedFilesArchive(entries, files.getAssemblyDirectory(),
                                  imageConfig.getName(), jKubeConfiguration);
                          copyFilesToContainer(changedFilesArchive, watcher);
-                                    callPostExec(watcher);
+                         callPostExec(watcher);
                      } catch (IOException | WatchException e) {
                          log.error("%s: Error when copying files to container %s: %s",
                                  imageConfig.getDescription(), watcher.getContainerId(), e.getMessage());

--- a/jkube-kit/watcher/standard/pom.xml
+++ b/jkube-kit/watcher/standard/pom.xml
@@ -41,8 +41,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jmockit</groupId>
-      <artifactId>jmockit</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/PodExecutor.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/PodExecutor.java
@@ -43,10 +43,10 @@ public class PodExecutor {
     this.waitTimeout = waitTimeout;
   }
 
-  void uploadFileToPod(Collection<HasMetadata> resources, File fileToUpload) throws WatchException {
+  void uploadChangedFilesToPod(Collection<HasMetadata> resources, File changedFilesTarball) throws WatchException {
     try (KubernetesClient client = clusterAccess.createDefaultClient()) {
       String namespace = clusterAccess.getNamespace();
-      File changedFilesDir = new File(fileToUpload.getParentFile(), "changed-files");
+      File changedFilesDir = new File(changedFilesTarball.getParentFile(), "changed-files");
       File[] changedFiles = changedFilesDir.listFiles();
       if (changedFiles != null && changedFiles.length > 0) {
         PodResource podResource = client.pods()

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/PodExecutor.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/PodExecutor.java
@@ -14,18 +14,19 @@
 package org.eclipse.jkube.watcher.standard;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.client.dsl.PodResource;
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchException;
+import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -34,52 +35,64 @@ import io.fabric8.kubernetes.client.dsl.ExecWatch;
 public class PodExecutor {
 
   private final ClusterAccess clusterAccess;
-  private final InputStream readingInput;
   private final Duration waitTimeout;
-  private final Runnable onOpen;
-  private final ObjectMapper objectMapper;
   private String output;
 
   public PodExecutor(ClusterAccess clusterAccess, Duration waitTimeout) {
-    this(clusterAccess, null, waitTimeout, null);
-  }
-
-  public PodExecutor(ClusterAccess clusterAccess, InputStream readingInput, Duration waitTimeout, Runnable onOpen) {
     this.clusterAccess = clusterAccess;
-    this.readingInput = readingInput;
     this.waitTimeout = waitTimeout;
-    this.onOpen = onOpen;
-    objectMapper = new ObjectMapper();
   }
 
-  void executeCommandInPod(Collection<HasMetadata> resources, String command) throws IOException, InterruptedException, WatchException {
+  void uploadFileToPod(Collection<HasMetadata> resources, File fileToUpload) throws WatchException {
+    try (KubernetesClient client = clusterAccess.createDefaultClient()) {
+      String namespace = clusterAccess.getNamespace();
+      File changedFilesDir = new File(fileToUpload.getParentFile(), "changed-files");
+      File[] changedFiles = changedFilesDir.listFiles();
+      if (changedFiles != null && changedFiles.length > 0) {
+        PodResource podResource = client.pods()
+            .inNamespace(namespace)
+            .withName(KubernetesHelper.getNewestApplicationPodName(client, namespace, resources));
+        for (File changedFile : changedFiles) {
+          if (changedFile.isFile()) {
+            podResource.file("/" + FileUtil.getRelativeFilePath(changedFilesDir.getPath(), changedFile.getPath()))
+                .upload(changedFile.toPath());
+          } else if (changedFile.isDirectory()) {
+            podResource.dir("/" + FileUtil.getRelativeFilePath(changedFilesDir.getPath(), changedFile.getPath()))
+                .upload(changedFile.toPath());
+          }
+        }
+      }
+    } catch (KubernetesClientException kubernetesClientException) {
+      throw new WatchException("Error while uploading changed files archive to pod: " + kubernetesClientException.getMessage());
+    }
+  }
+
+  void executeCommandInPod(Collection<HasMetadata> resources, String command) throws InterruptedException, WatchException, IOException {
     try (
         KubernetesClient client = clusterAccess.createDefaultClient();
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ByteArrayOutputStream error = new ByteArrayOutputStream()
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     ) {
       String namespace = clusterAccess.getNamespace();
-      final ExecListenerLatch latch = new ExecListenerLatch(onOpen);
+      final ExecListenerLatch latch = new ExecListenerLatch();
       ExecWatch execWatch = client.pods().inNamespace(namespace)
           .withName(KubernetesHelper.getNewestApplicationPodName(client, namespace, resources))
-          .readingInput(readingInput)
-          .writingOutput(outputStream)
-          .writingError(outputStream)
-          .writingErrorChannel(error)
+          .redirectingInput()
+          .writingOutput(byteArrayOutputStream)
+          .redirectingError()
           .usingListener(latch)
           .exec("sh", "-c", command);
       final boolean completed = latch.await(waitTimeout.toMillis(), TimeUnit.MILLISECONDS);
       execWatch.close();
-      output = outputStream.toString();
+      output = byteArrayOutputStream.toString();
       if (!completed) {
         throw new WatchException("Command execution timed out");
       }
       if (latch.getCloseCode() != 1000) {
         throw new WatchException("Command execution socket closed unexpectedly " + latch.getCloseReason());
       }
-      final Map<String, Object> status = objectMapper.readValue(error.toString(), Map.class);
-      if (status.getOrDefault("status", "Failure").equals("Failure")) {
-        throw new WatchException("Command execution failed: " + status.getOrDefault("message", ""));
+      final Status status = latch.getExitStatus();
+      if (status.getStatus().equals("Failure")) {
+        throw new WatchException("Command execution failed: " + status.getMessage());
       }
     } catch (KubernetesClientException e) {
       throw new WatchException("Execution failed due to a KubernetesClient error: " + e.getMessage(), e);

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherRestartContainerTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherRestartContainerTest.java
@@ -1,0 +1,278 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.watcher.standard;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
+import io.fabric8.kubernetes.api.model.ReplicationController;
+import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
+import io.fabric8.kubernetes.api.model.ReplicationControllerList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
+import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
+import io.fabric8.kubernetes.api.model.apps.ReplicaSetList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.fabric8.kubernetes.client.dsl.TimeoutImageEditReplacePatchable;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
+import io.fabric8.openshift.api.model.DeploymentConfigList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.dsl.DeployableScalableResource;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.eclipse.jkube.kit.build.service.docker.WatchService;
+import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
+import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.watcher.api.WatcherContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+class DockerImageWatcherRestartContainerTest {
+  private DockerImageWatcher dockerImageWatcher;
+  private KubernetesClient mockedKubernetesClient;
+  private WatchService.ImageWatcher mockedImageWatcher;
+
+  @BeforeEach
+  public void setUp() {
+    WatcherContext watcherContext = mock(WatcherContext.class, RETURNS_DEEP_STUBS);
+    ClusterAccess mockedClusterAccess = mock(ClusterAccess.class);
+    mockedImageWatcher = mock(WatchService.ImageWatcher.class);
+    mockedKubernetesClient = mock(KubernetesClient.class);
+    when(watcherContext.getJKubeServiceHub().getClusterAccess()).thenReturn(mockedClusterAccess);
+    when(mockedClusterAccess.createDefaultClient()).thenReturn(mockedKubernetesClient);
+    when(mockedClusterAccess.getNamespace()).thenReturn("test-ns");
+    dockerImageWatcher = new DockerImageWatcher(watcherContext);
+  }
+
+  @Test
+  void restartContainer_whenImageConfigurationAndDeploymentProvided_thenShouldDoRollingUpdate() {
+    // Given
+    Deployment deployment = createNewDeployment();
+    RollableScalableResource<Deployment> rollableScalableResource = mockKubernetesClientAppsDeploymentCall();
+    TimeoutImageEditReplacePatchable<Deployment> timeoutImageEditReplacePatchable = mock(TimeoutImageEditReplacePatchable.class);
+    when(mockedImageWatcher.getImageConfiguration()).thenReturn(createNewImageConfiguration("foo/example-deployment:snapshot-1234"));
+    when(rollableScalableResource.replace()).thenReturn(deployment);
+    when(rollableScalableResource.rolling()).thenReturn(timeoutImageEditReplacePatchable);
+    when(timeoutImageEditReplacePatchable.restart()).thenReturn(deployment);
+
+    // When
+    dockerImageWatcher.restartContainer(mockedImageWatcher, Collections.singletonList(deployment));
+
+    // Then
+    verify(rollableScalableResource).replace();
+    verify(rollableScalableResource).rolling();
+    verify(timeoutImageEditReplacePatchable).restart();
+    assertPodTemplateSpecContainsImage(deployment.getSpec().getTemplate(), "foo/example-deployment:snapshot-1234");
+  }
+
+  @Test
+  void restartContainer_whenImageConfigurationAndReplicaSetProvided_thenShouldDoRollingUpdate() {
+    // Given
+    ReplicaSet replicaSet = createNewReplicaSet();
+    RollableScalableResource<ReplicaSet> rollableScalableResource = mockKubernetesClientAppsReplicaSetCall();
+    TimeoutImageEditReplacePatchable<ReplicaSet> timeoutImageEditReplacePatchable = mock(TimeoutImageEditReplacePatchable.class);
+    when(mockedImageWatcher.getImageConfiguration()).thenReturn(createNewImageConfiguration("foo/example-replicaset:snapshot-1234"));
+    when(rollableScalableResource.replace()).thenReturn(replicaSet);
+    when(rollableScalableResource.rolling()).thenReturn(timeoutImageEditReplacePatchable);
+    when(timeoutImageEditReplacePatchable.restart()).thenReturn(replicaSet);
+
+    // When
+    dockerImageWatcher.restartContainer(mockedImageWatcher, Collections.singletonList(replicaSet));
+
+    // Then
+    verify(rollableScalableResource).replace();
+    verify(rollableScalableResource).rolling();
+    verify(timeoutImageEditReplacePatchable).restart();
+    assertPodTemplateSpecContainsImage(replicaSet.getSpec().getTemplate(), "foo/example-replicaset:snapshot-1234");
+  }
+
+  @Test
+  void restartContainer_whenImageConfigurationAndReplicationControllerProvided_thenShouldDoRollingUpdate() {
+    // Given
+    ReplicationController replicationController = createNewReplicationController();
+    RollableScalableResource<ReplicationController> rollableScalableResource = mockKubernetesClientAppsReplicationControllerCall();
+    TimeoutImageEditReplacePatchable<ReplicationController> timeoutImageEditReplacePatchable = mock(TimeoutImageEditReplacePatchable.class);
+    when(mockedImageWatcher.getImageConfiguration()).thenReturn(createNewImageConfiguration("foo/example-replicationcontroller:snapshot-1234"));
+    when(rollableScalableResource.replace()).thenReturn(replicationController);
+    when(rollableScalableResource.rolling()).thenReturn(timeoutImageEditReplacePatchable);
+    when(timeoutImageEditReplacePatchable.restart()).thenReturn(replicationController);
+
+    // When
+    dockerImageWatcher.restartContainer(mockedImageWatcher, Collections.singletonList(replicationController));
+
+    // Then
+    verify(rollableScalableResource).replace();
+    verify(rollableScalableResource).rolling();
+    verify(timeoutImageEditReplacePatchable).restart();
+    assertPodTemplateSpecContainsImage(replicationController.getSpec().getTemplate(), "foo/example-replicationcontroller:snapshot-1234");
+  }
+
+  @Test
+  void restartContainer_whenImageConfigurationAndDeploymentConfigProvided_thenShouldReplaceDeploymentConfig() {
+    try (MockedStatic<OpenshiftHelper> openshiftHelperMockedStatic = mockStatic(OpenshiftHelper.class)) {
+      // Given
+      OpenShiftClient mockedOpenShiftClient = mock(OpenShiftClient.class);
+      openshiftHelperMockedStatic.when(() -> OpenshiftHelper.asOpenShiftClient(mockedKubernetesClient))
+          .thenReturn(mockedOpenShiftClient);
+      DeploymentConfig deploymentConfig = createNewDeploymentConfig();
+      DeployableScalableResource<DeploymentConfig> rollableScalableResource = mockOpenShiftClientDeploymentConfigCall(mockedOpenShiftClient);
+      when(mockedImageWatcher.getImageConfiguration()).thenReturn(createNewImageConfiguration("foo/example-deploymentconfig:snapshot-1234"));
+      when(rollableScalableResource.replace()).thenReturn(deploymentConfig);
+
+      // When
+      dockerImageWatcher.restartContainer(mockedImageWatcher, Collections.singletonList(deploymentConfig));
+
+      // Then
+      verify(rollableScalableResource).replace();
+      assertPodTemplateSpecContainsImage(deploymentConfig.getSpec().getTemplate(), "foo/example-deploymentconfig:snapshot-1234");
+    }
+  }
+
+  private void assertPodTemplateSpecContainsImage(PodTemplateSpec podTemplateSpec, String expectedImage) {
+    assertThat(podTemplateSpec)
+        .extracting(PodTemplateSpec::getSpec)
+        .extracting(PodSpec::getContainers)
+        .asList()
+        .first(InstanceOfAssertFactories.type(Container.class))
+        .extracting(Container::getImage)
+        .isEqualTo(expectedImage);
+  }
+
+  private ImageConfiguration createNewImageConfiguration(String imageName) {
+    return ImageConfiguration.builder()
+        .name(imageName)
+        .build();
+  }
+
+  private RollableScalableResource<Deployment> mockKubernetesClientAppsDeploymentCall() {
+    AppsAPIGroupDSL mockedApps = mock(AppsAPIGroupDSL.class);
+    MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentOp = mock(MixedOperation.class);
+    NonNamespaceOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentNonNsOp = mock(NonNamespaceOperation.class);
+    RollableScalableResource<Deployment> rollableScalableResource = mock(RollableScalableResource.class);
+    when(mockedKubernetesClient.apps()).thenReturn(mockedApps);
+    when(mockedApps.deployments()).thenReturn(deploymentOp);
+    when(deploymentOp.inNamespace(anyString())).thenReturn(deploymentNonNsOp);
+    when(deploymentNonNsOp.resource(any())).thenReturn(rollableScalableResource);
+    when(deploymentNonNsOp.withName(anyString())).thenReturn(rollableScalableResource);
+    return rollableScalableResource;
+  }
+
+  private RollableScalableResource<ReplicaSet> mockKubernetesClientAppsReplicaSetCall() {
+    AppsAPIGroupDSL mockedApps = mock(AppsAPIGroupDSL.class);
+    MixedOperation<ReplicaSet, ReplicaSetList, RollableScalableResource<ReplicaSet>> replicaSetOp = mock(MixedOperation.class);
+    NonNamespaceOperation<ReplicaSet, ReplicaSetList, RollableScalableResource<ReplicaSet>> replicaSetNonNsOp = mock(NonNamespaceOperation.class);
+    RollableScalableResource<ReplicaSet> rollableScalableResource = mock(RollableScalableResource.class);
+    when(mockedKubernetesClient.apps()).thenReturn(mockedApps);
+    when(mockedApps.replicaSets()).thenReturn(replicaSetOp);
+    when(replicaSetOp.inNamespace(anyString())).thenReturn(replicaSetNonNsOp);
+    when(replicaSetNonNsOp.resource(any())).thenReturn(rollableScalableResource);
+    when(replicaSetNonNsOp.withName(anyString())).thenReturn(rollableScalableResource);
+    return rollableScalableResource;
+  }
+
+  private RollableScalableResource<ReplicationController> mockKubernetesClientAppsReplicationControllerCall() {
+    MixedOperation<ReplicationController, ReplicationControllerList, RollableScalableResource<ReplicationController>> replicationControllerOp = mock(MixedOperation.class);
+    NonNamespaceOperation<ReplicationController, ReplicationControllerList, RollableScalableResource<ReplicationController>> replicationControllerNonNsOp = mock(NonNamespaceOperation.class);
+    RollableScalableResource<ReplicationController> rollableScalableResource = mock(RollableScalableResource.class);
+    when(mockedKubernetesClient.replicationControllers()).thenReturn(replicationControllerOp);
+    when(replicationControllerOp.inNamespace(anyString())).thenReturn(replicationControllerNonNsOp);
+    when(replicationControllerNonNsOp.withName(anyString())).thenReturn(rollableScalableResource);
+    when(replicationControllerNonNsOp.resource(any())).thenReturn(rollableScalableResource);
+    return rollableScalableResource;
+  }
+
+  private DeployableScalableResource<DeploymentConfig> mockOpenShiftClientDeploymentConfigCall(OpenShiftClient mockedOpenShiftClient) {
+    MixedOperation<DeploymentConfig, DeploymentConfigList, DeployableScalableResource<DeploymentConfig>> mixedOp = mock(MixedOperation.class);
+    NonNamespaceOperation<DeploymentConfig, DeploymentConfigList, DeployableScalableResource<DeploymentConfig>> deploymentConfigNonNsOp = mock(NonNamespaceOperation.class);
+    DeployableScalableResource<DeploymentConfig> deployableScalableResource = mock(DeployableScalableResource.class);
+    when(mockedOpenShiftClient.deploymentConfigs()).thenReturn(mixedOp);
+    when(mixedOp.inNamespace(anyString())).thenReturn(deploymentConfigNonNsOp);
+    when(deploymentConfigNonNsOp.resource(any())).thenReturn(deployableScalableResource);
+    return deployableScalableResource;
+  }
+
+  private Deployment createNewDeployment() {
+    return new DeploymentBuilder()
+        .withNewMetadata()
+        .withName("test-deployment")
+        .endMetadata()
+        .withNewSpec()
+        .withTemplate(createNewPodTemplateSpec("foo/example-deployment:oldTag"))
+        .endSpec()
+        .build();
+  }
+  private ReplicaSet createNewReplicaSet() {
+    return new ReplicaSetBuilder()
+        .withNewMetadata()
+        .withName("test-replicaset")
+        .endMetadata()
+        .withNewSpec()
+        .withTemplate(createNewPodTemplateSpec("foo/example-replicaset:oldTag"))
+        .endSpec()
+        .build();
+  }
+
+  private ReplicationController createNewReplicationController() {
+    return new ReplicationControllerBuilder()
+        .withNewMetadata()
+        .withName("test-replicationcontroller")
+        .endMetadata()
+        .withNewSpec()
+        .withTemplate(createNewPodTemplateSpec("foo/example-replicationcontroller:oldTag"))
+        .endSpec()
+        .build();
+  }
+
+  private DeploymentConfig createNewDeploymentConfig() {
+    return new DeploymentConfigBuilder()
+        .withNewMetadata()
+        .withName("test-deploymentconfig")
+        .endMetadata()
+        .withNewSpec()
+        .withTemplate(createNewPodTemplateSpec("foo/example-deploymentconfig:oldTag"))
+        .endSpec()
+        .build();
+  }
+
+  private PodTemplateSpec createNewPodTemplateSpec(String imageName) {
+    return new PodTemplateSpecBuilder()
+        .withNewSpec()
+        .addNewContainer()
+        .withImage(imageName)
+        .endContainer()
+        .endSpec()
+        .build();
+  }
+}

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
@@ -13,11 +13,6 @@
  */
 package org.eclipse.jkube.watcher.standard;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 
@@ -34,7 +29,6 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import mockit.Verifications;
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -104,25 +98,8 @@ class DockerImageWatcherTest {
     // Then
     // @formatter:off
     new Verifications() {{
-      new PodExecutor(watcherContext.getJKubeServiceHub().getClusterAccess(),
-          (InputStream)any, Duration.ofMinutes(1), (Runnable)any); times = 1;
-      podExecutor.executeCommandInPod(null, "sh"); times = 1;
+      new PodExecutor(watcherContext.getJKubeServiceHub().getClusterAccess(), Duration.ofMinutes(1)); times = 1;
     }};
     // @formatter:on
-  }
-
-  @Test
-  void uploadFilesRunnable() throws Exception {
-    // Given
-    final PipedOutputStream pipedOutputStream = new PipedOutputStream();
-    final PipedInputStream pipedInputStream = new PipedInputStream(pipedOutputStream);
-    // When
-    DockerImageWatcher.uploadFilesRunnable(
-        new File(DockerImageWatcherTest.class.getResource("/file.txt").toURI().getPath()),
-        pipedOutputStream,
-        watcherContext.getLogger()
-    ).run();
-    assertThat(IOUtils.toString(pipedInputStream, StandardCharsets.UTF_8))
-      .isEqualTo("base64 -d << EOF | tar --no-overwrite-dir -C / -xf - && exit 0 || exit 1\nQSBmaWxl\nEOF\n");
   }
 }

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
@@ -13,93 +13,90 @@
  */
 package org.eclipse.jkube.watcher.standard;
 
-import java.time.Duration;
-import java.util.List;
+import java.io.IOException;
 
+import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
 import org.eclipse.jkube.kit.build.service.docker.WatchService;
 import org.eclipse.jkube.kit.build.service.docker.watch.CopyFilesTask;
 import org.eclipse.jkube.kit.build.service.docker.watch.ExecTask;
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchContext;
-import org.eclipse.jkube.kit.common.JKubeConfiguration;
-import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.watcher.api.WatcherContext;
 
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
-import mockit.Verifications;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@SuppressWarnings({"ResultOfMethodCallIgnored", "unused"})
-class DockerImageWatcherTest {
+class DockerImageWatcherTest{
 
-  @Mocked
   private WatcherContext watcherContext;
-  @Mocked
   private WatchService watchService;
-
   private DockerImageWatcher dockerImageWatcher;
-  private WatchContext watchContext;
 
   @BeforeEach
-  void setUp() {
+  public void setUp(){
+    watcherContext = mock(WatcherContext.class,RETURNS_DEEP_STUBS);
+    watchService = mock(WatchService.class);
+    DockerServiceHub mockedDockerServiceHub = mock(DockerServiceHub.class,RETURNS_DEEP_STUBS);
     dockerImageWatcher = new DockerImageWatcher(watcherContext);
-    // @formatter:off
-    new Expectations() {{
-      watcherContext.getWatchContext(); result = new WatchContext(); minTimes = 0;
-    }};
-    // @formatter:on
-    new MockUp<WatchService>() {
-      @Mock
-      void watch(WatchContext context, JKubeConfiguration buildContext, List<ImageConfiguration> images) {
-        watchContext = context;
-      }
-    };
+    when(mockedDockerServiceHub.getWatchService()).thenReturn(watchService);
+    when(watcherContext.getJKubeServiceHub().getDockerServiceHub()).thenReturn(mockedDockerServiceHub);
+    when(watcherContext.getWatchContext()).thenReturn(new WatchContext());
   }
 
   @Test
-  void watchShouldInitWatchContext() {
+  void watchShouldInitWatchContext() throws IOException{
+    // Given
+    ArgumentCaptor<WatchContext>watchContextArgumentCaptor=ArgumentCaptor.forClass(WatchContext.class);
     // When
-    dockerImageWatcher.watch(null, null, null, null);
+    dockerImageWatcher.watch(null,null,null,null);
     // Then
-    assertThat(watchContext)
+    verify(watchService).watch(watchContextArgumentCaptor.capture(),any(),any());
+    assertThat(watchContextArgumentCaptor.getValue())
         .isNotNull()
-        .extracting("imageCustomizer", "containerRestarter", "containerCommandExecutor", "containerCopyTask")
+        .extracting("imageCustomizer","containerRestarter","containerCommandExecutor","containerCopyTask")
         .doesNotContainNull();
   }
 
   @Test
-  void watchExecuteCommandInPodTask(@Mocked PodExecutor podExecutor) throws Exception {
-    // Given
-    dockerImageWatcher.watch(null, null, null, null);
-    final ExecTask execTask = watchContext.getContainerCommandExecutor();
-    // When
-    execTask.exec("the command");
-    // Then
-    // @formatter:off
-    new Verifications() {{
-      new PodExecutor(watcherContext.getJKubeServiceHub().getClusterAccess(), Duration.ofMinutes(1)); times = 1;
-      podExecutor.executeCommandInPod(null, "the command"); times = 1;
-    }};
-    // @formatter:on
+  void watchExecuteCommandInPodTask() throws Exception{
+    try(MockedConstruction<PodExecutor>podExecutorMockedConstruction=mockConstruction(PodExecutor.class)){
+      // Given
+      ArgumentCaptor<WatchContext>watchContextArgumentCaptor=ArgumentCaptor.forClass(WatchContext.class);
+      dockerImageWatcher.watch(null,null,null,null);
+      verify(watchService).watch(watchContextArgumentCaptor.capture(),any(),any());
+      final ExecTask execTask=watchContextArgumentCaptor.getValue().getContainerCommandExecutor();
+      //When
+      execTask.exec("thecommand");
+      // Then
+      assertThat(podExecutorMockedConstruction.constructed()).hasSize(1);
+      verify(podExecutorMockedConstruction.constructed().get(0)).executeCommandInPod(isNull(),eq("thecommand"));
+    }
   }
 
   @Test
-  void watchCopyFileToPod(@Mocked PodExecutor podExecutor) throws Exception {
-    // Given
-    dockerImageWatcher.watch(null, null, null, null);
-    final CopyFilesTask copyFilesTask = watchContext.getContainerCopyTask();
-    // When
-    copyFilesTask.copy(null);
-    // Then
-    // @formatter:off
-    new Verifications() {{
-      new PodExecutor(watcherContext.getJKubeServiceHub().getClusterAccess(), Duration.ofMinutes(1)); times = 1;
-    }};
-    // @formatter:on
+  void watchCopyFileToPod() throws Exception{
+    try(MockedConstruction<PodExecutor> podExecutorMockedConstruction = mockConstruction(PodExecutor.class)){
+      // Given
+      ArgumentCaptor<WatchContext> watchContextArgumentCaptor = ArgumentCaptor.forClass(WatchContext.class);
+      dockerImageWatcher.watch(null,null,null,null);
+      verify(watchService).watch(watchContextArgumentCaptor.capture(),any(),any());
+      final CopyFilesTask copyFilesTask=watchContextArgumentCaptor.getValue().getContainerCopyTask();
+      // When
+      copyFilesTask.copy(null);
+      // Then
+      assertThat(podExecutorMockedConstruction.constructed()).hasSize(1);
+      verify(podExecutorMockedConstruction.constructed().get(0)).executeCommandInPod(isNull(),eq("sh"));
+    }
   }
 }

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/ExecListenerLatchTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/ExecListenerLatchTest.java
@@ -17,22 +17,10 @@ package org.eclipse.jkube.watcher.standard;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ExecListenerLatchTest {
-
-  @Test
-  void onOpenWithConsumer() {
-    // Given
-    final AtomicBoolean consumed = new AtomicBoolean(false);
-    final ExecListenerLatch ell = new ExecListenerLatch(() -> consumed.set(true));
-    // When
-    ell.onOpen();
-    // Then
-    assertThat(consumed.get()).isTrue();
-  }
 
   @Test
   void onCloseShouldSetCodeAndReason() {

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/PodExecutorTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/PodExecutorTest.java
@@ -17,7 +17,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
@@ -28,36 +27,43 @@ import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collections;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("unused")
 class PodExecutorTest {
-  private PodOperationsImpl podOperations;
   private KubernetesClient kubernetesClient;
   private PodExecutor podExecutor;
+  private PodOperationsImpl podOperations;
   private NonNamespaceOperation<Pod, PodList, PodResource> podNonNamespaceOp;
   private MockedStatic<KubernetesHelper> kubernetesHelperMockedStatic;
 
   @BeforeEach
   public void setUp() {
     ClusterAccess clusterAccess = mock(ClusterAccess.class);
-    podOperations = mock(PodOperationsImpl.class);
+    podOperations = mock(PodOperationsImpl.class, RETURNS_DEEP_STUBS);
     kubernetesClient = mock(KubernetesClient.class);
     when(clusterAccess.getNamespace()).thenReturn("default");
     when(clusterAccess.createDefaultClient()).thenReturn(kubernetesClient);
-    podNonNamespaceOp = createPodsInNamespaceMock(kubernetesClient);
+    podNonNamespaceOp = createPodsInNamespaceMock();
     when(podNonNamespaceOp.withName(anyString())).thenReturn(podOperations);
     kubernetesHelperMockedStatic = mockStatic(KubernetesHelper.class);
     kubernetesHelperMockedStatic.when(() -> KubernetesHelper.getNewestApplicationPodName(eq(kubernetesClient), any(), any())).thenReturn("test-pod");
@@ -72,15 +78,90 @@ class PodExecutorTest {
   @Test
   void executeCommandInPodKubernetesError() {
     // Given
-    when(podNonNamespaceOp.withName(anyString())).thenThrow(new KubernetesClientException("MockedError"));
-    // When
-    final WatchException result = assertThrows(WatchException.class,
-        () -> podExecutor.executeCommandInPod(Collections.emptySet(), "sh"));
-    // Then
-    assertThat(result).hasMessage("ExecutionfailedduetoaKubernetesClienterror:MockedError");
+    when(podNonNamespaceOp.withName(anyString())).thenThrow(new KubernetesClientException("Mocked Error"));
+    // When + Then
+    assertThatExceptionOfType(WatchException.class)
+        .isThrownBy(() -> podExecutor.executeCommandInPod(Collections.emptySet(), "sh"))
+        .withMessage("Execution failed due to a KubernetesClient error: Mocked Error");
   }
 
-  private NonNamespaceOperation<Pod, PodList, PodResource> createPodsInNamespaceMock(KubernetesClient client) {
+  @Test
+  void executeCommandInPodTimeout() {
+    // When + Then
+    assertThatExceptionOfType(WatchException.class)
+        .isThrownBy(() -> podExecutor.executeCommandInPod(Collections.emptySet(), "sh"))
+        .withMessage("Command execution timed out");
+  }
+
+  @Test
+  void uploadChangedFilesToPod_whenChangedFilesDirEmpty_thenDoNothing(@TempDir File tempDir) throws WatchException {
+    // Given
+    File changedFilesTarball = createChangedFilesDir(tempDir);
+
+    // When
+    podExecutor.uploadChangedFilesToPod(Collections.emptyList(), changedFilesTarball);
+
+    // Then
+    verify(kubernetesClient, times(0)).pods();
+  }
+
+  @Test
+  void uploadChangedFilesToPod_whenChangedFilesDirContainsFile_thenUploadFilesToPod(@TempDir File tempDir) throws WatchException, IOException {
+    // Given
+    File changedFilesTarball = createChangedFilesDir(tempDir);
+    File changedFilesDir = new File(tempDir, "changed-files");
+    File changedFile = new File(changedFilesDir, "ROOT.war");
+    boolean changedFileCreated = changedFile.createNewFile();
+    when(podOperations.file(anyString())).thenReturn(podOperations);
+    when(podOperations.upload(any(Path.class))).thenReturn(true);
+    ArgumentCaptor<Path> uploadedFilePathCaptor = ArgumentCaptor.forClass(Path.class);
+
+    // When
+    podExecutor.uploadChangedFilesToPod(Collections.emptyList(), changedFilesTarball);
+
+    // Then
+    assertThat(changedFileCreated).isTrue();
+    verify(podOperations).upload(uploadedFilePathCaptor.capture());
+    assertThat(uploadedFilePathCaptor.getValue()).isEqualTo(changedFile.toPath());
+  }
+
+  @Test
+  void uploadChangedFilesToPod_whenChangedFilesDirContainsDir_thenUploadDirToPod(@TempDir File tempDir) throws WatchException, IOException {
+    // Given
+    File changedFilesTarball = createChangedFilesDir(tempDir);
+    File changedFilesDir = new File(tempDir, "changed-files");
+    File changedDeploymentDir = new File(changedFilesDir, "/deployments");
+    boolean changedDeploymentDirCreated = changedDeploymentDir.mkdir();
+    when(podOperations.dir(anyString())).thenReturn(podOperations);
+    when(podOperations.upload(any(Path.class))).thenReturn(true);
+    ArgumentCaptor<Path> uploadedFilePathCaptor = ArgumentCaptor.forClass(Path.class);
+
+    // When
+    podExecutor.uploadChangedFilesToPod(Collections.emptyList(), changedFilesTarball);
+
+    // Then
+    assertThat(changedDeploymentDirCreated).isTrue();
+    verify(podOperations).upload(uploadedFilePathCaptor.capture());
+    assertThat(uploadedFilePathCaptor.getValue()).isEqualTo(changedDeploymentDir.toPath());
+  }
+
+  @Test
+  void uploadChangedFilesToPod_whenUploadFailed_thenThrowsException(@TempDir File tempDir) throws IOException, WatchException {
+    // Given
+    File changedFilesTarball = createChangedFilesDir(tempDir);
+    File changedFilesDir = new File(tempDir, "changed-files");
+    File changedFile = new File(changedFilesDir, "ROOT.war");
+    assertThat(changedFile.createNewFile()).isTrue();
+    when(podOperations.file(anyString())).thenReturn(podOperations);
+    when(podOperations.upload(any(Path.class))).thenThrow(new KubernetesClientException("Mock Error"));
+
+    // When
+    assertThatExceptionOfType(WatchException.class)
+        .isThrownBy(() -> podExecutor.uploadChangedFilesToPod(Collections.emptyList(), changedFilesTarball))
+        .withMessage("Error while uploading changed files archive to pod: Mock Error");
+  }
+
+  private NonNamespaceOperation<Pod, PodList, PodResource> createPodsInNamespaceMock() {
     MixedOperation<Pod, PodList, PodResource> podMixedOp = mock(MixedOperation.class);
     NonNamespaceOperation<Pod, PodList, PodResource> nonNamespaceOperation = mock(NonNamespaceOperation.class);
     when(kubernetesClient.pods()).thenReturn(podMixedOp);
@@ -88,24 +169,9 @@ class PodExecutorTest {
     return nonNamespaceOperation;
   }
 
-  @Test
-  void executeCommandInPodTimeout() {
-    // When
-    final WatchException result = assertThrows(WatchException.class,
-        () -> podExecutor.executeCommandInPod(Collections.emptySet(), "sh"));
-    // Then
-    assertThat(result).hasMessage("Command execution timed out");
-  }
-
-  private void createPodExecMock(NonNamespaceOperation<Pod, PodList, PodResource> podNonNamespaceOp) {
-    PodResource mockPodResource = mock(PodResource.class);
-    when(podNonNamespaceOp.withName(anyString())).thenReturn(mockPodResource);
-    when(mockPodResource.readingInput(any())).thenReturn(podOperations);
-    when(podOperations.writingOutput(any())).thenReturn(podOperations);
-    when(podOperations.writingError(any())).thenReturn(podOperations);
-    when(podOperations.writingErrorChannel(any())).thenReturn(podOperations);
-    when(podOperations.usingListener(any())).thenReturn(podOperations);
-    ExecWatch execWatch = mock(ExecWatch.class);
-    when(podOperations.exec(any())).thenReturn(execWatch);
+  private File createChangedFilesDir(File rootDir) {
+    File changedFilesDir = new File(rootDir, "changed-files");
+    assertThat(changedFilesDir.mkdir()).isTrue();
+    return new File(rootDir, "changed-files.tar");
   }
 }

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/PodExecutorTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/PodExecutorTest.java
@@ -99,29 +99,6 @@ class PodExecutorTest {
     assertThat(result).hasMessage("Command execution socket closed unexpectedly Closed by mock");
   }
 
-  @Test
-  void executeCommandInPodCommandFailure() {
-    // Given
-    listenableCloseWithCode(1000);
-    withErrorChannelResponse("{\"message\": \"Deserialized JSON message\"}");
-    // When
-    final WatchException result = assertThrows(WatchException.class,
-        () -> podExecutor.executeCommandInPod(Collections.emptySet(), "sh"));
-    // Then
-    assertThat(result).hasMessage("Command execution failed: Deserialized JSON message");
-  }
-
-  @Test
-  void executeCommandInPodCommandSuccess() throws Exception {
-    // Given
-    listenableCloseWithCode(1000);
-    withErrorChannelResponse("{\"status\": \"Success\"}");
-    // When
-    podExecutor.executeCommandInPod(Collections.emptySet(), "sh");
-    // Then
-    assertThat(podExecutor.getOutput()).isNotNull();
-  }
-
   private void listenableCloseWithCode(int code) {
     new MockUp<PodOperationsImpl>() {
       @Mock

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/PodExecutorTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/PodExecutorTest.java
@@ -13,70 +13,79 @@
  */
 package org.eclipse.jkube.watcher.standard;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.ExecWatch;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
+import org.eclipse.jkube.kit.build.service.docker.watch.WatchException;
+import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
 import java.time.Duration;
 import java.util.Collections;
 
-import org.eclipse.jkube.kit.build.service.docker.watch.WatchException;
-import org.eclipse.jkube.kit.config.access.ClusterAccess;
-
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.ExecListener;
-import io.fabric8.kubernetes.client.dsl.Execable;
-import io.fabric8.kubernetes.client.dsl.TtyExecable;
-import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.MockUp;
-import mockit.Mocked;
-import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unused")
 class PodExecutorTest {
-
-  @Mocked
-  private ClusterAccess clusterAccess;
-  @Mocked
   private PodOperationsImpl podOperations;
-  @Mocked
   private KubernetesClient kubernetesClient;
-
   private PodExecutor podExecutor;
+  private NonNamespaceOperation<Pod, PodList, PodResource> podNonNamespaceOp;
+  private MockedStatic<KubernetesHelper> kubernetesHelperMockedStatic;
 
   @BeforeEach
-  void setUp() {
-    // @formatter:off
-    new Expectations() {{
-      clusterAccess.getNamespace(); result = "default";
-      clusterAccess.createDefaultClient(); result = kubernetesClient;
-      kubernetesClient.pods().inNamespace(anyString).withName(anyString); result = podOperations;
-    }};
-    // @formatter:on
+  public void setUp() {
+    ClusterAccess clusterAccess = mock(ClusterAccess.class);
+    podOperations = mock(PodOperationsImpl.class);
+    kubernetesClient = mock(KubernetesClient.class);
+    when(clusterAccess.getNamespace()).thenReturn("default");
+    when(clusterAccess.createDefaultClient()).thenReturn(kubernetesClient);
+    podNonNamespaceOp = createPodsInNamespaceMock(kubernetesClient);
+    when(podNonNamespaceOp.withName(anyString())).thenReturn(podOperations);
+    kubernetesHelperMockedStatic = mockStatic(KubernetesHelper.class);
+    kubernetesHelperMockedStatic.when(() -> KubernetesHelper.getNewestApplicationPodName(eq(kubernetesClient), any(), any())).thenReturn("test-pod");
     podExecutor = new PodExecutor(clusterAccess, Duration.ZERO);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    kubernetesHelperMockedStatic.close();
   }
 
   @Test
   void executeCommandInPodKubernetesError() {
     // Given
-    // @formatter:off
-    new Expectations() {{
-      kubernetesClient.pods().inNamespace(anyString).withName(anyString); result = new KubernetesClientException("Mocked Error");
-    }};
-    // @formatter:on
+    when(podNonNamespaceOp.withName(anyString())).thenThrow(new KubernetesClientException("MockedError"));
     // When
     final WatchException result = assertThrows(WatchException.class,
         () -> podExecutor.executeCommandInPod(Collections.emptySet(), "sh"));
     // Then
-    assertThat(result).hasMessage("Execution failed due to a KubernetesClient error: Mocked Error");
+    assertThat(result).hasMessage("ExecutionfailedduetoaKubernetesClienterror:MockedError");
+  }
+
+  private NonNamespaceOperation<Pod, PodList, PodResource> createPodsInNamespaceMock(KubernetesClient client) {
+    MixedOperation<Pod, PodList, PodResource> podMixedOp = mock(MixedOperation.class);
+    NonNamespaceOperation<Pod, PodList, PodResource> nonNamespaceOperation = mock(NonNamespaceOperation.class);
+    when(kubernetesClient.pods()).thenReturn(podMixedOp);
+    when(podMixedOp.inNamespace(anyString())).thenReturn(nonNamespaceOperation);
+    return nonNamespaceOperation;
   }
 
   @Test
@@ -88,38 +97,15 @@ class PodExecutorTest {
     assertThat(result).hasMessage("Command execution timed out");
   }
 
-  @Test
-  void executeCommandInPodSocketError() {
-    // Given
-    listenableCloseWithCode(1337);
-    // When
-    final WatchException result = assertThrows(WatchException.class,
-        () -> podExecutor.executeCommandInPod(Collections.emptySet(), "sh"));
-    // Then
-    assertThat(result).hasMessage("Command execution socket closed unexpectedly Closed by mock");
-  }
-
-  private void listenableCloseWithCode(int code) {
-    new MockUp<PodOperationsImpl>() {
-      @Mock
-      public Execable usingListener(ExecListener execListener) {
-        execListener.onClose(code, "Closed by mock");
-        return podOperations;
-      }
-    };
-  }
-
-  private void withErrorChannelResponse(String response) {
-    new MockUp<PodOperationsImpl>() {
-      @Mock
-      public TtyExecable writingErrorChannel(OutputStream errChannel) {
-        try {
-          IOUtils.write(response, errChannel, StandardCharsets.UTF_8);
-        } catch (IOException e) {
-          fail("Couldn't fake ErrorChannelResponse");
-        }
-        return podOperations;
-      }
-    };
+  private void createPodExecMock(NonNamespaceOperation<Pod, PodList, PodResource> podNonNamespaceOp) {
+    PodResource mockPodResource = mock(PodResource.class);
+    when(podNonNamespaceOp.withName(anyString())).thenReturn(mockPodResource);
+    when(mockPodResource.readingInput(any())).thenReturn(podOperations);
+    when(podOperations.writingOutput(any())).thenReturn(podOperations);
+    when(podOperations.writingError(any())).thenReturn(podOperations);
+    when(podOperations.writingErrorChannel(any())).thenReturn(podOperations);
+    when(podOperations.usingListener(any())).thenReturn(podOperations);
+    ExecWatch execWatch = mock(ExecWatch.class);
+    when(podOperations.exec(any())).thenReturn(execWatch);
   }
 }

--- a/jkube-kit/watcher/standard/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/jkube-kit/watcher/standard/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Description

Fixes #1704 #1606

+ Use Fabric8 Kubernetes Client Pod upload API to upload changed files
  instead of manually copying via exec
+ With this fix all watch tests in JettyK8sWatchITCase were passing ( https://github.com/jkubeio/jkube-integration-tests/pull/187 )

Signed-off-by: Rohan Kumar <rohaan@redhat.com>

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
