### PR TITLE
fix (jkube-kit/config/image) : Remove user field from ImageName (#2116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ Usage:
 ### 1.14-SNAPSHOT
 * Fix #1713: Add HelidonHealthCheckEnricher to add Kubernetes health checks for Helidon applications
 * Fix #1714: Add HelidonGenerator to add opinionated container image for Helidon applications
+* Fix #1929: Docker Image Name parsing fix
 * Fix #1985: Update outdated methods in Spring Boot CRD Maven Quickstart
+* Fix #2116: Remove user field from ImageName class
 * Fix #2224: Quarkus native base image read from properties (configurable)
 
 ### 1.13.1 (2023-06-16)
@@ -31,7 +33,6 @@ Usage:
 
 ### 1.13.0 (2023-06-14)
 * Fix #1478: Should detect and warn the user if creating ingress and ingress controller not available
-* Fix #1929: Docker Image Name parsing fix
 * Fix #2092: Support for `Chart.yaml` fragments
 * Fix #2150: Bump Kubernetes Client to 6.6.0 (fixes issues when trace-logging OpenShift builds)
 * Fix #2162: Bump Kubernetes Client to 6.6.1 (HttpClient with support for PUT + InputStream)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Usage:
 
 ### 1.13.0 (2023-06-14)
 * Fix #1478: Should detect and warn the user if creating ingress and ingress controller not available
+* Fix #1929: Docker Image Name parsing fix
 * Fix #2092: Support for `Chart.yaml` fragments
 * Fix #2150: Bump Kubernetes Client to 6.6.0 (fixes issues when trace-logging OpenShift builds)
 * Fix #2162: Bump Kubernetes Client to 6.6.1 (HttpClient with support for PUT + InputStream)
@@ -493,3 +494,4 @@ Only the set of documented features are available to users.
 
 ### 0.1.0 (2019-12-19)
 * Initial release
+

--- a/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/helper/RegistryUtil.java
+++ b/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/helper/RegistryUtil.java
@@ -23,13 +23,23 @@ public class RegistryUtil {
 
   public static String getApplicablePushRegistryFrom(ImageConfiguration imageConfiguration, RegistryConfig registryConfig) {
     ImageName imageName = new ImageName(imageConfiguration.getName());
-    return EnvUtil.firstRegistryOf(imageName.getRegistry(),
-        imageConfiguration.getRegistry(),
-        registryConfig.getRegistry());
+    if (imageName.isFullyQualifiedName()) {
+      return EnvUtil.firstRegistryOf(imageName.getRegistry(),
+          imageConfiguration.getRegistry(),
+          registryConfig.getRegistry());
+    } else {
+      return EnvUtil.firstRegistryOf(imageConfiguration.getRegistry(),
+          registryConfig.getRegistry(),
+          imageName.getRegistry());
+    }
   }
 
   public static String getApplicablePullRegistryFrom(String fromImage, RegistryConfig registryConfig) {
     ImageName imageName = new ImageName(fromImage);
-    return EnvUtil.firstRegistryOf(imageName.getRegistry(), registryConfig.getRegistry());
+    if (imageName.isFullyQualifiedName()) {
+      return EnvUtil.firstRegistryOf(imageName.getRegistry(), registryConfig.getRegistry());
+    } else {
+      return EnvUtil.firstRegistryOf(registryConfig.getRegistry(), imageName.getRegistry());
+    }
   }
 }

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RegistryService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RegistryService.java
@@ -61,7 +61,7 @@ public class RegistryService {
         if (buildConfig != null) {
             String configuredRegistry = getApplicablePushRegistryFrom(imageConfig, registryConfig);
 
-            AuthConfig authConfig = createAuthConfig(true, new ImageName(name).getUser(), configuredRegistry, registryConfig);
+            AuthConfig authConfig = createAuthConfig(true, new ImageName(name).inferUser(), configuredRegistry, registryConfig);
 
             long start = System.currentTimeMillis();
             docker.pushImage(name, authConfig, configuredRegistry, retries);

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/DockerAccessWithHcClient.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/access/hc/DockerAccessWithHcClient.java
@@ -650,15 +650,14 @@ public class DockerAccessWithHcClient implements DockerAccess {
 
     private TemporaryImageHandler tagTemporaryImage(ImageName name, String registry) throws DockerAccessException {
         String targetImage = name.getFullName(registry);
-        if (name.hasRegistry() || registry == null) {
+        String fullName = name.getFullName();
+        if ((name.isFullyQualifiedName() && name.hasRegistry()) || targetImage.equals(fullName) || registry == null) {
             return () ->
                 log.info("Temporary image tag skipped. Target image '%s' already has registry set or no registry is available",
                     targetImage);
         }
 
-        String fullName = name.getFullName();
         boolean alreadyHasImage = hasImage(targetImage);
-
         if (alreadyHasImage) {
             log.warn("Target image '%s' already exists. Tagging of '%s' will replace existing image",
                 targetImage, fullName);

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -142,16 +142,8 @@ public class ImageName {
         return builder.toString();
     }
 
-    private boolean containsPeriodOrColon(String part) {
-        return containsPeriod(part) || containsColon(part);
-    }
-
-    private boolean containsPeriod(String part) {
+    private boolean isRegistryPart(String part) {
         return part.contains(".");
-    }
-
-    private boolean containsColon(String part) {
-        return part.contains(":");
     }
 
     /**
@@ -281,26 +273,18 @@ public class ImageName {
             registry = null;
             user = null;
             repository = parts[0];
-        } else if (parts.length >= 2) {
-            if (containsPeriodOrColon(parts[0])) {
-                if (parts.length > 2) {
-                    assignRegistryUserAndRepository(parts);
-                } else {
-                    checkWhetherFirstElementIsUserOrRegistryAndAssign(parts);
-                }
+        } else if (parts.length == 2) {
+            if (isRegistryPart(parts[0])) {
+                assignRegistryAndRepository(parts);
             } else {
-                registry = null;
-                user = parts[0];
-                repository = rest;
+                assignUserAndRepository(parts);
             }
-        }
-    }
-
-    private void checkWhetherFirstElementIsUserOrRegistryAndAssign(String[] parts) {
-        if (containsColon(parts[0])) {
-            assignRegistryAndRepository(parts);
-        } else {
-            assignUserAndRepository(parts);
+        } else if (parts.length >= 3) {
+            if (isRegistryPart(parts[0])) {
+                assignRegistryUserAndRepository(parts);
+            } else {
+                assignUserAndRepository(parts);
+            }
         }
     }
 

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -142,8 +142,16 @@ public class ImageName {
         return builder.toString();
     }
 
-    private boolean isRegistryPart(String part) {
+    private boolean containsPeriodOrColon(String part) {
+        return containsPeriod(part) || containsColon(part);
+    }
+
+    private boolean containsPeriod(String part) {
         return part.contains(".");
+    }
+
+    private boolean containsColon(String part) {
+        return part.contains(":");
     }
 
     /**
@@ -273,18 +281,26 @@ public class ImageName {
             registry = null;
             user = null;
             repository = parts[0];
-        } else if (parts.length == 2) {
-            if (isRegistryPart(parts[0])) {
-                assignRegistryAndRepository(parts);
+        } else if (parts.length >= 2) {
+            if (containsPeriodOrColon(parts[0])) {
+                if (parts.length > 2) {
+                    assignRegistryUserAndRepository(parts);
+                } else {
+                    checkWhetherFirstElementIsUserOrRegistryAndAssign(parts);
+                }
             } else {
-                assignUserAndRepository(parts);
+                registry = null;
+                user = parts[0];
+                repository = rest;
             }
-        } else if (parts.length >= 3) {
-            if (isRegistryPart(parts[0])) {
-                assignRegistryUserAndRepository(parts);
-            } else {
-                assignUserAndRepository(parts);
-            }
+        }
+    }
+
+    private void checkWhetherFirstElementIsUserOrRegistryAndAssign(String[] parts) {
+        if (containsColon(parts[0])) {
+            assignRegistryAndRepository(parts);
+        } else {
+            assignUserAndRepository(parts);
         }
     }
 

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameFullNameParseTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameFullNameParseTest.java
@@ -154,10 +154,10 @@ class ImageNameFullNameParseTest {
     return Stream.of(
         new Object[][] {
             {
-                "Repo and Name with special characters", "invalid.name-with__separators/eclipse_jkube"
+                "Repo and Name with special characters", "invalid.name-with__separators/eclipse_-jkube"
             },
             {
-                "Repo, Name and Tag with special characters", "invalid.name-with__separators/eclipse_jkube:valid__tag-4.2"
+                "Repo, Name and Tag with special characters", "invalid.name-with__separators/eclipse_jkube:valid!__tag-4.2"
             },
         });
   }

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameFullNameParseTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameFullNameParseTest.java
@@ -13,59 +13,180 @@
  */
 package org.eclipse.jkube.kit.config.image;
 
+import lombok.Builder;
+import lombok.Value;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class ImageNameFullNameParseTest {
 
-  public static Stream<Object[]> data() {
+  public static Stream<Object[]> validData() {
     return Stream.of(
-     new Object[][] {
-        {"Repo and Name", "eclipse/eclipse_jkube",
-            "eclipse/eclipse_jkube:latest", null, "eclipse", "eclipse/eclipse_jkube", "latest", null},
-        {"Repo and Name with special characters", "valid.name-with__separators/eclipse_jkube",
-            "valid.name-with__separators/eclipse_jkube:latest", null,
-            "valid.name-with__separators", "valid.name-with__separators/eclipse_jkube", "latest", null},
-        {"Repo, Name and Tag", "eclipse/eclipse_jkube:1.3.3.7",
-            "eclipse/eclipse_jkube:1.3.3.7", null, "eclipse", "eclipse/eclipse_jkube", "1.3.3.7", null},
-        {"Repo, Name and Tag with special characters", "valid.name-with__separators/eclipse_jkube:valid__tag-4.2",
-            "valid.name-with__separators/eclipse_jkube:valid__tag-4.2", null,
-            "valid.name-with__separators", "valid.name-with__separators/eclipse_jkube", "valid__tag-4.2", null},
-        {"Registry, Repo and Name", "docker.io/eclipse/eclipse_jkube",
-            "docker.io/eclipse/eclipse_jkube:latest", "docker.io", "eclipse", "eclipse/eclipse_jkube", "latest", null},
-        {"Registry, Repo and Name with special characters",
-            "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube",
-            "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:latest",
-            "long.registry.example.com:8080",
-            "valid.name--with__separators", "valid.name--with__separators/eclipse_jkube", "latest", null},
-        {"Registry, Repo, Name and Tag", "docker.io/eclipse/eclipse_jkube:1.33.7",
-            "docker.io/eclipse/eclipse_jkube:1.33.7", "docker.io", "eclipse", "eclipse/eclipse_jkube", "1.33.7", null},
-        {"Registry, Repo, Name and Tag with special characters",
-            "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A",
-            "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A",
-            "long.registry.example.com:8080",
-            "valid.name--with__separators", "valid.name--with__separators/eclipse_jkube", "very--special__tag.2.A", null},
-    });
+        new Object[][] {
+            {
+                "Repo and Name", "eclipse/eclipse_jkube",
+                SimpleImageName.builder()
+                    .fullName("eclipse/eclipse_jkube:latest")
+                    .registry(null)
+                    .user("eclipse")
+                    .repository("eclipse/eclipse_jkube")
+                    .tag("latest")
+                    .digest(null)
+                    .build()
+            },
+            {
+                "Repo, Name and Tag", "eclipse/eclipse_jkube:1.3.3.7",
+                SimpleImageName.builder()
+                    .fullName("eclipse/eclipse_jkube:1.3.3.7")
+                    .registry(null)
+                    .user("eclipse")
+                    .repository("eclipse/eclipse_jkube")
+                    .tag("1.3.3.7")
+                    .digest(null)
+                    .build()
+            },
+            {
+                "Registry, Repo and Name", "docker.io/eclipse/eclipse_jkube",
+                SimpleImageName.builder()
+                    .fullName("docker.io/eclipse/eclipse_jkube:latest")
+                    .registry("docker.io")
+                    .user("eclipse")
+                    .repository("eclipse/eclipse_jkube")
+                    .tag("latest")
+                    .digest(null)
+                    .build()
+            },
+            { "Registry, Repo and Name with special characters",
+                "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube",
+                SimpleImageName.builder()
+                    .fullName("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:latest")
+                    .registry("long.registry.example.com:8080")
+                    .user("valid.name--with__separators")
+                    .repository("valid.name--with__separators/eclipse_jkube")
+                    .tag("latest")
+                    .digest(null)
+                    .build()
+            },
+            { "Registry, Repo, Name and Tag", "docker.io/eclipse/eclipse_jkube:1.33.7",
+                SimpleImageName.builder()
+                    .fullName("docker.io/eclipse/eclipse_jkube:1.33.7")
+                    .registry("docker.io")
+                    .user("eclipse")
+                    .repository("eclipse/eclipse_jkube")
+                    .tag("1.33.7")
+                    .digest(null)
+                    .build()
+            },
+            {
+                "Registry, Repo, Name and Tag with special characters",
+                "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A",
+                SimpleImageName.builder()
+                    .fullName(
+                        "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A")
+                    .registry("long.registry.example.com:8080")
+                    .user("valid.name--with__separators")
+                    .repository("valid.name--with__separators/eclipse_jkube")
+                    .tag("very--special__tag.2.A")
+                    .digest(null)
+                    .build()
+            },
+            {
+                "Repo only", "eclipse-temurin:11",
+                SimpleImageName.builder()
+                    .fullName("eclipse-temurin:11")
+                    .registry(null)
+                    .user(null)
+                    .repository("eclipse-temurin")
+                    .tag("11")
+                    .digest(null)
+                    .build()
+            },
+            {
+                "User and repo", "user/my-repo_z:11",
+                SimpleImageName.builder()
+                    .fullName("user/my-repo_z:11")
+                    .registry(null)
+                    .user("user")
+                    .repository("user/my-repo_z")
+                    .tag("11")
+                    .digest(null)
+                    .build()
+            },
+            {
+                "Registry and repo", "foo-bar-registry.jfrog.io/java:jre-17",
+                SimpleImageName.builder()
+                    .fullName("foo-bar-registry.jfrog.io/java:jre-17")
+                    .registry("foo-bar-registry.jfrog.io")
+                    .user(null)
+                    .repository("java")
+                    .tag("jre-17")
+                    .digest(null)
+                    .build()
+            },
+            {
+                "JFrog repo", "user.jfrog.io/my-jkube/openjdk:jre-17",
+                SimpleImageName.builder()
+                    .fullName("user.jfrog.io/my-jkube/openjdk:jre-17")
+                    .registry("user.jfrog.io")
+                    .user("my-jkube")
+                    .repository("my-jkube/openjdk")
+                    .tag("jre-17")
+                    .digest(null)
+                    .build()
+            },
+        });
   }
 
   @ParameterizedTest(name = "{0}")
-  @MethodSource("data")
-  void fullNameParse(String testName, String providedFullName, String expectedFullName, String registry, String user,
-                     String repository, String tag, String digest) {
-    final ImageName result = new ImageName(providedFullName);
-    assertThat(result)
-        .extracting(
-            ImageName::getFullName,
-            ImageName::getRegistry,
-            ImageName::getUser,
-            ImageName::getRepository,
-            ImageName::getTag,
-            ImageName::getDigest
-        )
-        .containsExactly(expectedFullName, registry, user, repository, tag, digest);
+  @MethodSource("validData")
+  void shouldParseImageName(String testName, String providedImageName, SimpleImageName expectedImageName) {
+    ImageName imageName = new ImageName(providedImageName);
+    SimpleImageName currentImageName = SimpleImageName.toSimpleImageName(imageName);
+    assertThat(currentImageName).isEqualTo(expectedImageName);
+  }
+
+  public static Stream<Object[]> invalidData() {
+    return Stream.of(
+        new Object[][] {
+            {
+                "Repo and Name with special characters", "invalid.name-with__separators/eclipse_jkube"
+            },
+            {
+                "Repo, Name and Tag with special characters", "invalid.name-with__separators/eclipse_jkube:valid__tag-4.2"
+            },
+        });
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("invalidData")
+  void shouldFailedParseImageName(String testName, String providedImageName) {
+    assertThatCode(() -> new ImageName(providedImageName))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Builder
+  @Value
+  public static class SimpleImageName {
+    String fullName;
+    String registry;
+    String user;
+    String repository;
+    String tag;
+    String digest;
+
+    public static SimpleImageName toSimpleImageName(ImageName imageName) {
+      return new SimpleImageName(imageName.getFullName(),
+          imageName.getRegistry(),
+          imageName.getUser(),
+          imageName.getRepository(),
+          imageName.getTag(),
+          imageName.getDigest());
+    }
+
   }
 }

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameFullNameParseTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameFullNameParseTest.java
@@ -13,180 +13,199 @@
  */
 package org.eclipse.jkube.kit.config.image;
 
-import lombok.Builder;
-import lombok.Value;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ImageNameFullNameParseTest {
 
-  public static Stream<Object[]> validData() {
+  @ParameterizedTest(name ="{index}: With full name ''{0}'' should return same or complete full name (''{1}'')")
+  @DisplayName("getFullName")
+  @MethodSource("getFullNameData")
+  void getFullName(String providedFullName, String expectedFullName) {
+    assertThat(new ImageName(providedFullName).getFullName()).isEqualTo(expectedFullName);
+  }
+
+  static Stream<Arguments> getFullNameData() {
     return Stream.of(
-        new Object[][] {
-            {
-                "Repo and Name", "eclipse/eclipse_jkube",
-                SimpleImageName.builder()
-                    .fullName("eclipse/eclipse_jkube:latest")
-                    .registry(null)
-                    .user("eclipse")
-                    .repository("eclipse/eclipse_jkube")
-                    .tag("latest")
-                    .digest(null)
-                    .build()
-            },
-            {
-                "Repo, Name and Tag", "eclipse/eclipse_jkube:1.3.3.7",
-                SimpleImageName.builder()
-                    .fullName("eclipse/eclipse_jkube:1.3.3.7")
-                    .registry(null)
-                    .user("eclipse")
-                    .repository("eclipse/eclipse_jkube")
-                    .tag("1.3.3.7")
-                    .digest(null)
-                    .build()
-            },
-            {
-                "Registry, Repo and Name", "docker.io/eclipse/eclipse_jkube",
-                SimpleImageName.builder()
-                    .fullName("docker.io/eclipse/eclipse_jkube:latest")
-                    .registry("docker.io")
-                    .user("eclipse")
-                    .repository("eclipse/eclipse_jkube")
-                    .tag("latest")
-                    .digest(null)
-                    .build()
-            },
-            { "Registry, Repo and Name with special characters",
-                "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube",
-                SimpleImageName.builder()
-                    .fullName("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:latest")
-                    .registry("long.registry.example.com:8080")
-                    .user("valid.name--with__separators")
-                    .repository("valid.name--with__separators/eclipse_jkube")
-                    .tag("latest")
-                    .digest(null)
-                    .build()
-            },
-            { "Registry, Repo, Name and Tag", "docker.io/eclipse/eclipse_jkube:1.33.7",
-                SimpleImageName.builder()
-                    .fullName("docker.io/eclipse/eclipse_jkube:1.33.7")
-                    .registry("docker.io")
-                    .user("eclipse")
-                    .repository("eclipse/eclipse_jkube")
-                    .tag("1.33.7")
-                    .digest(null)
-                    .build()
-            },
-            {
-                "Registry, Repo, Name and Tag with special characters",
-                "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A",
-                SimpleImageName.builder()
-                    .fullName(
-                        "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A")
-                    .registry("long.registry.example.com:8080")
-                    .user("valid.name--with__separators")
-                    .repository("valid.name--with__separators/eclipse_jkube")
-                    .tag("very--special__tag.2.A")
-                    .digest(null)
-                    .build()
-            },
-            {
-                "Repo only", "eclipse-temurin:11",
-                SimpleImageName.builder()
-                    .fullName("eclipse-temurin:11")
-                    .registry(null)
-                    .user(null)
-                    .repository("eclipse-temurin")
-                    .tag("11")
-                    .digest(null)
-                    .build()
-            },
-            {
-                "User and repo", "user/my-repo_z:11",
-                SimpleImageName.builder()
-                    .fullName("user/my-repo_z:11")
-                    .registry(null)
-                    .user("user")
-                    .repository("user/my-repo_z")
-                    .tag("11")
-                    .digest(null)
-                    .build()
-            },
-            {
-                "Registry and repo", "foo-bar-registry.jfrog.io/java:jre-17",
-                SimpleImageName.builder()
-                    .fullName("foo-bar-registry.jfrog.io/java:jre-17")
-                    .registry("foo-bar-registry.jfrog.io")
-                    .user(null)
-                    .repository("java")
-                    .tag("jre-17")
-                    .digest(null)
-                    .build()
-            },
-            {
-                "JFrog repo", "user.jfrog.io/my-jkube/openjdk:jre-17",
-                SimpleImageName.builder()
-                    .fullName("user.jfrog.io/my-jkube/openjdk:jre-17")
-                    .registry("user.jfrog.io")
-                    .user("my-jkube")
-                    .repository("my-jkube/openjdk")
-                    .tag("jre-17")
-                    .digest(null)
-                    .build()
-            },
-        });
+      Arguments.of("eclipse/eclipse_jkube:latest", "eclipse/eclipse_jkube:latest"),
+      Arguments.of("eclipse/eclipse_jkube:1.3.3.7", "eclipse/eclipse_jkube:1.3.3.7"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube", "docker.io/eclipse/eclipse_jkube:latest"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube", "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:latest"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube:1.33.7", "docker.io/eclipse/eclipse_jkube:1.33.7"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A", "long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A"),
+      Arguments.of("eclipse-temurin:11", "eclipse-temurin:11"),
+      Arguments.of("user/my-repo_z:11", "user/my-repo_z:11"),
+      Arguments.of("foo-bar-registry.jfrog.io/java:jre-17", "foo-bar-registry.jfrog.io/java:jre-17"),
+      Arguments.of("user.jfrog.io/my-jkube/openjdk:jre-17", "user.jfrog.io/my-jkube/openjdk:jre-17"),
+      Arguments.of("quay.io/jkube/jkube-java:0.0.19@sha256:b7d8650e04b282b9d7b94daedf38321512f9910bce896cd40ffa15b1b92bab17", "quay.io/jkube/jkube-java:0.0.19@sha256:b7d8650e04b282b9d7b94daedf38321512f9910bce896cd40ffa15b1b92bab17")
+    );
   }
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("validData")
-  void shouldParseImageName(String testName, String providedImageName, SimpleImageName expectedImageName) {
-    ImageName imageName = new ImageName(providedImageName);
-    SimpleImageName currentImageName = SimpleImageName.toSimpleImageName(imageName);
-    assertThat(currentImageName).isEqualTo(expectedImageName);
+  @ParameterizedTest(name ="{index}: With full name ''{0}'' should return ''{1}'' as repository")
+  @DisplayName("getRepository")
+  @MethodSource("getRepositoryData")
+  void getRepository(String providedFullName, String expectedRepository) {
+    assertThat(new ImageName(providedFullName).getRepository()).isEqualTo(expectedRepository);
   }
 
-  public static Stream<Object[]> invalidData() {
+  static Stream<Arguments> getRepositoryData() {
     return Stream.of(
-        new Object[][] {
-            {
-                "Repo and Name with special characters", "invalid.name-with__separators/eclipse_-jkube"
-            },
-            {
-                "Repo, Name and Tag with special characters", "invalid.name-with__separators/eclipse_jkube:valid!__tag-4.2"
-            },
-        });
+      Arguments.of("eclipse/eclipse_jkube:latest", "eclipse/eclipse_jkube"),
+      Arguments.of("eclipse/eclipse_jkube:1.3.3.7", "eclipse/eclipse_jkube"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube", "eclipse/eclipse_jkube"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube", "valid.name--with__separators/eclipse_jkube"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube:1.33.7", "eclipse/eclipse_jkube"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A", "valid.name--with__separators/eclipse_jkube"),
+      Arguments.of("eclipse-temurin:11", "eclipse-temurin"),
+      Arguments.of("user/my-repo_z:11", "user/my-repo_z"),
+      Arguments.of("foo-bar-registry.jfrog.io/java:jre-17", "java"),
+      Arguments.of("user.jfrog.io/my-jkube/openjdk:jre-17", "my-jkube/openjdk"),
+      Arguments.of("quay.io/jkube/jkube-java:0.0.19@sha256:b7d8650e04b282b9d7b94daedf38321512f9910bce896cd40ffa15b1b92bab17", "jkube/jkube-java")
+    );
   }
 
-  @ParameterizedTest(name = "{0}")
-  @MethodSource("invalidData")
-  void shouldFailedParseImageName(String testName, String providedImageName) {
-    assertThatCode(() -> new ImageName(providedImageName))
-        .isInstanceOf(IllegalArgumentException.class);
+  @ParameterizedTest(name ="{index}: With full name ''{0}'' should return ''{1}'' as registry")
+  @DisplayName("getRegistry")
+  @MethodSource("getRegistryData")
+  void getRegistry(String providedFullName, String expectedRegistry) {
+    assertThat(new ImageName(providedFullName).getRegistry()).isEqualTo(expectedRegistry);
   }
 
-  @Builder
-  @Value
-  public static class SimpleImageName {
-    String fullName;
-    String registry;
-    String user;
-    String repository;
-    String tag;
-    String digest;
-
-    public static SimpleImageName toSimpleImageName(ImageName imageName) {
-      return new SimpleImageName(imageName.getFullName(),
-          imageName.getRegistry(),
-          imageName.getUser(),
-          imageName.getRepository(),
-          imageName.getTag(),
-          imageName.getDigest());
-    }
-
+  static Stream<Arguments> getRegistryData() {
+    return Stream.of(
+      Arguments.of("eclipse/eclipse_jkube:latest", null),
+      Arguments.of("eclipse/eclipse_jkube:1.3.3.7", null),
+      Arguments.of("docker.io/eclipse/eclipse_jkube", "docker.io"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube", "long.registry.example.com:8080"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube:1.33.7", "docker.io"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A", "long.registry.example.com:8080"),
+      Arguments.of("eclipse-temurin:11", null),
+      Arguments.of("user/my-repo_z:11", null),
+      Arguments.of("foo-bar-registry.jfrog.io/java:jre-17", "foo-bar-registry.jfrog.io"),
+      Arguments.of("user.jfrog.io/my-jkube/openjdk:jre-17", "user.jfrog.io"),
+      Arguments.of("quay.io/jkube/jkube-java:0.0.19@sha256:b7d8650e04b282b9d7b94daedf38321512f9910bce896cd40ffa15b1b92bab17", "quay.io")
+    );
   }
+
+  @ParameterizedTest(name ="{index}: With full name ''{0}'' should return ''{1}'' as tag")
+  @DisplayName("getTag")
+  @MethodSource("getTagData")
+  void getTag(String providedFullName, String expectedTag) {
+    assertThat(new ImageName(providedFullName).getTag()).isEqualTo(expectedTag);
+  }
+
+  static Stream<Arguments> getTagData() {
+    return Stream.of(
+      Arguments.of("eclipse/eclipse_jkube:latest", "latest"),
+      Arguments.of("eclipse/eclipse_jkube:1.3.3.7", "1.3.3.7"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube", "latest"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube", "latest"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube:1.33.7", "1.33.7"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A", "very--special__tag.2.A"),
+      Arguments.of("eclipse-temurin:11", "11"),
+      Arguments.of("user/my-repo_z:11", "11"),
+      Arguments.of("foo-bar-registry.jfrog.io/java:jre-17", "jre-17"),
+      Arguments.of("user.jfrog.io/my-jkube/openjdk:jre-17", "jre-17"),
+      Arguments.of("quay.io/jkube/jkube-java:0.0.19@sha256:b7d8650e04b282b9d7b94daedf38321512f9910bce896cd40ffa15b1b92bab17", "0.0.19")
+    );
+  }
+
+  @ParameterizedTest(name ="{index}: With full name ''{0}'' should return ''{1}'' as digest")
+  @DisplayName("getDigest")
+  @MethodSource("getDigestData")
+  void getDigest(String providedFullName, String expectedDigest) {
+    assertThat(new ImageName(providedFullName).getDigest()).isEqualTo(expectedDigest);
+  }
+
+  static Stream<Arguments> getDigestData() {
+    return Stream.of(
+      Arguments.of("eclipse/eclipse_jkube:latest", null),
+      Arguments.of("eclipse/eclipse_jkube:1.3.3.7", null),
+      Arguments.of("docker.io/eclipse/eclipse_jkube", null),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube", null),
+      Arguments.of("docker.io/eclipse/eclipse_jkube:1.33.7", null),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A", null),
+      Arguments.of("eclipse-temurin:11", null),
+      Arguments.of("user/my-repo_z:11", null),
+      Arguments.of("foo-bar-registry.jfrog.io/java:jre-17", null),
+      Arguments.of("user.jfrog.io/my-jkube/openjdk:jre-17", null),
+      Arguments.of("quay.io/jkube/jkube-java:0.0.19@sha256:b7d8650e04b282b9d7b94daedf38321512f9910bce896cd40ffa15b1b92bab17", "sha256:b7d8650e04b282b9d7b94daedf38321512f9910bce896cd40ffa15b1b92bab17")
+    );
+  }
+
+  @ParameterizedTest(name ="{index}: With full name ''{0}'' should return ''{1}'' as inferred user")
+  @DisplayName("inferUser")
+  @MethodSource("inferUserData")
+  void getUser(String providedFullName, String expectedUser) {
+    assertThat(new ImageName(providedFullName).inferUser()).isEqualTo(expectedUser);
+  }
+
+  static Stream<Arguments> inferUserData() {
+    return Stream.of(
+      Arguments.of("eclipse/eclipse_jkube:latest", "eclipse"),
+      Arguments.of("eclipse/eclipse_jkube:1.3.3.7", "eclipse"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube", "eclipse"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube", "valid.name--with__separators"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube:1.33.7", "eclipse"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A", "valid.name--with__separators"),
+      Arguments.of("eclipse-temurin:11", null),
+      Arguments.of("user/my-repo_z:11", "user"),
+      Arguments.of("foo-bar-registry.jfrog.io/java:jre-17", null),
+      Arguments.of("user.jfrog.io/my-jkube/openjdk:jre-17", "my-jkube"),
+      Arguments.of("quay.io/jkube/jkube-java:0.0.19@sha256:b7d8650e04b282b9d7b94daedf38321512f9910bce896cd40ffa15b1b92bab17", "jkube")
+    );
+  }
+
+  @ParameterizedTest(name ="{index}: With full name ''{0}'' should return ''{1}'' as simple name")
+  @DisplayName("getSimpleName")
+  @MethodSource("getSimpleNameData")
+  void getSimpleName(String providedFullName, String expectedSimpleName) {
+    assertThat(new ImageName(providedFullName).getSimpleName()).isEqualTo(expectedSimpleName);
+  }
+
+  static Stream<Arguments> getSimpleNameData() {
+    return Stream.of(
+      Arguments.of("eclipse/eclipse_jkube:latest", "eclipse_jkube"),
+      Arguments.of("eclipse/eclipse_jkube:1.3.3.7", "eclipse_jkube"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube", "eclipse_jkube"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube", "eclipse_jkube"),
+      Arguments.of("docker.io/eclipse/eclipse_jkube:1.33.7", "eclipse_jkube"),
+      Arguments.of("long.registry.example.com:8080/valid.name--with__separators/eclipse_jkube:very--special__tag.2.A", "eclipse_jkube"),
+      Arguments.of("eclipse-temurin:11", "eclipse-temurin"),
+      Arguments.of("user/my-repo_z:11", "my-repo_z"),
+      Arguments.of("foo-bar-registry.jfrog.io/java:jre-17", "java"),
+      Arguments.of("user.jfrog.io/my-jkube/openjdk:jre-17", "openjdk"),
+      Arguments.of("quay.io/jkube/jkube-java:0.0.19@sha256:b7d8650e04b282b9d7b94daedf38321512f9910bce896cd40ffa15b1b92bab17", "jkube-java")
+    );
+  }
+  @Test
+  @DisplayName("With special characters in name, should throw Exception")
+  void withSpecialCharactersInName() {
+    assertThatThrownBy(() -> new ImageName("invalid.name-with__separators/eclipse_-jkube"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageStartingWith("Given Docker name 'invalid.name-with__separators/eclipse_-jkube:latest' is invalid");
+  }
+  @Test
+  @DisplayName("With special characters in tag, should throw Exception")
+  void withSpecialCharactersInTag() {
+    assertThatThrownBy(() -> new ImageName("invalid.name-with__separators/eclipse_jkube:valid!__tag-4.2"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageStartingWith("Given Docker name 'invalid.name-with__separators/eclipse_jkube:valid!__tag-4.2' is invalid");
+  }
+  @Test
+  @DisplayName("With null full name, should throw Exception")
+  void withNullFullName() {
+    assertThatThrownBy(() -> new ImageName(null))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("Image name must not be null");
+  }
+
 }

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
@@ -157,18 +157,16 @@ class ImageNameTest {
     @Test
     void testImageNameWithUsernameHavingPeriods() {
         // Given
-        String name = "roman.gordill/customer-service-cache:latest";
-
+        final String name = "quay.io/roman.gordill/customer-service-cache:latest";
         // When
-        String nameWithRegistry = new ImageName(name).getFullName("quay.io");
-        ImageName imageName = new ImageName(nameWithRegistry);
-
+        final ImageName result = new ImageName(name);
         // Then
-        assertThat(imageName).isNotNull();
-        assertThat(imageName.getUser()).isEqualTo("roman.gordill");
-        assertThat(imageName.getRepository()).isEqualTo("roman.gordill/customer-service-cache");
-        assertThat(imageName.getTag()).isEqualTo("latest");
-        assertThat(imageName.getRegistry()).isEqualTo("quay.io");
+        assertThat(result)
+          .isNotNull()
+          .hasFieldOrPropertyWithValue("repository", "roman.gordill/customer-service-cache")
+          .hasFieldOrPropertyWithValue("tag", "latest")
+          .hasFieldOrPropertyWithValue("registry", "quay.io")
+          .returns("roman.gordill", ImageName::inferUser);
     }
 
     @ParameterizedTest
@@ -183,7 +181,7 @@ class ImageNameTest {
 
         // Then
         assertThat(imageName).isNotNull();
-        assertThat(imageName.getUser()).isNull();
+        assertThat(imageName.inferUser()).isNull();
         assertThat(imageName.getRegistry()).isEqualTo(registry);
         assertThat(imageName.getRepository()).isEqualTo(repository);
         assertThat(imageName.getTag()).isEqualTo(tag);
@@ -199,7 +197,7 @@ class ImageNameTest {
 
         // Then
         assertThat(imageName).isNotNull();
-        assertThat(imageName.getUser()).isNull();
+        assertThat(imageName.inferUser()).isNull();
         assertThat(imageName.getRegistry()).isEqualTo("foo.com:5000");
         assertThat(imageName.getRepository()).isEqualTo("customer-service-cache");
         assertThat(imageName.getTag()).isEqualTo("latest");

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
@@ -159,30 +160,33 @@ class ImageNameTest {
         String name = "roman.gordill/customer-service-cache:latest";
 
         // When
-        ImageName imageName = new ImageName(name);
+        String nameWithRegistry = new ImageName(name).getFullName("quay.io");
+        ImageName imageName = new ImageName(nameWithRegistry);
 
         // Then
         assertThat(imageName).isNotNull();
         assertThat(imageName.getUser()).isEqualTo("roman.gordill");
         assertThat(imageName.getRepository()).isEqualTo("roman.gordill/customer-service-cache");
         assertThat(imageName.getTag()).isEqualTo("latest");
-        assertThat(imageName.getRegistry()).isNull();
+        assertThat(imageName.getRegistry()).isEqualTo("quay.io");
     }
 
-    @Test
-    void testImageNameWithRegistry() {
+    @ParameterizedTest
+    @CsvSource({
+        "foo.com/customer-service-cache:latest,foo.com,customer-service-cache,latest",
+        "myregistry.127.0.0.1.nip.io/eclipse-temurin:11.0.18_10-jdk-alpine,myregistry.127.0.0.1.nip.io,eclipse-temurin,11.0.18_10-jdk-alpine"
+    })
+    void testImageNameWithRegistry(String name, String registry, String repository, String tag) {
         // Given
-        String name = "foo.com/customer-service-cache:latest";
-
         // When
         ImageName imageName = new ImageName(name);
 
         // Then
         assertThat(imageName).isNotNull();
         assertThat(imageName.getUser()).isNull();
-        assertThat(imageName.getRepository()).isEqualTo("customer-service-cache");
-        assertThat(imageName.getTag()).isEqualTo("latest");
-        assertThat(imageName.getRegistry()).isEqualTo("foo.com");
+        assertThat(imageName.getRegistry()).isEqualTo(registry);
+        assertThat(imageName.getRepository()).isEqualTo(repository);
+        assertThat(imageName.getTag()).isEqualTo(tag);
     }
 
     @Test

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
@@ -154,17 +154,17 @@ class ImageNameTest {
     }
 
     @Test
-    void testImageNameWithUsernameHavingNumber() {
+    void testImageNameWithUsernameHavingPeriods() {
         // Given
-        String name = "romangordill10/customer-service-cache:latest";
+        String name = "roman.gordill/customer-service-cache:latest";
 
         // When
         ImageName imageName = new ImageName(name);
 
         // Then
         assertThat(imageName).isNotNull();
-        assertThat(imageName.getUser()).isEqualTo("romangordill10");
-        assertThat(imageName.getRepository()).isEqualTo("romangordill10/customer-service-cache");
+        assertThat(imageName.getUser()).isEqualTo("roman.gordill");
+        assertThat(imageName.getRepository()).isEqualTo("roman.gordill/customer-service-cache");
         assertThat(imageName.getTag()).isEqualTo("latest");
         assertThat(imageName.getRegistry()).isNull();
     }

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
@@ -154,19 +154,35 @@ class ImageNameTest {
     }
 
     @Test
-    void testImageNameWithUsernameHavingPeriods() {
+    void testImageNameWithUsernameHavingNumber() {
         // Given
-        String name = "roman.gordill/customer-service-cache:latest";
+        String name = "romangordill10/customer-service-cache:latest";
 
         // When
         ImageName imageName = new ImageName(name);
 
         // Then
         assertThat(imageName).isNotNull();
-        assertThat(imageName.getUser()).isEqualTo("roman.gordill");
-        assertThat(imageName.getRepository()).isEqualTo("roman.gordill/customer-service-cache");
+        assertThat(imageName.getUser()).isEqualTo("romangordill10");
+        assertThat(imageName.getRepository()).isEqualTo("romangordill10/customer-service-cache");
         assertThat(imageName.getTag()).isEqualTo("latest");
         assertThat(imageName.getRegistry()).isNull();
+    }
+
+    @Test
+    void testImageNameWithRegistry() {
+        // Given
+        String name = "foo.com/customer-service-cache:latest";
+
+        // When
+        ImageName imageName = new ImageName(name);
+
+        // Then
+        assertThat(imageName).isNotNull();
+        assertThat(imageName.getUser()).isNull();
+        assertThat(imageName.getRepository()).isEqualTo("customer-service-cache");
+        assertThat(imageName.getTag()).isEqualTo("latest");
+        assertThat(imageName.getRegistry()).isEqualTo("foo.com");
     }
 
     @Test

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceGetApplicableRegistryTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceGetApplicableRegistryTest.java
@@ -28,9 +28,9 @@ class JibBuildServiceGetApplicableRegistryTest {
       "word.word/word/word:tag,word.word",
       "word:5000/word:tag,word:5000",
       "word.word:5000/word:tag,word.word:5000",
-//      "word.word/word:tag,",
+      "word.word/word:tag,word.word",
       "word.word/word.word/word:tag,word.word",
-//      "word.word.word/word:tag,",
+      "word.word.word/word:tag,word.word.word",
       "word.word.word/word/word:tag,word.word.word"
   })
   void pull_whenRegistryNotPresentFromAnySource_thenReturnRegistryFromImageName(String from, String expectedPullRegistry) {
@@ -87,12 +87,12 @@ class JibBuildServiceGetApplicableRegistryTest {
   @CsvSource({
       "word:word,",
       "word/word:tag,",
-//      "word.word/word:tag,",
+      "word.word/word:tag,word.word",
       "word.word/word/word:tag,word.word",
       "word.word/word.word/word:tag,word.word",
       "word:5000/word:tag,word:5000",
       "word.word:5000/word:tag,word.word:5000",
-//      "word.word.word/word:tag,",
+      "word.word.word/word:tag,word.word.word",
       "word.word.word/word/word:tag,word.word.word"
   })
   void push_whenRegistryNotPresentFromAnySource_thenReturnRegistryFromImageName(String imageName, String expectedPushRegistry) {

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
@@ -381,7 +381,7 @@ public class KubernetesResourceUtil {
 
     private static String extractImageUser(String image, String groupId) {
         ImageName name = new ImageName(image);
-        String imageUser = name.getUser();
+        String imageUser = name.inferUser();
         if(imageUser != null) {
             return imageUser;
         } else {

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
@@ -201,13 +201,13 @@ class ContainerHandlerTest {
       }
 
       @Test
-      @DisplayName("with user, image and tag with period in image user, should return configured image")
-      void withUserAndImageAndTagWithPeriodInImageUser_shouldReturnConfiguredImage() {
+      @DisplayName("with user, image and tag with dash in image user, should return configured image")
+      void withUserAndImageAndTagWithDashInImageUser_shouldReturnConfiguredImage() {
         // Given
         ContainerHandler containerHandler = createContainerHandler(project);
         List<ImageConfiguration> imageConfigurations = new ArrayList<>();
         imageConfigurations.add(ImageConfiguration.builder()
-            .name("roman.gordill/customer-service-cache:latest")
+            .name("roman-gordill/customer-service-cache:latest")
             .registry("quay.io")
             .build(BuildConfiguration.builder()
                 .from("quay.io/jkube/jkube-java:0.0.13")
@@ -222,7 +222,7 @@ class ContainerHandlerTest {
 
         // Then
         assertThat(containers).singleElement()
-            .hasFieldOrPropertyWithValue("image", "quay.io/roman.gordill/customer-service-cache:latest");
+            .hasFieldOrPropertyWithValue("image", "quay.io/roman-gordill/customer-service-cache:latest");
       }
 
       @Test

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
@@ -201,13 +201,13 @@ class ContainerHandlerTest {
       }
 
       @Test
-      @DisplayName("with user, image and tag with dash in image user, should return configured image")
-      void withUserAndImageAndTagWithDashInImageUser_shouldReturnConfiguredImage() {
+      @DisplayName("with user, image and tag with period in image user, should return configured image")
+      void withUserAndImageAndTagWithPeriodInImageUser_shouldReturnConfiguredImage() {
         // Given
         ContainerHandler containerHandler = createContainerHandler(project);
         List<ImageConfiguration> imageConfigurations = new ArrayList<>();
         imageConfigurations.add(ImageConfiguration.builder()
-            .name("roman-gordill/customer-service-cache:latest")
+            .name("roman.gordill/customer-service-cache:latest")
             .registry("quay.io")
             .build(BuildConfiguration.builder()
                 .from("quay.io/jkube/jkube-java:0.0.13")
@@ -222,7 +222,7 @@ class ContainerHandlerTest {
 
         // Then
         assertThat(containers).singleElement()
-            .hasFieldOrPropertyWithValue("image", "quay.io/roman-gordill/customer-service-cache:latest");
+            .hasFieldOrPropertyWithValue("image", "quay.io/roman.gordill/customer-service-cache:latest");
       }
 
       @Test

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/TriggersAnnotationEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/TriggersAnnotationEnricher.java
@@ -133,7 +133,7 @@ public class TriggersAnnotationEnricher extends BaseEnricher {
                 String containerName = container.getName();
                 String containerImage = container.getImage();
                 ImageName image = new ImageName(containerImage);
-                if (isContainerAllowed(containerName) && image.getRegistry() == null && image.getUser() == null) {
+                if (isContainerAllowed(containerName) && image.getRegistry() == null && image.inferUser() == null) {
                     // Imagestreams used as trigger are in the same namespace
                     String tag = image.getTag() != null ? image.getTag() : "latest";
 

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
@@ -157,8 +157,8 @@ public abstract class BaseGenerator implements Generator {
                     tag = "latest";
                 }
                 fromExt.put(JKubeBuildStrategy.SourceStrategy.name.key(), iName.getSimpleName() + ":" + tag);
-                if (iName.getUser() != null) {
-                    fromExt.put(JKubeBuildStrategy.SourceStrategy.namespace.key(), iName.getUser());
+                if (iName.inferUser() != null) {
+                    fromExt.put(JKubeBuildStrategy.SourceStrategy.namespace.key(), iName.inferUser());
                 }
                 fromExt.put(JKubeBuildStrategy.SourceStrategy.kind.key(), "ImageStreamTag");
             } else {


### PR DESCRIPTION
Fix #2116
Closes #2011

Relates to:
- #523 
- #543
- #2011

Earlier we split image names before tagging into `registry`, `user` and `repository`. In Docker code, there is no mention of this user attribute. Split image name into `registry` and `repository` only. User can be extracted from `repository` if required. This would mean that in some cases(`foo.bar/name:tag`) path element would be considered as registry, added a case in getNameWithoutTag to consider optionalRegistry as registry.

+ Remove user field from ImageName class
   - In Docker reference package, there is no mention of user field. A valid
repository is split into a domain and path component. Remove this user
field, but keep getUser method which will try to extract possible
username from path component (repository).
    - Add `isFullyQualifiedName` method to ImageName so that we can distinguish between image names of complete notation ($registry/$user/$name:$tag) from incomplete ones
    - There are some places in code where registry gets appended to image name later using `getFullName(optionalRegistry)`. If given image name is not fully qualified and registry element is a valid path element, then `getNameWithoutTag` would consider `optionalRegistry` as registry and current registry as path element




## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
