### PR TITLE
feat (jkube-kit/common) : Add workDir configuration option in ExternalCommand

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/ExternalCommand.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/ExternalCommand.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.kit.common;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,13 +36,19 @@ import org.apache.commons.lang3.StringUtils;
  */
 public abstract class ExternalCommand {
     protected final KitLogger log;
+    private final File workDir;
 
     private final ExecutorService executor = Executors.newFixedThreadPool(2);
 
     private int statusCode;
 
     protected ExternalCommand(KitLogger log) {
+        this(log, null);
+    }
+
+    protected ExternalCommand(KitLogger log, File dir) {
         this.log = log;
+        this.workDir = dir;
     }
 
     public void execute() throws IOException {
@@ -109,7 +116,7 @@ public abstract class ExternalCommand {
 
     private Process startProcess() throws IOException {
         try {
-            return Runtime.getRuntime().exec(getArgs());
+            return Runtime.getRuntime().exec(getArgs(), null, workDir);
         } catch (IOException e) {
             throw new IOException(String.format("Failed to start '%s' : %s",
                                                 getCommandAsString(),

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/ExternalCommandTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/ExternalCommandTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIOException;
+
+class ExternalCommandTest {
+  private final KitLogger kitLogger = new KitLogger.SilentLogger();
+
+  @Test
+  void execute_whenCommandCompletedSuccessfully_thenPrintResult() throws IOException {
+    // Given
+    TestCommand testCommand = new TestCommand(kitLogger, new String[] {"echo", "hello"});
+
+    // When
+    testCommand.execute();
+
+    // Then
+    assertThat(testCommand.getResult()).isEqualTo("hello");
+  }
+
+  @Test
+  void execute_whenCommandFailed_thenThrowException() {
+    // Given
+    TestCommand testCommand = new TestCommand(kitLogger, new String[] {"ls", "idontexist"});
+
+    // When + Then
+    assertThatIOException()
+        .isThrownBy(testCommand::execute)
+        .withMessage("Process 'ls idontexist' exited with status 2");
+  }
+
+  @Test
+  void execute_whenWorkDirProvided_thenUseWorkDir(@TempDir File temporaryFolder) throws IOException {
+    // Given
+    TestCommand testCommand = new TestCommand(kitLogger, new String[] {"touch", "foo"}, temporaryFolder);
+
+    // When
+    testCommand.execute();
+
+    // Then
+    assertThat(new File(temporaryFolder, "foo")).exists();
+  }
+
+
+  private static class TestCommand extends ExternalCommand {
+    private String result;
+    private final String[] args;
+    public TestCommand(KitLogger kitLogger, String[] args) {
+      this(kitLogger, args, null);
+    }
+
+    public TestCommand(KitLogger kitLogger, String[] args, File dir) {
+      super(kitLogger, dir);
+      this.args = args;
+    }
+
+    @Override
+    protected String[] getArgs() {
+      return args;
+    }
+
+    @Override
+    protected void processLine(String line) {
+        result = line;
+    }
+
+    public String getResult() {
+      return result;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Related to #1674

While executing a command, add a workDir configuration option to execute the command in a directory other than the current directory.

This will be used in Spring Boot layered generator when we want to extract layers in the build output directory rather than the project's base directory.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
