### PR TITLE
fix(docker-build): failing container build with Podman should fail properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.10-SNAPSHOT
+* Fix #1684: Podman builds with errors are correctly processed and reported 
 
 ### 1.9.1 (2022-09-14)
 * Fix #1747: Apply service doesn't attempt to create OpenShift Projects in Kubernetes clusters

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/chunked/EntityStreamReaderUtil.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/chunked/EntityStreamReaderUtil.java
@@ -33,7 +33,7 @@ public class EntityStreamReaderUtil {
         try(JsonReader json = new JsonReader(new InputStreamReader(stream))) {
             json.setLenient(true);
             while (json.peek() != JsonToken.END_DOCUMENT) {
-            	JsonObject jsonObject = JsonParser.parseReader(json).getAsJsonObject();
+                JsonObject jsonObject = JsonParser.parseReader(json).getAsJsonObject();
                 handler.process(jsonObject);
             }
         } finally {

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/HcChunkedResponseHandlerWrapperTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/HcChunkedResponseHandlerWrapperTest.java
@@ -13,75 +13,105 @@
  */
 package org.eclipse.jkube.kit.build.service.docker.access.hc;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.google.gson.JsonObject;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpResponse;
+import org.eclipse.jkube.kit.build.service.docker.access.chunked.EntityStreamReaderUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import org.eclipse.jkube.kit.build.service.docker.access.chunked.EntityStreamReaderUtil;
-
-import mockit.Expectations;
-import mockit.Mocked;
-import mockit.Verifications;
-import org.apache.http.Header;
-import org.apache.http.HttpResponse;
-import org.apache.http.message.BasicHeader;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 @SuppressWarnings("unused")
 class HcChunkedResponseHandlerWrapperTest {
 
-  @Mocked
-  private EntityStreamReaderUtil.JsonEntityResponseHandler handler;
-  @Mocked
-  private HttpResponse response;
-  @Mocked
-  private EntityStreamReaderUtil entityStreamReaderUtil;
-
   private Header[] headers;
+  private TestJsonEntityResponseHandler handler;
   private HcChunkedResponseHandlerWrapper hcChunkedResponseHandlerWrapper;
 
   @BeforeEach
   void setUp() {
+    handler = new TestJsonEntityResponseHandler();
     hcChunkedResponseHandlerWrapper = new HcChunkedResponseHandlerWrapper(handler);
   }
 
   @Test
-  void handleResponseWithJsonResponse() throws IOException {
-    givenResponseHeaders(new BasicHeader("ConTenT-Type", "application/json; charset=UTF-8"));
+  void handleResponseWithInvalidStatusAndJsonBody() throws IOException {
+    final HttpResponse response = response(400, "WRONG!!",
+      new StringEntity("{}"));
     hcChunkedResponseHandlerWrapper.handleResponse(response);
-    verifyProcessJsonStream(1);
+    // TODO: Maybe we should propagate the status in some way
+    assertThat(handler.processedObject).isNotNull();
   }
 
   @Test
-  void handleResponseWithTextPlainResponse() throws IOException {
-    givenResponseHeaders(new BasicHeader("Content-Type", "text/plain"));
-    assertThrows(IllegalArgumentException.class, () -> {
-      hcChunkedResponseHandlerWrapper.handleResponse(response);
-    });
+  void handleResponseWithJsonContentTypeAndJsonBody() throws IOException {
+    final HttpResponse response = response(200, "OK",
+      new StringEntity("{\"field\":\"value\"}"),
+      new BasicHeader("ConTenT-Type", "application/json; charset=UTF-8"));
+    hcChunkedResponseHandlerWrapper.handleResponse(response);
+    assertThat(handler.processedObject)
+      .returns("value", jo -> jo.get("field").getAsString());
+  }
+  @Test
+  void handleResponseWithJsonContentTypeAndInvalidBody() throws IOException {
+    final HttpResponse response = response(200, "OK",
+      new StringEntity("This is not a JSON string"),
+      new BasicHeader("ConTenT-Type", "application/json"));
+    assertThatIllegalStateException()
+      .isThrownBy(() -> hcChunkedResponseHandlerWrapper.handleResponse(response))
+      .withMessageStartingWith("Not a JSON Object:");
   }
 
   @Test
-  void handleResponseWithNoContentTypeAsForPodman() throws IOException {
-    givenResponseHeaders();
+  void handleResponseWithTextPlainAndJsonBody() throws IOException {
+    final HttpResponse response = response(200, "OK",
+      new StringEntity("{\"field\":\"value\"}"),
+      new BasicHeader("ConTenT-Type", "text/plain"));
     hcChunkedResponseHandlerWrapper.handleResponse(response);
-    verifyProcessJsonStream(1);
+    assertThat(handler.processedObject)
+      .returns("value", jo -> jo.get("field").getAsString());
   }
 
-  private void givenResponseHeaders(Header... headers) {
-    // @formatter:off
-    new Expectations() {{
-      response.getAllHeaders(); result = headers;
-    }};
-    // @formatter:on
+  @Test
+  void handleResponseWithNoContentTypeAndJsonBody() throws IOException {
+    final HttpResponse response = response(200, "OK",
+      new StringEntity("{\"field\":\"value\"}"));
+    hcChunkedResponseHandlerWrapper.handleResponse(response);
+    assertThat(handler.processedObject)
+      .returns("value", jo -> jo.get("field").getAsString());
   }
 
-  @SuppressWarnings("AccessStaticViaInstance")
-  private void verifyProcessJsonStream(int timesCalled) throws IOException {
-    // @formatter:off
-    new Verifications() {{
-      entityStreamReaderUtil.processJsonStream(handler, response.getEntity().getContent()); times = timesCalled;
-    }};
-    // @formatter:on
+  private static HttpResponse response(int code, String reason, HttpEntity entity, Header... headers) {
+    final BasicHttpResponse response = new BasicHttpResponse(
+      new ProtocolVersion("HTTP", 1, 1), code, reason);
+    response.setEntity(entity);
+    response.setHeaders(headers);
+    return response;
+  }
+
+  private static final class TestJsonEntityResponseHandler implements EntityStreamReaderUtil.JsonEntityResponseHandler {
+
+    private JsonObject processedObject;
+    @Override
+    public void process(JsonObject toProcess) {
+      processedObject = toProcess;
+    }
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void stop() {
+    }
   }
 }

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/HcChunkedResponseHandlerWrapperTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/access/hc/HcChunkedResponseHandlerWrapperTest.java
@@ -13,6 +13,8 @@
  */
 package org.eclipse.jkube.kit.build.service.docker.access.hc;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 
 import org.eclipse.jkube.kit.build.service.docker.access.chunked.EntityStreamReaderUtil;
@@ -54,15 +56,16 @@ class HcChunkedResponseHandlerWrapperTest {
   @Test
   void handleResponseWithTextPlainResponse() throws IOException {
     givenResponseHeaders(new BasicHeader("Content-Type", "text/plain"));
-    hcChunkedResponseHandlerWrapper.handleResponse(response);
-    verifyProcessJsonStream(0);
+    assertThrows(IllegalArgumentException.class, () -> {
+      hcChunkedResponseHandlerWrapper.handleResponse(response);
+    });
   }
 
   @Test
-  void handleResponseWithNoContentType() throws IOException {
+  void handleResponseWithNoContentTypeAsForPodman() throws IOException {
     givenResponseHeaders();
     hcChunkedResponseHandlerWrapper.handleResponse(response);
-    verifyProcessJsonStream(0);
+    verifyProcessJsonStream(1);
   }
 
   private void givenResponseHeaders(Header... headers) {


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes https://github.com/eclipse/jkube/issues/1684


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
