### PR TITLE
fix: remove unused ResourceConfig.customResourceDefinitions field

### DIFF
--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceConfig.java
@@ -100,8 +100,6 @@ public class ResourceConfig {
   private String namespace;
   private String serviceAccount;
   @Singular
-  private List<String> customResourceDefinitions;
-  @Singular
   private List<ServiceAccountConfig> serviceAccounts;
   private ContainerResourcesConfig openshiftBuildConfig;
   private Boolean createExternalUrls;

--- a/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/resource/ResourceConfigTest.java
+++ b/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/resource/ResourceConfigTest.java
@@ -126,7 +126,6 @@ class ResourceConfigTest {
         .hasFieldOrPropertyWithValue("remotes", Collections.singletonList("http://example.com/manifests/deployment.yaml"))
         .hasFieldOrPropertyWithValue("namespace", "foo-ns")
         .hasFieldOrPropertyWithValue("serviceAccount", "foo-sa")
-        .hasFieldOrPropertyWithValue("customResourceDefinitions", Collections.singletonList("crontab.sample.example.com"))
         .hasFieldOrPropertyWithValue("createExternalUrls", true)
         .hasFieldOrPropertyWithValue("routeDomain", "example.com")
         .satisfies(r -> assertProbe(r.getLiveness()))

--- a/jkube-kit/config/resource/src/test/resources/resource-config.json
+++ b/jkube-kit/config/resource/src/test/resources/resource-config.json
@@ -47,7 +47,6 @@
     "name": "foo-sa",
     "deploymentRef": "foo-deployment"
   }],
-  "customResourceDefinitions": ["crontab.sample.example.com"],
   "createExternalUrls": true,
   "routeDomain": "example.com",
   "liveness": {


### PR DESCRIPTION
## Description

Relates to #2219


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
