### PR TITLE
refactor: removes redundant ClusterAccess.isOpenShift method

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -79,7 +79,7 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
     kitLogger = createLogger(null);
     logOutputSpecFactory = new LogOutputSpecFactory(isAnsiEnabled(), kubernetesExtension.getLogStdoutOrDefault(),
         kubernetesExtension.getLogDateOrNull());
-    clusterAccess = new ClusterAccess(kitLogger, initClusterConfiguration());
+    clusterAccess = new ClusterAccess(initClusterConfiguration());
     jKubeServiceHub = initJKubeServiceHubBuilder().build();
     kubernetesExtension.resources = updateResourceConfigNamespace(kubernetesExtension.getNamespaceOrNull(), kubernetesExtension.resources);
     ImageConfigResolver imageConfigResolver = new ImageConfigResolver();

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
@@ -48,17 +48,23 @@ public class KubernetesApplyTask extends AbstractJKubeTask {
 
       final File manifest = getManifest(kubernetes);
       URL masterUrl = kubernetes.getMasterUrl();
+
+      final boolean isOpenShift = OpenshiftHelper.isOpenShift(kubernetes);
       KubernetesResourceUtil.validateKubernetesMasterUrl(masterUrl);
       List<HasMetadata> entities = KubernetesHelper.loadResources(manifest);
 
       configureApplyService();
 
-      kitLogger.info("Using %s at %s in namespace %s with manifest %s ", OpenshiftHelper.isOpenShift(kubernetes) ? "OpenShift" : "Kubernetes", masterUrl, applyService.getNamespace(), manifest);
+      kitLogger.info("Using %s at %s in namespace %s with manifest %s ",
+        isOpenShift ? "OpenShift" : "Kubernetes",
+        masterUrl,
+        applyService.getNamespace(),
+        manifest);
 
       // Apply rest of the entities present in manifest
       applyService.applyEntities(manifest.getName(), entities);
       kitLogger.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up",
-          clusterAccess.isOpenShift() ? "oc" : "kubectl");
+        isOpenShift ? "oc" : "kubectl");
     } catch (KubernetesClientException e) {
       KubernetesResourceUtil.handleKubernetesClientException(e, kitLogger);
     } catch (IOException ioException) {

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/access/ClusterAccess.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/access/ClusterAccess.java
@@ -30,11 +30,9 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
  */
 public class ClusterAccess {
 
-    private final KitLogger kitLogger;
     private final ClusterConfiguration clusterConfiguration;
 
-    public ClusterAccess(KitLogger kitLogger, ClusterConfiguration clusterConfiguration) {
-        this.kitLogger = kitLogger;
+    public ClusterAccess(ClusterConfiguration clusterConfiguration) {
         this.clusterConfiguration = clusterConfiguration == null ?
             ClusterConfiguration.builder().build() : clusterConfiguration;
     }
@@ -49,20 +47,6 @@ public class ClusterAccess {
 
     public String getNamespace() {
         return this.clusterConfiguration.getNamespace();
-    }
-
-    public boolean isOpenShift() {
-        try (KubernetesClient client = createDefaultClient()) {
-            return OpenshiftHelper.isOpenShift(client);
-        } catch (KubernetesClientException exp) {
-            Throwable cause = exp.getCause();
-            String prefix = cause instanceof UnknownHostException ?
-              "Unknown host" : Optional.ofNullable(cause).map(Object::getClass).map(Class::getSimpleName).orElse("");
-            kitLogger.warn("Cannot access cluster for detecting mode: %s %s",
-                    prefix,
-                    cause != null && cause.getMessage() != null ? cause.getMessage() : exp.getMessage());
-        }
-        return false;
     }
 
 }

--- a/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/access/ClusterAccessTest.java
+++ b/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/access/ClusterAccessTest.java
@@ -13,73 +13,31 @@
  */
 package org.eclipse.jkube.kit.config.access;
 
-import io.fabric8.kubernetes.api.model.APIGroupListBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.client.OpenShiftClient;
-import org.eclipse.jkube.kit.common.KitLogger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.startsWith;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @EnableKubernetesMockClient(https = false)
 class ClusterAccessTest {
-
-  private KitLogger logger;
   private KubernetesMockServer mockServer;
   private ClusterConfiguration clusterConfiguration;
 
   @BeforeEach
   void setUp() {
-    logger = spy(new KitLogger.SilentLogger());
     clusterConfiguration = ClusterConfiguration.builder()
       .masterUrl(mockServer.url("/"))
       .build();
   }
 
   @Test
-  void isOpenShiftOpenShiftClusterShouldReturnTrue() {
-    // Given
-    mockServer.expect().get().withPath("/apis").andReturn(200,
-      new APIGroupListBuilder().addNewGroup().withName("project.openshift.io").withApiVersion("v1").endGroup().build()).once();
-    // When
-    final boolean result = new ClusterAccess(logger, clusterConfiguration).isOpenShift();
-    // Then
-    assertThat(result).isTrue();
-  }
-
-  @Test
-  void isOpenShiftKubernetesClusterShouldReturnFalse() {
-    // When
-    final boolean result = new ClusterAccess(logger, clusterConfiguration).isOpenShift();
-    // Then
-    assertThat(result).isFalse();
-  }
-
-  @Test
-  void isOpenShiftThrowsExceptionShouldReturnFalse() {
-    // Given
-    clusterConfiguration = ClusterConfiguration.builder().masterUrl("https://unknown.example.com").build();
-    // When
-    final boolean result = new ClusterAccess(logger, clusterConfiguration).isOpenShift();
-    // Then
-    assertThat(result).isFalse();
-    verify(logger, times(1))
-        .warn(startsWith("Cannot access cluster for detecting mode"), eq("IOException"), eq("unknown.example.com"));
-  }
-
-  @Test
   void createDefaultClientShouldReturnKubernetesClient() {
     // When
-    final KubernetesClient result = new ClusterAccess(logger, clusterConfiguration).createDefaultClient();
+    final KubernetesClient result = new ClusterAccess(clusterConfiguration).createDefaultClient();
     // Then
     assertThat(result).isNotNull().isNotInstanceOf(OpenShiftClient.class);
   }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/JKubeServiceHub.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/JKubeServiceHub.java
@@ -127,8 +127,8 @@ public class JKubeServiceHub implements Closeable {
         if (clusterAccess != null) {
             return clusterAccess;
         }
-        return new ClusterAccess(log,
-            ClusterConfiguration.from(System.getProperties(), configuration.getProject().getProperties()).build());
+        return new ClusterAccess(ClusterConfiguration.from(
+          System.getProperties(), configuration.getProject().getProperties()).build());
     }
 
     public RuntimeMode getRuntimeMode() {

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
@@ -77,12 +77,11 @@ class ApplyServiceTest {
 
     @BeforeEach
     void setUp() {
-      final KitLogger log = new KitLogger.SilentLogger();
       final JKubeServiceHub serviceHub = JKubeServiceHub.builder()
-        .log(log)
+        .log(new KitLogger.SilentLogger())
         .configuration(JKubeConfiguration.builder().build())
         .platformMode(RuntimeMode.KUBERNETES)
-        .clusterAccess(new ClusterAccess(log, ClusterConfiguration.from(client.getConfiguration()).build()))
+        .clusterAccess(new ClusterAccess(ClusterConfiguration.from(client.getConfiguration()).build()))
         .build();
       applyService = new ApplyService(serviceHub);
       applyService.setNamespace("default");

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/DebugServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/DebugServiceTest.java
@@ -87,7 +87,7 @@ class DebugServiceTest {
       .log(logger)
       .configuration(JKubeConfiguration.builder().build())
       .platformMode(RuntimeMode.KUBERNETES)
-      .clusterAccess(new ClusterAccess(logger, ClusterConfiguration.from(kubernetesClient.getConfiguration()).build()))
+      .clusterAccess(new ClusterAccess(ClusterConfiguration.from(kubernetesClient.getConfiguration()).build()))
       .build();
     singleThreadExecutor = Executors.newSingleThreadExecutor();
     final ApplyService applyService = new ApplyService(serviceHub);

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
@@ -74,7 +74,7 @@ class KubernetesUndeployServiceTest {
       .log(logger)
       .platformMode(RuntimeMode.KUBERNETES)
       .configuration(JKubeConfiguration.builder().build())
-      .clusterAccess(new ClusterAccess(logger, ClusterConfiguration.from(kubernetesClient.getConfiguration()).namespace("test").build()))
+      .clusterAccess(new ClusterAccess(ClusterConfiguration.from(kubernetesClient.getConfiguration()).namespace("test").build()))
       .build();
     kubernetesUndeployService = new KubernetesUndeployService(jKubeServiceHub, logger);
   }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftUndeployServiceTest.java
@@ -74,7 +74,7 @@ class OpenshiftUndeployServiceTest {
       .log(logger)
       .platformMode(RuntimeMode.KUBERNETES)
       .configuration(JKubeConfiguration.builder().build())
-      .clusterAccess(new ClusterAccess(logger, ClusterConfiguration.from(openShiftClient.getConfiguration()).namespace("test").build()))
+      .clusterAccess(new ClusterAccess(ClusterConfiguration.from(openShiftClient.getConfiguration()).namespace("test").build()))
       .build();
     resourceConfig = ResourceConfig.builder().namespace("test").build();
     openshiftUndeployService = new OpenshiftUndeployService(jKubeServiceHub, logger);

--- a/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherManager.java
+++ b/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherManager.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.watcher.api;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.ClassUtil;
+import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
 import org.eclipse.jkube.kit.common.util.PluginServiceFactory;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -47,7 +48,7 @@ public class WatcherManager {
           watcherCtx.getBuildContext().getProject().getCompileClassPathElements(), watcherCtx.getLogger()));
     }
 
-    final boolean isOpenshift = watcherCtx.getJKubeServiceHub().getClusterAccess().isOpenShift();
+    final boolean isOpenshift = OpenshiftHelper.isOpenShift(watcherCtx.getJKubeServiceHub().getClient());
     final PlatformMode mode = isOpenshift ? PlatformMode.openshift : PlatformMode.kubernetes;
 
     final KitLogger log = watcherCtx.getLogger();

--- a/jkube-kit/watcher/api/src/test/java/org/eclipse/jkube/watcher/api/WatcherManagerTest.java
+++ b/jkube-kit/watcher/api/src/test/java/org/eclipse/jkube/watcher/api/WatcherManagerTest.java
@@ -44,7 +44,6 @@ class WatcherManagerTest {
   void setUp() {
     JKubeServiceHub jKubeServiceHub = mock(JKubeServiceHub.class, RETURNS_DEEP_STUBS);
     logger = mock(KitLogger.class);
-    when(jKubeServiceHub.getClusterAccess().isOpenShift()).thenReturn(false);
     final ProcessorConfig processorConfig = new ProcessorConfig();
     processorConfig.setIncludes(Collections.singletonList("fake-watcher"));
     watcherContext = WatcherContext.builder()

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -413,7 +413,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo
         logOutputSpecFactory = new LogOutputSpecFactory(useColorForLogging(), logStdout, logDate);
         authConfigFactory = new AuthConfigFactory(log);
         imageConfigResolver.setLog(log);
-        clusterAccess = new ClusterAccess(log, initClusterConfiguration());
+        clusterAccess = new ClusterAccess(initClusterConfiguration());
         runtimeMode = getConfiguredRuntimeMode();
     }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractJKubeMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractJKubeMojo.java
@@ -120,7 +120,7 @@ public abstract class AbstractJKubeMojo extends AbstractMojo implements KitLogge
 
     protected void init() throws DependencyResolutionRequiredException {
         log = createLogger(null);
-        clusterAccess = new ClusterAccess(log, initClusterConfiguration());
+        clusterAccess = new ClusterAccess(initClusterConfiguration());
         javaProject = MavenUtil.convertMavenProjectToJKubeProject(project, session);
         jkubeServiceHub = initJKubeServiceHubBuilder(javaProject).build();
         resources = updateResourceConfigNamespace(namespace, resources);

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
@@ -163,22 +163,22 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
                 }
             }
 
-            String clusterKind = "Kubernetes";
-            if (OpenshiftHelper.isOpenShift(kubernetes)) {
-                clusterKind = "OpenShift";
-            }
+            final boolean isOpenShift = OpenshiftHelper.isOpenShift(kubernetes);
             KubernetesResourceUtil.validateKubernetesMasterUrl(masterUrl);
             List<HasMetadata> entities = KubernetesHelper.loadResources(manifest);
 
             configureApplyService(kubernetes);
 
-            log.info("Using %s at %s in namespace %s with manifest %s ", clusterKind, masterUrl,
+            log.info("Using %s at %s in namespace %s with manifest %s ",
+                isOpenShift ? "OpenShift" : "Kubernetes",
+                masterUrl,
                 applyService.getNamespace(),
                 manifest);
 
             // Apply rest of the entities present in manifest
             applyEntities(kubernetes, manifest.getName(), entities);
-            log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up", clusterAccess.isOpenShift() ? "oc" : "kubectl");
+            log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up",
+              isOpenShift ? "oc" : "kubectl");
         } catch (KubernetesClientException e) {
             KubernetesResourceUtil.handleKubernetesClientException(e, this.log);
         } catch(InterruptedException ex) {

--- a/quickstarts/kit/docker-image/pom.xml
+++ b/quickstarts/kit/docker-image/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.eclipse.jkube.quickstarts.kit</groupId>
   <artifactId>docker-image</artifactId>
-  <version>1.12.0</version>
+  <version>1.13-SNAPSHOT</version>
   <name>Eclipse JKube :: Quickstarts :: Kit :: Docker Image</name>
   <packaging>jar</packaging>
 

--- a/quickstarts/kit/docker-image/src/main/java/org/eclipse/jkube/quickstart/kit/docker/Main.java
+++ b/quickstarts/kit/docker-image/src/main/java/org/eclipse/jkube/quickstart/kit/docker/Main.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
+import org.eclipse.jkube.kit.common.Arguments;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.RunImageConfiguration;
 import org.eclipse.jkube.kit.common.Assembly;
@@ -26,7 +27,6 @@ import org.eclipse.jkube.kit.common.AssemblyFileSet;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
-import org.eclipse.jkube.kit.config.image.build.Arguments;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;

--- a/quickstarts/kit/dynamic-docker-image-file-multi-layer/pom.xml
+++ b/quickstarts/kit/dynamic-docker-image-file-multi-layer/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.eclipse.jkube.quickstarts.kit</groupId>
   <artifactId>dynamic-docker-image-file-multi-layer</artifactId>
-  <version>1.12.0</version>
+  <version>1.13-SNAPSHOT</version>
   <name>Eclipse JKube :: Quickstarts :: Kit :: Docker Image from Multilayer Dockerfile</name>
   <packaging>jar</packaging>
 

--- a/quickstarts/kit/dynamic-docker-image-file-multi-layer/src/main/java/org/eclipse/jkube/quickstart/kit/docker/dynamic/DynamicDockerfileGenerator.java
+++ b/quickstarts/kit/dynamic-docker-image-file-multi-layer/src/main/java/org/eclipse/jkube/quickstart/kit/docker/dynamic/DynamicDockerfileGenerator.java
@@ -14,10 +14,10 @@
 package org.eclipse.jkube.quickstart.kit.docker.dynamic;
 
 import org.apache.commons.io.FileUtils;
+import org.eclipse.jkube.kit.common.Arguments;
 import org.eclipse.jkube.kit.common.AssemblyConfiguration;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
-import org.eclipse.jkube.kit.config.image.build.Arguments;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.image.build.DockerFileBuilder;
 

--- a/quickstarts/kit/helm/src/main/java/org/eclipse/jkube/quickstart/kit/Main.java
+++ b/quickstarts/kit/helm/src/main/java/org/eclipse/jkube/quickstart/kit/Main.java
@@ -91,10 +91,11 @@ public class Main {
     FileUtils.write(
         new File(kubernetesHelmInputDir, "kubernetes.yml"), Serialization.asYaml(klb.build()), StandardCharsets.UTF_8);
 
+    FileUtils.forceMkdir(new File(targetDir, "kubernetes"));
     final HelmConfig helmConfig = HelmConfig.builder()
         .chart(APP_NAME + "-chart")
         .version("1.33.7")
-        .templates(Collections.singletonList(values))
+        .parameterTemplates(Collections.singletonList(values))
         .sourceDir(helmSourceDir.getAbsolutePath())
         .outputDir(new File(targetDir, "helm").getAbsolutePath())
         .tarballOutputDir(targetDir.getAbsolutePath())


### PR DESCRIPTION
## Description
Fix #2155 

refactor: removes redundant ClusterAccess.isOpenShift method


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
