### PR TITLE
Semver compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.10-SNAPSHOT
+* Fix #1860: Add compatibility with SemVer versions
 
 ### 1.9.1 (2022-09-14)
 * Fix #1747: Apply service doesn't attempt to create OpenShift Projects in Kubernetes clusters

--- a/gradle-plugin/doc/src/main/asciidoc/inc/image/_naming.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/image/_naming.adoc
@@ -1,5 +1,8 @@
 [[image-name]]
-When specifying the image name in the configuration with the `name` field you can use several placeholders which are replaced during runtime by this plugin. In addition you can use regular Gradle properties which are resolved by Gradle itself.
+When specifying the image name in the configuration with the `<name>` field, then you can use several placeholders.
+These placeholders are replaced during the execution by this plugin.
+In addition, you can use regular Gradle properties.
+These properties are resolved by Gradle itself.
 
 .Image Names
 [cols="1,5"]
@@ -7,17 +10,33 @@ When specifying the image name in the configuration with the `name` field you ca
 | Placeholder | Description
 
 | *%g*
-| The last part of the Gradle group name, sanitized so that it can be used as username on GitHub. Only the part after the last dot is used. E.g. for a group id `org.eclipse.jkube` this placeholder would insert `jkube`
+| The last part of the Gradle group name.
+The name gets sanitized, so that it can be used as username on GitHub.
+Only the part after the last dot is used.
+For example, given the group id `org.eclipse.jkube`, this placeholder would insert `jkube`.
 
 | *%a*
-| A sanitized version of the artefact id so that it can be used as part of an Docker image name. I.e. it is converted to all lower case (as required by Docker)
+| A sanitized version of the artefact id, so that it can be used as part of a Docker image name.
+This means primarily, that it is converted to all lower case (as required by Docker).
 
 | *%v*
-| The project version.
+| A sanitized version of the project version. Replaces `+` with `-` in `${project.version}` to comply with the Docker tag convention.
+(A different replacement symbol can be defined by setting the `jkube.image.tag.semver_plus_substitution` property.)
+For example, the version '1.2.3b' becomes the exact same Docker tag, '1.2.3b'.
+But '1.2.3+internal' becomes the `1.2.3-internal` Docker tag.
 
 | *%l*
-| If the project version ends with `-SNAPSHOT` then this placeholder is `latest`, otherwise its the full version (same as `%v`)
+| If the https://semver.org/spec/v2.0.0.html#spec-item-9[pre-release part] of the project version ends with `-SNAPSHOT`, then this placeholder resolves to `latest`.
+Otherwise, it's the same as `%v`.
+
+If the `${project.version}` contains a https://semver.org/spec/v2.0.0.html#spec-item-10[build metadata part] (i.e. everything after the `+`), then the `+` is substituted and the rest is appended.
+For example, the project version `1.2.3-SNAPSHOT+internal` becomes the `latest-internal` Docker tag.
 
 | *%t*
-| If the project version ends with `-SNAPSHOT` this placeholder resolves to `snapshot-<timestamp>` where timestamp has the date format `yyMMdd-HHmmss-SSSS` (eg `snapshot-`). This feature is especially useful during development in oder to avoid conflicts when images are to be updated which are still in use. You need to take care yourself of cleaning up old images afterwards, though.
+| If the project version ends with `-SNAPSHOT`, this placeholder resolves to `snapshot-<timestamp>` where timestamp has the date format `yyMMdd-HHmmss-SSSS` (eg `snapshot-`).
+This feature is especially useful during development in oder to avoid conflicts when images are to be updated which are still in use.
+You need to take care yourself of cleaning up old images afterwards, though.
+
+If the `${project.version}` contains a https://semver.org/spec/v2.0.0.html#spec-item-10[build metadata part] (i.e. everything after the `+`), then the `+` is substituted and the rest is appended.
+For example, the project version `1.2.3-SNAPSHOT+internal` becomes the `snapshot-221018-113000-0000-internal` Docker tag.
 |===

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/image/_naming.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/image/_naming.adoc
@@ -1,5 +1,8 @@
 [[image-name]]
-When specifying the image name in the configuration with the `<name>` field you can use several placeholders which are replaced during runtime by this plugin. In addition you can use regular Maven properties which are resolved by Maven itself.
+When specifying the image name in the configuration with the `<name>` field, then you can use several placeholders.
+These placeholders are replaced during the execution by this plugin.
+In addition, you can use regular Maven properties.
+These properties are resolved by Maven itself.
 
 .Image Names
 [cols="1,5"]
@@ -7,18 +10,33 @@ When specifying the image name in the configuration with the `<name>` field you 
 | Placeholder | Description
 
 | *%g*
-| The last part of the Maven group name, sanitized so that it can be used as username on GitHub. Only the part after the last dot is used. E.g. for a group id `org.eclipse.jkube` this placeholder would insert `jkube`
+| The last part of the Maven group name.
+The name gets sanitized, so that it can be used as username on GitHub.
+Only the part after the last dot is used.
+For example, given the group id `org.eclipse.jkube`, this placeholder would insert `jkube`.
 
 | *%a*
-| A sanitized version of the artefact id so that it can be used as part of an Docker image name. I.e. it is converted to all lower case (as required by Docker)
+| A sanitized version of the artefact id, so that it can be used as part of a Docker image name.
+This means primarily, that it is converted to all lower case (as required by Docker).
 
 | *%v*
-| The project version. Synonym to `${project.version}`
+| A sanitized version of the project version. Replaces `+` with `-` in `${project.version}` to comply with the Docker tag convention.
+(A different replacement symbol can be defined by setting the `jkube.image.tag.semver_plus_substitution` property.)
+For example, the version '1.2.3b' becomes the exact same Docker tag, '1.2.3b'.
+But '1.2.3+internal' becomes the `1.2.3-internal` Docker tag.
 
 | *%l*
-| If the project version ends with `-SNAPSHOT` then this placeholder is `latest`, otherwise its the full version (same as `%v`)
+| If the https://semver.org/spec/v2.0.0.html#spec-item-9[pre-release part] of the project version ends with `-SNAPSHOT`, then this placeholder resolves to `latest`.
+Otherwise, it's the same as `%v`.
+
+If the `${project.version}` contains a https://semver.org/spec/v2.0.0.html#spec-item-10[build metadata part] (i.e. everything after the `+`), then the `+` is substituted and the rest is appended.
+For example, the project version `1.2.3-SNAPSHOT+internal` becomes the `latest-internal` Docker tag.
 
 | *%t*
-| If the project version ends with `-SNAPSHOT` this placeholder resolves to `snapshot-<timestamp>` where timestamp has the date format `yyMMdd-HHmmss-SSSS` (eg `snapshot-`). This feature is especially useful during development in oder to avoid conflicts when images are to be updated which are still in use. You need to take care yourself of cleaning up old images afterwards, though.
-|===
+| If the project version ends with `-SNAPSHOT`, this placeholder resolves to `snapshot-<timestamp>` where timestamp has the date format `yyMMdd-HHmmss-SSSS` (eg `snapshot-`).
+This feature is especially useful during development in oder to avoid conflicts when images are to be updated which are still in use.
+You need to take care yourself of cleaning up old images afterwards, though.
 
+If the `${project.version}` contains a https://semver.org/spec/v2.0.0.html#spec-item-10[build metadata part] (i.e. everything after the `+`), then the `+` is substituted and the rest is appended.
+For example, the project version `1.2.3-SNAPSHOT+internal` becomes the `snapshot-221018-113000-0000-internal` Docker tag.
+|===


### PR DESCRIPTION
## Description

Fixes `n/a`

This pull request deals with the fact that a Docker image tag is not allowed to contain a `+`. When working with SemVer, a `+` is used [to indicate the beginning of the build metadata section][build-metadata].

When `project.version` contains such build metadata, then currently the build fails:

```log
[ERROR] k8s: Failed to execute the build [Given Docker name 'component/mobile-search:4.3.3-SNAPSHOT+st1666023054591-b24-7ca68455' is invalid:

   * tag part '4.3.3-SNAPSHOT+st1666023054591-b24-7ca68455' doesn't match allowed pattern '^[\w][\w.-]{0,127}$'

See http://bit.ly/docker_image_fmt for more details]
```

In this PR, I made two changes:

- The `-SNAPSHOT` [is correctly detected as pre-release section][pre-release], even if there is [build metadata][build-metadata] following it.
- The `+` sign is replaced by `-` to bring the whole tag in line with Docker's naming conventions. This is configurable using the new property `jkube.image.tag.semver_plus_substitution`.

[pre-release]: https://semver.org/#spec-item-9
[build-metadata]: https://semver.org/#spec-item-10

## Type of change

<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist

 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
