### PR TITLE
test : Fix flaky PortForwardServicePortOrderTest (#2030)

### DIFF
--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServicePortOrderTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/PortForwardServicePortOrderTest.java
@@ -38,7 +38,6 @@ class PortForwardServicePortOrderTest {
   private NamespacedKubernetesClient kubernetesClient;
   private KubernetesMockServer mockServer;
 
-  @SuppressWarnings("EmptyTryBlock")
   @DisplayName("portForward")
   @ParameterizedTest(name = "with containerPort {0} and localPort {1} should perform HTTP request to {0}")
   @MethodSource("ports")
@@ -55,9 +54,9 @@ class PortForwardServicePortOrderTest {
          final Socket ignored = new Socket(InetAddress.getLocalHost(), localPort)
     ) {
       // The socket connection triggers the KubernetesClient request to the k8s portforward endpoint
+      // Then
+      assertThat(request).succeedsWithin(10, TimeUnit.SECONDS);
     }
-    // Then
-    assertThat(request).succeedsWithin(10, TimeUnit.SECONDS);
   }
 
   static Stream<Arguments> ports() {


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #2030

Move CompletableFuture assertion within try with resources block to ensure that LocalPortForward closes after CompletableFuture is satisfied.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>





## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
