### PR TITLE
fix (jkube-kit/enricher) : Add hint for using `jkube.domain` if `createExternalUrls` is used without domain (#1439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.11-SNAPSHOT
+* Fix #1439: Add hint to use jkube.domain if createExternalUrls is used without domain
 * Fix #1459: Route Generation should support `8443` as default web port
 * Fix #1546: Migrate to JUnit5 testing framework
 * Fix #1858: Properties in image name not replaced


### PR DESCRIPTION
## Description

Fixes #1439

Currently, value for IngressRule's `.host` field depends either on `HOST` enricher configuration or `jkube.domain` configuration. If none of these options are provided, we set `.spec.defaultBackend`.

+ Add a hint to suggest specifying `jkube.domain` in case no value for host is found.

This hint will appear if user forgets to specify host via XML/Groovy DSL configuration or `jkube.domain`/`jkube.enricher.jkube-ingress.host` properties. IngressEnricher doesn't do anything when an Ingress fragment is provided. I'm not sure whether we should check fragment too.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>




## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
