### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
@@ -125,7 +125,7 @@ class DockerFileUtilTest {
     @Test
     void createSimpleDockerfileConfig() throws IOException {
         // Given
-        File dockerFile = File.createTempFile("Dockerfile", "-test");
+        File dockerFile = Files.createTempFile("Dockerfile", "-test").toFile();
         // When
         ImageConfiguration imageConfiguration1 = DockerFileUtil.createSimpleDockerfileConfig(dockerFile, null);
         ImageConfiguration imageConfiguration2 = DockerFileUtil.createSimpleDockerfileConfig(dockerFile, "someImage:0.0.1");
@@ -148,7 +148,7 @@ class DockerFileUtilTest {
         ImageConfiguration imageConfiguration = ImageConfiguration.builder()
                 .name("test-image")
                 .build();
-        File dockerFile = File.createTempFile("Dockerfile", "-test");
+        File dockerFile = Files.createTempFile("Dockerfile", "-test").toFile();
 
         // When
         ImageConfiguration result = DockerFileUtil.addSimpleDockerfileConfig(imageConfiguration, dockerFile);

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/PathTestUtil.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/PathTestUtil.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.kit.build.api.helper;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -143,7 +144,7 @@ public class PathTestUtil {
      */
     public static File createTmpFile(String nameHint, TMP_FILE_PRESERVE_MODE preserveMode) {
         try {
-            File tmpFile = File.createTempFile(nameHint, ".tmp");
+            File tmpFile = Files.createTempFile(nameHint, ".tmp").toFile();
             assertThat(tmpFile).isAbsolute();
             if (preserveMode != null) {
                 switch (preserveMode) {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileSetUtilsTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/AssemblyFileSetUtilsTest.java
@@ -43,8 +43,8 @@ class AssemblyFileSetUtilsTest {
   void calculateFilePermissionsFileWithNoFileMode() throws Exception {
     // Given
     final AssemblyFileSet afs = AssemblyFileSet.builder().build();
-    final File sourceFile = File.createTempFile("source-file", "txt", temp);
-    final File aFile = File.createTempFile("just-a-file", "txt", temp);
+    final File sourceFile = Files.createTempFile(temp.toPath(), "source-file", "txt").toFile();
+    final File aFile = Files.createTempFile(temp.toPath(), "just-a-file", "txt").toFile();
     // When
     final List<AssemblyFileEntry> result = calculateFilePermissions(sourceFile, aFile, afs);
     // Then
@@ -55,8 +55,8 @@ class AssemblyFileSetUtilsTest {
   void calculateFilePermissionsFileWithFileMode() throws Exception {
     // Given
     final AssemblyFileSet afs = AssemblyFileSet.builder().fileMode("0777").build();
-    final File sourceFile = File.createTempFile("source-file", "txt", temp);
-    final File aFile = File.createTempFile("just-a-file", "txt", temp);
+    final File sourceFile = Files.createTempFile(temp.toPath(), "source-file", "txt").toFile();
+    final File aFile = Files.createTempFile(temp.toPath(), "just-a-file", "txt").toFile();
     // When
     final List<AssemblyFileEntry> result = calculateFilePermissions(sourceFile, aFile, afs);
     // Then

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiverTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/archive/JKubeTarArchiverTest.java
@@ -58,7 +58,7 @@ class JKubeTarArchiverTest {
   @Test
   void createTarBallOfDirectory_defaultCompression_createsTar() throws Exception {
     // Given
-    final File outputFile = File.createTempFile("target", "noExtension", temporaryFolder);
+    final File outputFile = Files.createTempFile(temporaryFolder.toPath(), "target", "noExtension").toFile();
     // When
     final File result = JKubeTarArchiver.createTarBallOfDirectory(outputFile, toCompress, ArchiveCompression.none);
     // Then
@@ -77,7 +77,7 @@ class JKubeTarArchiverTest {
   @Test
   void createTarBallOfDirectory_gzipCompression_createsTar() throws Exception {
     // Given
-    final File outputFile = File.createTempFile("target", "tar.gzip", temporaryFolder);
+    final File outputFile = Files.createTempFile(temporaryFolder.toPath(), "target", "tar.gzip").toFile();
     // When
     final File result = JKubeTarArchiver.createTarBallOfDirectory(outputFile, toCompress, ArchiveCompression.gzip);
     // Then
@@ -96,7 +96,7 @@ class JKubeTarArchiverTest {
   @Test
   void createTarBallOfDirectory_bzip2Compression_createsTar() throws Exception {
     // Given
-    final File outputFile = File.createTempFile("target", "tar.bz2", temporaryFolder);
+    final File outputFile = Files.createTempFile(temporaryFolder.toPath(), "target", "tar.bz2").toFile();
     // When
     final File result = JKubeTarArchiver.createTarBallOfDirectory(outputFile, toCompress, ArchiveCompression.bzip2);
     // Then
@@ -115,7 +115,7 @@ class JKubeTarArchiverTest {
   @Test
   void createTarBallOfDirectory_defaultCompressionWithEntryCustomizer_createsCustomizedTar() throws Exception {
     // Given
-    final File outputFile = File.createTempFile("target", "tar", temporaryFolder);
+    final File outputFile = Files.createTempFile(temporaryFolder.toPath(), "target", "tar").toFile();
     final Consumer<TarArchiveEntry> prependDirectory = tae ->  tae.setName("directory/" + tae.getName());
     // When
     final File result = JKubeTarArchiver.createTarBall(outputFile, toCompress,
@@ -137,7 +137,7 @@ class JKubeTarArchiverTest {
   @Test
   void createTarBallOfDirectory_defaultCompressionWithTarCustomizer_createsCustomizedTar() throws Exception {
     // Given
-    final File outputFile = File.createTempFile("target", "tar", temporaryFolder);
+    final File outputFile = Files.createTempFile(temporaryFolder.toPath(), "target", "tar").toFile();
     final Consumer<TarArchiveOutputStream> truncateFilenames = tae ->  tae.setLongFileMode(TarArchiveOutputStream.LONGFILE_TRUNCATE);
     // When
     final File result = JKubeTarArchiver.createTarBall(outputFile, toCompress,
@@ -160,7 +160,7 @@ class JKubeTarArchiverTest {
   void createTarBallOfDirectory_defaultCompression_createsTarWithCorrectEntrySizeAndModeForDirectories() throws Exception {
     // Given
     final int defaultDirMode = Integer.parseInt("040755", 8); // 16877
-    final File outputFile = File.createTempFile("target", "noExtension", temporaryFolder);
+    final File outputFile = Files.createTempFile(temporaryFolder.toPath(), "target", "noExtension").toFile();
     // When
     final File result = JKubeTarArchiver.createTarBallOfDirectory(outputFile, toCompress, ArchiveCompression.none);
     // Then
@@ -181,7 +181,7 @@ class JKubeTarArchiverTest {
   void createTarBallOfDirectory_defaultCompression_createsTarWithCorrectEntrySizeAndModeForFiles() throws Exception {
     // Given
     final int defaultFileMode = Integer.parseInt("0100644", 8); // 33188
-    final File outputFile = File.createTempFile("target", "noExtension", temporaryFolder);
+    final File outputFile = Files.createTempFile(temporaryFolder.toPath(), "target", "noExtension").toFile();
     // When
     final File result = JKubeTarArchiver.createTarBallOfDirectory(outputFile, toCompress, ArchiveCompression.none);
     // Then
@@ -202,7 +202,7 @@ class JKubeTarArchiverTest {
   void createTarBall_defaultCompressionWithFileModes_createsTarWithCorrectEntrySizeAndModeForFiles() throws Exception {
     // Given
     final int defaultDirMode = Integer.parseInt("040755", 8); // 16877
-    final File outputFile = File.createTempFile("target", "noExtension", temporaryFolder);
+    final File outputFile = Files.createTempFile(temporaryFolder.toPath(), "target", "noExtension").toFile();
     Map<File, String> fileModeMap = new HashMap<>();
     fileModeMap.put(new File(toCompress, "nested"), "040755");
     fileModeMap.put(new File(toCompress, "nested/directory"), "040755");

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/ImageStreamServiceTest.java
@@ -73,7 +73,7 @@ class ImageStreamServiceTest {
         final ImageStream lookedUpIs = lookupImageStream("ab12cd");
         setupClientMock(lookedUpIs,"default", "test");
         ImageName name = new ImageName("test:1.0");
-        File target = File.createTempFile("ImageStreamServiceTest",".yml", temporaryFolder);
+        File target = Files.createTempFile(temporaryFolder.toPath(), "ImageStreamServiceTest", ".yml").toFile();
         service.appendImageStreamResource(name, target);
         assertThat(target).exists();
 

--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/generator/SpringBootGenerator.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/generator/SpringBootGenerator.java
@@ -19,6 +19,7 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -167,7 +168,7 @@ public class SpringBootGenerator extends JavaExecGenerator {
     }
 
     private void copyFilesToFatJar(List<File> libs, List<File> classes, File target) throws IOException {
-        File tmpZip = File.createTempFile(target.getName(), null);
+        File tmpZip = Files.createTempFile(target.getName(), null).toFile();
         tmpZip.delete();
 
         // Using Apache commons rename, because renameTo has issues across file systems

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmConfigTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmConfigTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.kit.resource.helm;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -143,7 +144,7 @@ class HelmConfigTest {
   @Test
   void createHelmConfig() throws IOException {
     // Given
-    File file = File.createTempFile("test", ".tmp");
+    File file = Files.createTempFile("test", ".tmp").toFile();
     file.deleteOnExit();
 
     HelmConfig helmConfig = new HelmConfig();

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmUploaderTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmUploaderTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.nio.file.Files;
 
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.junit.jupiter.api.AfterEach;
@@ -75,7 +76,7 @@ class HelmUploaderTest {
     HelmRepository helmRepository = mock(HelmRepository.class, RETURNS_DEEP_STUBS);
     HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
     // Given
-    File file = File.createTempFile("test", "tmp", temporaryFolder);
+    File file = Files.createTempFile(temporaryFolder.toPath(), "test", "tmp").toFile();
     when(helmRepository.getType().createConnection(any(File.class), eq(helmRepository))).thenReturn(httpURLConnection);
     when(httpURLConnection.getResponseCode()).thenReturn(500);
     when(httpURLConnection.getErrorStream()).thenReturn(new ByteArrayInputStream("Server error in ES".getBytes()));
@@ -95,7 +96,7 @@ class HelmUploaderTest {
     // Given
     HelmRepository helmRepository = mock(HelmRepository.class, RETURNS_DEEP_STUBS);
     HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
-    File file = File.createTempFile("test", "tmp", temporaryFolder);
+    File file = Files.createTempFile(temporaryFolder.toPath(), "test", "tmp").toFile();
     when(helmRepository.getType().createConnection(any(File.class), eq(helmRepository))).thenReturn(httpURLConnection);
     when(httpURLConnection.getResponseCode()).thenReturn(500);
     when(httpURLConnection.getErrorStream()).thenReturn(null);
@@ -114,7 +115,7 @@ class HelmUploaderTest {
     // Given
     HelmRepository helmRepository = mock(HelmRepository.class, RETURNS_DEEP_STUBS);
     HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
-    File file = File.createTempFile("test", "tmp", temporaryFolder);
+    File file = Files.createTempFile(temporaryFolder.toPath(), "test", "tmp").toFile();
     when(helmRepository.getType().createConnection(any(File.class), eq(helmRepository))).thenReturn(httpURLConnection);
     when(httpURLConnection.getResponseCode()).thenReturn(500);
     when(httpURLConnection.getErrorStream()).thenReturn(null);
@@ -133,7 +134,7 @@ class HelmUploaderTest {
     // Given
     HelmRepository helmRepository = mock(HelmRepository.class, RETURNS_DEEP_STUBS);
     HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
-    File file = File.createTempFile("test", "tmp", temporaryFolder);
+    File file = Files.createTempFile(temporaryFolder.toPath(), "test", "tmp").toFile();
     when(helmRepository.getType().createConnection(any(File.class), eq(helmRepository))).thenReturn(httpURLConnection);
     when(httpURLConnection.getResponseCode()).thenReturn(201);
     when(httpURLConnection.getInputStream()).thenReturn(null);

--- a/jkube-kit/resource/service/src/test/java/org/eclipse/jkube/kit/resource/service/WriteUtilTest.java
+++ b/jkube-kit/resource/service/src/test/java/org/eclipse/jkube/kit/resource/service/WriteUtilTest.java
@@ -63,7 +63,7 @@ class WriteUtilTest {
   @Test
   void writeResource() throws IOException {
     // Given
-    final File baton = File.createTempFile("junit", "ext", temporaryFolder);
+    final File baton = Files.createTempFile(temporaryFolder.toPath(), "junit", "ext").toFile();
     mockResourceUtilSave(baton);
     // When
     final File result = WriteUtil.writeResource(null, null, null);

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/LogMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/LogMojoTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.maven.plugin.mojo.develop;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -65,7 +66,7 @@ class LogMojoTest {
         });
     clusterAccessMockedConstruction = mockConstruction(ClusterAccess.class);
     podLogServiceMockedConstruction = mockConstruction(PodLogService.class);
-    kubernetesManifestFile = File.createTempFile("kubernetes", ".yml", temporaryFolder);
+    kubernetesManifestFile = Files.createTempFile(temporaryFolder.toPath(), "kubernetes", ".yml").toFile();
     mavenProject = mock(MavenProject.class);
     when(mavenProject.getProperties()).thenReturn(new Properties());
     // @formatter:off

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojoTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.maven.plugin.mojo.develop;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Properties;
 
 import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
@@ -62,7 +63,7 @@ class WatchMojoTest {
 
   @BeforeEach
   void setUp(@TempDir File temporaryFolder) throws IOException {
-    kubernetesManifestFile =  File.createTempFile("kubernetes", ".yml", temporaryFolder);
+    kubernetesManifestFile =  Files.createTempFile(temporaryFolder.toPath(), "kubernetes", ".yml").toFile();
     mockedJKubeServiceHub = mock(JKubeServiceHub.class);
     mavenProject = mock(MavenProject.class);
     mavenSettings = mock(Settings.class);

--- a/openshift-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/OpenshiftUndeployMojoTest.java
+++ b/openshift-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/OpenshiftUndeployMojoTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,9 +40,9 @@ class OpenshiftUndeployMojoTest {
   @BeforeEach
   void setUp(@TempDir File temporaryFolder) throws IOException {
     mockServiceHub = mock(JKubeServiceHub.class, RETURNS_DEEP_STUBS);
-    kubernetesManifestFile = File.createTempFile("junit", "ext", temporaryFolder);
-    openShiftManifestFile = File.createTempFile("junit", "ext", temporaryFolder);
-    openShiftISManifestFile = File.createTempFile("junit", "ext", temporaryFolder);
+    kubernetesManifestFile = Files.createTempFile(temporaryFolder.toPath(), "junit", "ext").toFile();
+    openShiftManifestFile = Files.createTempFile(temporaryFolder.toPath(), "junit", "ext").toFile();
+    openShiftISManifestFile = Files.createTempFile(temporaryFolder.toPath(), "junit", "ext").toFile();
     // @formatter:off
     undeployMojo = new OpenshiftUndeployMojo() {{
       kubernetesManifest = kubernetesManifestFile;


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
