### PR TITLE
fix: PodExecutor uses KubernetesClient singleton from JKubeServiceHub

### DIFF
--- a/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherContext.java
+++ b/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherContext.java
@@ -44,4 +44,7 @@ public class WatcherContext {
   private JKubeConfiguration buildContext;
   private JKubeServiceHub jKubeServiceHub;
 
+  public String getNamespace() {
+    return getJKubeServiceHub().getClusterAccess().getNamespace();
+  }
 }

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/PodExecutor.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/PodExecutor.java
@@ -25,27 +25,28 @@ import io.fabric8.kubernetes.client.dsl.PodResource;
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchException;
 import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
-import org.eclipse.jkube.kit.config.access.ClusterAccess;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
+import org.eclipse.jkube.watcher.api.WatcherContext;
 
 public class PodExecutor {
 
-  private final ClusterAccess clusterAccess;
+  private final WatcherContext watcherContext;
   private final Duration waitTimeout;
   private String output;
 
-  public PodExecutor(ClusterAccess clusterAccess, Duration waitTimeout) {
-    this.clusterAccess = clusterAccess;
+  public PodExecutor(WatcherContext watcherContext, Duration waitTimeout) {
+    this.watcherContext = watcherContext;
     this.waitTimeout = waitTimeout;
   }
 
   void uploadChangedFilesToPod(Collection<HasMetadata> resources, File changedFilesTarball) throws WatchException {
-    try (KubernetesClient client = clusterAccess.createDefaultClient()) {
-      String namespace = clusterAccess.getNamespace();
+    try {
+      final KubernetesClient client = watcherContext.getJKubeServiceHub().getClient();
+      final String namespace = watcherContext.getNamespace();
       File changedFilesDir = new File(changedFilesTarball.getParentFile(), "changed-files");
       File[] changedFiles = changedFilesDir.listFiles();
       if (changedFiles != null && changedFiles.length > 0) {
@@ -68,11 +69,11 @@ public class PodExecutor {
   }
 
   void executeCommandInPod(Collection<HasMetadata> resources, String command) throws InterruptedException, WatchException, IOException {
+    final KubernetesClient client = watcherContext.getJKubeServiceHub().getClient();
     try (
-        KubernetesClient client = clusterAccess.createDefaultClient();
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     ) {
-      String namespace = clusterAccess.getNamespace();
+      final String namespace = watcherContext.getNamespace();
       final ExecListenerLatch latch = new ExecListenerLatch();
       ExecWatch execWatch = client.pods().inNamespace(namespace)
           .withName(KubernetesHelper.getNewestApplicationPodName(client, namespace, resources))

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherRestartContainerTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherRestartContainerTest.java
@@ -67,12 +67,10 @@ class DockerImageWatcherRestartContainerTest {
   @BeforeEach
   public void setUp() {
     WatcherContext watcherContext = mock(WatcherContext.class, RETURNS_DEEP_STUBS);
-    ClusterAccess mockedClusterAccess = mock(ClusterAccess.class);
     mockedImageWatcher = mock(WatchService.ImageWatcher.class);
     mockedKubernetesClient = mock(KubernetesClient.class);
     when(watcherContext.getJKubeServiceHub().getClient()).thenReturn(mockedKubernetesClient);
-    when(watcherContext.getJKubeServiceHub().getClusterAccess()).thenReturn(mockedClusterAccess);
-    when(mockedClusterAccess.getNamespace()).thenReturn("test-ns");
+    when(watcherContext.getNamespace()).thenReturn("test-ns");
     dockerImageWatcher = new DockerImageWatcher(watcherContext);
   }
 

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/PodExecutorTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/PodExecutorTest.java
@@ -23,7 +23,7 @@ import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.internal.core.v1.PodOperationsImpl;
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchException;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
-import org.eclipse.jkube.kit.config.access.ClusterAccess;
+import org.eclipse.jkube.watcher.api.WatcherContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,16 +58,16 @@ class PodExecutorTest {
 
   @BeforeEach
   public void setUp() {
-    ClusterAccess clusterAccess = mock(ClusterAccess.class);
-    podOperations = mock(PodOperationsImpl.class, RETURNS_DEEP_STUBS);
     kubernetesClient = mock(KubernetesClient.class);
-    when(clusterAccess.getNamespace()).thenReturn("default");
-    when(clusterAccess.createDefaultClient()).thenReturn(kubernetesClient);
+    final WatcherContext watcherContext = mock(WatcherContext.class, RETURNS_DEEP_STUBS);
+    when(watcherContext.getNamespace()).thenReturn("default");
+    when(watcherContext.getJKubeServiceHub().getClient()).thenReturn(kubernetesClient);
+    podOperations = mock(PodOperationsImpl.class, RETURNS_DEEP_STUBS);
     podNonNamespaceOp = createPodsInNamespaceMock();
     when(podNonNamespaceOp.withName(anyString())).thenReturn(podOperations);
     kubernetesHelperMockedStatic = mockStatic(KubernetesHelper.class);
     kubernetesHelperMockedStatic.when(() -> KubernetesHelper.getNewestApplicationPodName(eq(kubernetesClient), any(), any())).thenReturn("test-pod");
-    podExecutor = new PodExecutor(clusterAccess, Duration.ZERO);
+    podExecutor = new PodExecutor(watcherContext, Duration.ZERO);
   }
 
   @AfterEach


### PR DESCRIPTION
## Description

Fix #2153 

fix: PodExecutor uses KubernetesClient singleton from JKubeServiceHub

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
