### PR TITLE
fix (jkube-kit/config/service) : Close LocalPortForward in PortForwardServicePortOrderTest (#1940)

### DIFF
--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServicePortOrderTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServicePortOrderTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.kit.config.service;
 
+import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
@@ -49,9 +50,10 @@ class PortForwardServicePortOrderTest {
         request.complete(r);
         return "";
       }).always();
-    PortForwardService.forwardPortAsync(kubernetesClient, "foo-pod", containerPort, localPort);
-    // When
-    try (final Socket ignored = new Socket(InetAddress.getLocalHost(), localPort)) {
+    try (LocalPortForward localPortForward = PortForwardService.forwardPortAsync(kubernetesClient, "foo-pod", containerPort, localPort);
+         // When
+         final Socket ignored = new Socket(InetAddress.getLocalHost(), localPort)
+    ) {
       // The socket connection triggers the KubernetesClient request to the k8s portforward endpoint
     }
     // Then


### PR DESCRIPTION
## Description

Fixes #1940
PortForwardServicePortOrderTest and DebugServiceTest both seem to be using port forward in their tests.

On Eclipse Jenkins, somehow PortForwardServicePortOrderTest's portforward doesn't seem to be getting closed even after test execution which seems to fail portforward in DebugServiceTest where port seems unavailable for local port forward.

I've tested this on https://ci.eclipse.org/jkube/job/downloads-eclipse-release-job/ by pointing this pipeline to my branch.

Once this PR and #1941 get merged, I can enable tests in the main release pipeline on Jenkins




## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
