### PR TITLE
fix: DockerImageWatcher uses KubernetesClient singleton from JKubeServiceHub

### DIFF
--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
@@ -140,14 +140,11 @@ public class DockerImageWatcher extends BaseWatcher {
     protected void restartContainer(WatchService.ImageWatcher watcher, Collection<HasMetadata> resources) {
         ImageConfiguration imageConfig = watcher.getImageConfiguration();
         String imageName = imageConfig.getName();
-        ClusterAccess clusterAccess = getContext().getJKubeServiceHub().getClusterAccess();
-        try (KubernetesClient client = clusterAccess.createDefaultClient()) {
-
-            String namespace = clusterAccess.getNamespace();
-
-            String imagePrefix = getImagePrefix(imageName);
+        final KubernetesClient client = getContext().getJKubeServiceHub().getClient();
+        try {
+            String namespace = getContext().getJKubeServiceHub().getClusterAccess().getNamespace();
             for (HasMetadata entity : resources) {
-                updateImageName(client, namespace, entity, imagePrefix, imageName);
+                updateImageName(client, namespace, entity, getImagePrefix(imageName), imageName);
             }
         } catch (KubernetesClientException e) {
             KubernetesHelper.handleKubernetesClientException(e, this.log);

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherRestartContainerTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherRestartContainerTest.java
@@ -70,8 +70,8 @@ class DockerImageWatcherRestartContainerTest {
     ClusterAccess mockedClusterAccess = mock(ClusterAccess.class);
     mockedImageWatcher = mock(WatchService.ImageWatcher.class);
     mockedKubernetesClient = mock(KubernetesClient.class);
+    when(watcherContext.getJKubeServiceHub().getClient()).thenReturn(mockedKubernetesClient);
     when(watcherContext.getJKubeServiceHub().getClusterAccess()).thenReturn(mockedClusterAccess);
-    when(mockedClusterAccess.createDefaultClient()).thenReturn(mockedKubernetesClient);
     when(mockedClusterAccess.getNamespace()).thenReturn("test-ns");
     dockerImageWatcher = new DockerImageWatcher(watcherContext);
   }


### PR DESCRIPTION
## Description

Fix #2152

fix: DockerImageWatcher uses KubernetesClient singleton from JKubeServiceHub

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] My code follows the style guidelines of this project
 - [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [ ] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
