### PR TITLE
Fix: #2239 Quarkus k8s:resource automatic port pick up from application.properties

### DIFF
--- a/gradle-plugin/it/src/it/quarkus-properties/build.gradle
+++ b/gradle-plugin/it/src/it/quarkus-properties/build.gradle
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+plugins {
+    id 'java'
+    id "io.quarkus" version "${quarkusPluginVersion}"
+    id 'org.eclipse.jkube.kubernetes' version "${jKubeVersion}"
+    id 'org.eclipse.jkube.openshift' version "${jKubeVersion}"
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+    mavenLocal()
+}
+
+dependencies {
+    implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation 'io.quarkus:quarkus-smallrye-health'
+    implementation 'io.quarkus:quarkus-arc'
+}
+
+group 'org.eclipse.jkube.integration.tests.gradle'
+version '0.0.1-SNAPSHOT'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
+}

--- a/gradle-plugin/it/src/it/quarkus-properties/expected/kubernetes.yml
+++ b/gradle-plugin/it/src/it/quarkus-properties/expected/kubernetes.yml
@@ -1,0 +1,113 @@
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.eclipse.org/git-commit: "@ignore@"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9779"
+        jkube.eclipse.org/git-url: "@ignore@"
+        prometheus.io/scrape: "true"
+        jkube.eclipse.org/git-branch: "@ignore@"
+      labels:
+        app: quarkus-properties
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube.integration.tests.gradle
+      name: quarkus-properties
+    spec:
+      ports:
+        - name: http-alt
+          port: 8008
+          protocol: TCP
+          targetPort: 8008
+      selector:
+        app: quarkus-properties
+        provider: jkube
+        group: org.eclipse.jkube.integration.tests.gradle
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        jkube.eclipse.org/git-commit: "@ignore@"
+        jkube.eclipse.org/git-url: "@ignore@"
+        jkube.eclipse.org/git-branch: "@ignore@"
+      labels:
+        app: quarkus-properties
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube.integration.tests.gradle
+      name: quarkus-properties
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app: quarkus-properties
+          provider: jkube
+          group: org.eclipse.jkube.integration.tests.gradle
+      template:
+        metadata:
+          annotations:
+            jkube.eclipse.org/git-commit: "@ignore@"
+            jkube.eclipse.org/git-url: "@ignore@"
+            jkube.eclipse.org/git-branch: "@ignore@"
+          labels:
+            app: quarkus-properties
+            provider: jkube
+            version: "@ignore@"
+            group: org.eclipse.jkube.integration.tests.gradle
+          name: quarkus-properties
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: gradle/quarkus-properties:latest
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /q/health/live
+                  port: 8008
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                successThreshold: 1
+              name: quarkus
+              ports:
+                - containerPort: 8008
+                  name: http-alt
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /q/health/ready
+                  port: 8008
+                  scheme: HTTP
+                initialDelaySeconds: 5
+                successThreshold: 1
+              securityContext:
+                privileged: false
+              startupProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /q/health/started
+                  port: 8008
+                  scheme: HTTP
+                initialDelaySeconds: 5
+                successThreshold: 1

--- a/gradle-plugin/it/src/it/quarkus-properties/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/quarkus-properties/expected/openshift.yml
@@ -1,0 +1,128 @@
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        jkube.eclipse.org/git-commit: "@ignore@"
+        app.openshift.io/vcs-ref: "@ignore@"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9779"
+        jkube.eclipse.org/git-url: "@ignore@"
+        prometheus.io/scrape: "true"
+        app.openshift.io/vcs-uri: "@ignore@"
+        jkube.eclipse.org/git-branch: "@ignore@"
+      labels:
+        app: quarkus-properties
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube.integration.tests.gradle
+      name: quarkus-properties
+    spec:
+      ports:
+        - name: http-alt
+          port: 8008
+          protocol: TCP
+          targetPort: 8008
+      selector:
+        app: quarkus-properties
+        provider: jkube
+        group: org.eclipse.jkube.integration.tests.gradle
+  - apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      annotations:
+        jkube.eclipse.org/git-commit: "@ignore@"
+        jkube.eclipse.org/git-url: "@ignore@"
+        app.openshift.io/vcs-ref: "@ignore@"
+        app.openshift.io/vcs-uri: "@ignore@"
+        jkube.eclipse.org/git-branch: "@ignore@"
+      labels:
+        app: quarkus-properties
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube.integration.tests.gradle
+      name: quarkus-properties
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        app: quarkus-properties
+        provider: jkube
+        group: org.eclipse.jkube.integration.tests.gradle
+      strategy:
+        rollingParams:
+          timeoutSeconds: 3600
+        type: Rolling
+      template:
+        metadata:
+          annotations:
+            jkube.eclipse.org/git-commit: "@ignore@"
+            jkube.eclipse.org/git-url: "@ignore@"
+            app.openshift.io/vcs-ref: "@ignore@"
+            app.openshift.io/vcs-uri: "@ignore@"
+            jkube.eclipse.org/git-branch: "@ignore@"
+          labels:
+            app: quarkus-properties
+            provider: jkube
+            version: "@ignore@"
+            group: org.eclipse.jkube.integration.tests.gradle
+          name: quarkus-properties
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: quarkus-properties:latest
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /q/health/live
+                  port: 8008
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                successThreshold: 1
+              name: quarkus
+              ports:
+                - containerPort: 8008
+                  name: http-alt
+                  protocol: TCP
+                - containerPort: 9779
+                  name: prometheus
+                  protocol: TCP
+                - containerPort: 8778
+                  name: jolokia
+                  protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /q/health/ready
+                  port: 8008
+                  scheme: HTTP
+                initialDelaySeconds: 5
+                successThreshold: 1
+              securityContext:
+                privileged: false
+              startupProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /q/health/started
+                  port: 8008
+                  scheme: HTTP
+                initialDelaySeconds: 5
+                successThreshold: 1
+      triggers:
+        - type: ConfigChange
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+              - quarkus
+            from:
+              kind: ImageStreamTag
+              name: quarkus-properties:latest
+          type: ImageChange

--- a/gradle-plugin/it/src/it/quarkus-properties/gradle.properties
+++ b/gradle-plugin/it/src/it/quarkus-properties/gradle.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+#Gradle properties
+quarkusPluginId=io.quarkus
+quarkusPluginVersion=3.2.2.Final
+quarkusPlatformGroupId=io.quarkus.platform
+quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformVersion=3.2.2.Final

--- a/gradle-plugin/it/src/it/quarkus-properties/src/main/resources/application.properties
+++ b/gradle-plugin/it/src/it/quarkus-properties/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+quarkus.http.port=8008

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/QuarkusPropertiesIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/QuarkusPropertiesIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.tests;
+
+import net.minidev.json.parser.ParseException;
+import org.eclipse.jkube.kit.common.ResourceVerify;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class QuarkusPropertiesIT {
+  @RegisterExtension
+  private final ITGradleRunnerExtension gradleRunner = new ITGradleRunnerExtension();
+
+  @Test
+  void k8sResource_whenRun_generatesK8sManifestsWithProbes() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("quarkus-properties")
+        .withArguments("build", "k8sResource", "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
+        gradleRunner.resolveFile("expected", "kubernetes.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("jkube-controller: Adding a default Deployment")
+        .contains("jkube-service: Adding a default service")
+        .contains("jkube-healthcheck-quarkus: Adding readiness probe on port 8008")
+        .contains("jkube-healthcheck-quarkus: Adding liveness probe on port 8008")
+        .contains("jkube-service-discovery: Using first mentioned service port '8008' ")
+        .contains("jkube-revision-history: Adding revision history limit to 2");
+  }
+
+  @Test
+  void ocResource_whenRun_generatesOpenShiftManifestsWithProbes() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject("quarkus-properties")
+        .withArguments("build", "ocResource", "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
+        gradleRunner.resolveFile("expected", "openshift.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("jkube-controller: Adding a default Deployment")
+        .contains("jkube-service: Adding a default service")
+        .contains("jkube-openshift-deploymentconfig: Converting Deployment to DeploymentConfig")
+        .contains("jkube-healthcheck-quarkus: Adding readiness probe on port 8008")
+        .contains("jkube-healthcheck-quarkus: Adding liveness probe on port 8008")
+        .contains("jkube-service-discovery: Using first mentioned service port '8008' ")
+        .contains("jkube-revision-history: Adding revision history limit to 2");
+  }
+}

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricher.java
@@ -32,6 +32,8 @@ import static org.eclipse.jkube.quarkus.QuarkusUtils.QUARKUS_GROUP_ID;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.concatPath;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.isStartupEndpointSupported;
 import static org.eclipse.jkube.quarkus.QuarkusUtils.resolveCompleteQuarkusHealthRootPath;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.extractPort;
+import static org.eclipse.jkube.quarkus.QuarkusUtils.getQuarkusConfiguration;
 
 /**
  * Enriches Quarkus containers with health checks if the quarkus-smallrye-health is present
@@ -87,7 +89,7 @@ public class QuarkusHealthCheckEnricher extends AbstractHealthCheckEnricher {
         }
         return new ProbeBuilder()
             .withNewHttpGet()
-              .withNewPort(asInteger(getConfig(Config.PORT)))
+              .withNewPort(asInteger(extractPort(getContext().getProject(), getQuarkusConfiguration(getContext().getProject()), getConfig(Config.PORT))))
               .withPath(resolveHealthPath(pathResolver.apply(getContext().getProject())))
               .withScheme(getConfig(Config.SCHEME))
             .endHttpGet()


### PR DESCRIPTION
## Description



Fixes #2239 

- [x] Requires https://github.com/eclipse/jkube/pull/2312 to be merged first

k8s:resource doesn't automatically pick up port from Quarkus application.properties


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
