### PR TITLE
chore (quickstarts/gradle/spring-boot-crd) : Spring Boot CRD Gradle quickstart should use KubernetesClient from Eclipse JKube

### DIFF
--- a/quickstarts/gradle/spring-boot-crd/build.gradle
+++ b/quickstarts/gradle/spring-boot-crd/build.gradle
@@ -31,7 +31,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'io.fabric8:kubernetes-client:5.7.0'
+    implementation 'org.eclipse.jkube.kubernetes:org.eclipse.jkube.kubernetes.gradle.plugin:1.13.1'
 }
 
 kubernetes {

--- a/quickstarts/gradle/spring-boot-crd/src/main/java/org/eclipse/jkube/quickstart/gradle/springboot/crd/springbootcrd/Application.java
+++ b/quickstarts/gradle/spring-boot-crd/src/main/java/org/eclipse/jkube/quickstart/gradle/springboot/crd/springbootcrd/Application.java
@@ -13,7 +13,7 @@
  */
 package org.eclipse.jkube.quickstart.gradle.springboot.crd.springbootcrd;
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
 import org.springframework.boot.SpringApplication;
@@ -29,7 +29,7 @@ public class Application {
 
   @Bean
   public KubernetesClient kubernetesClient() {
-    return new DefaultKubernetesClient();
+    return new KubernetesClientBuilder().build();
   }
 
   @Bean


### PR DESCRIPTION

## Description

Align both maven and gradle quickstarts to follow the same approach of inheriting transitive KubernetesClient dependency from Eclipse JKube


Related to #1985 


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
