### PR TITLE
doc (jkube-kit/doc) : Remove deprecated fields from Controller Configuration table (#2057)

### DIFF
--- a/jkube-kit/doc/src/main/asciidoc/inc/resource-generation/_controller_resource_generation.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/resource-generation/_controller_resource_generation.adoc
@@ -39,53 +39,6 @@ endif::[]
 | <<generated-controller-resource-configuration, `controller`>>
 | Configuration element for changing various aspects of generated Controller.
 
-| `env`
-| _Deprecated: Use same field inside <<generated-controller-resource-configuration, `controller`>>_
-
-Environment variables which will be added to containers in Pod template spec.
-
-| <<volume-resource-configuration, `volumes`>>
-| _Deprecated: Use same field inside <<generated-controller-resource-configuration, `controller`>>_
-
-Configuration element for adding volume mounts to containers in Pod template spec
-
-| `controllerName`
-| _Deprecated: Use same field inside <<generated-controller-resource-configuration, `controller`>>_
-
-Name of the controller resource(i.e. `Deployment`, `ReplicaSet`, `StatefulSet` etc) generated
-
-| <<probe-resources-configuration, `liveness`>>
-| _Deprecated: Use same field inside <<generated-controller-resource-configuration, `controller`>>_
-
-Configuration element for adding a liveness probe
-
-| <<probe-resources-configuration, `readiness`>>
-| _Deprecated: Use same field inside <<generated-controller-resource-configuration, `controller`>>_
-
-Configuration element for adding readiness probe
-
-| `containerPrivileged`
-| _Deprecated: Use same field inside <<generated-controller-resource-configuration, `controller`>>_
-
-Run container in privileged mode. Sets `privileged: true` in generated Controller's PodTemplateSpec
-
-| `imagePullPolicy`
-| _Deprecated: Use same field inside <<generated-controller-resource-configuration, `controller`>>_
-
-How images should be pulled (maps to ImagePullPolicy).
-
-| `replicas`
-| _Deprecated: Use same field inside <<generated-controller-resource-configuration, `controller`>>_
-
-Number of replicas to create
-
-| `restartPolicy`
-| _Deprecated: Use same field inside <<generated-controller-resource-configuration, `controller`>>_
-
-Pod's restart policy.
-
-For `Job`, this defaults to `OnFailure`. For others, it's not provided ({cluster} assumes it to be `Always`)
-
 | `serviceAccount`
 | ServiceAccount name which will be used by pods created by controller resources(e.g. `Deployment`, `ReplicaSet` etc)
 |===


### PR DESCRIPTION
## Description

Most fields in this table are deprecated and cause confusion. It's better to remove these so that users don't get confused by them and use new configuration methods.

Fixes #2057


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
