### PR TITLE
fix: project website url is now based on eclipse.dev/jkube

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,8 +27,8 @@ body:
 
         Useful Links:
 
-          - 📄  Documentation: https://www.eclipse.org/jkube/docs/
-          - 📝  Contributing: https://www.eclipse.org/jkube/contributing
+          - 📄  Documentation: https://www.eclipse.dev/jkube/docs/
+          - 📝  Contributing: https://www.eclipse.dev/jkube/contributing/
 
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -27,12 +27,12 @@ body:
 
         Useful Links:
 
-          - 📄  Documentation: https://www.eclipse.org/jkube/docs/
-          - 📝  Contributing: https://www.eclipse.org/jkube/contributing
+          - 📄  Documentation: https://www.eclipse.dev/jkube/docs/
+          - 📝  Contributing: https://www.eclipse.dev/jkube/contributing/
 
 
   - type: dropdown
-    id: component 
+    id: component
     attributes:
       label: Component
       description: Component

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -27,11 +27,11 @@ body:
 
         Useful Links:
 
-          - 📄  Documentation: https://www.eclipse.org/jkube/docs/
-          - 📝  Contributing: https://www.eclipse.org/jkube/contributing
+          - 📄  Documentation: https://www.eclipse.dev/jkube/docs/
+          - 📝  Contributing: https://www.eclipse.dev/jkube/contributing/
 
   - type: dropdown
-    id: component 
+    id: component
     attributes:
       label: Component
       description: Component

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ What types of changes does your code introduce? Put an `x` in all the boxes that
    test, version modification, documentation, etc.)
 
 ## Checklist
- - [ ] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
+ - [ ] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
  - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
  - [ ] My code follows the style guidelines of this project
  - [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## How to Contribute
 
 For information related to contributing to Eclipse JKube, please check out the
-[Contributing](https://www.eclipse.org/jkube/contributing)
-section at the [Eclipse JKube](https://www.eclipse.org/jkube/) site.
+[Contributing](https://www.eclipse.dev/jkube/contributing)
+section at the [Eclipse JKube](https://www.eclipse.dev/jkube/) site.
 
 ## Legal
 

--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -1,5 +1,5 @@
 # Migration Guide for projects using Fabric8 Maven Plugin to Eclipse JKube
 
 For information related to migrating from Fabric8 Maven Plugin to Eclipse JKube, please check out the
-[Migration Guide](https://www.eclipse.org/jkube/docs/migration-guide/)
-section of the documentation at the [Eclipse JKube](https://www.eclipse.org/jkube/) site.
+[Migration Guide](https://www.eclipse.dev/jkube/docs/migration-guide/)
+section of the documentation at the [Eclipse JKube](https://www.eclipse.dev/jkube/) site.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Twitter](https://img.shields.io/twitter/follow/jkubeio?style=social)](https://twitter.com/jkubeio)
 
 <p align="center">
-  <a href="https://www.eclipse.org/jkube/">
+  <a href="https://www.eclipse.dev/jkube/">
     <img src="./media/JKube-Logo-final-horizontal-color.png" alt="Eclipse JKube" title="The Eclipse JKube Logo"/>
   </a>
 </p>
@@ -22,17 +22,17 @@
   - [Kubernetes Gradle Plugin](#kubernetes-gradle-plugin)
   - [OpenShift Maven Plugin](#openshift-maven-plugin)
   - [OpenShift Gradle Plugin](#openshift-gradle-plugin)
-- [Migrating from Fabric8 Maven Plugin to Kubernetes/OpenShift Maven Plugin](https://www.eclipse.org/jkube/docs/migration-guide)
+- [Migrating from Fabric8 Maven Plugin to Kubernetes/OpenShift Maven Plugin](https://www.eclipse.dev/jkube/docs/migration-guide)
 - [Getting Started](#getting-started)
   - [Maven Quickstarts](./quickstarts/maven)
   - [Gradle Quickstarts](./quickstarts/gradle)
   - [Hello World using Eclipse JKube](#hello-world-using-eclipse-jkube)
     - [Troubleshooting](#troubleshooting)
 - [Rebranding Notice](#rebranding-notice--loudspeaker-)
-- [Contributing](https://www.eclipse.org/jkube/contributing/)
+- [Contributing](https://www.eclipse.dev/jkube/contributing/)
 - [How to use Eclipse JKube snapshot artifacts?](./USING-SNAPSHOT-ARTIFACTS.md)
 - [Add your organization to ADOPTERS](./ADOPTERS.md)
-- [FAQs](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin/#faq)
+- [FAQs](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin/#faq)
 
 ## Introduction
 
@@ -48,7 +48,7 @@ This project contains various building blocks for the Kubernetes Java developer 
 ### Kubernetes Maven Plugin
 
 - [![Maven Central](https://img.shields.io/maven-central/v/org.eclipse.jkube/kubernetes-maven-plugin.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.eclipse.jkube%22%20AND%20a:%22kubernetes-maven-plugin%22)
-- [![Documentation](https://img.shields.io/badge/plugin-documentation-lightgrey)](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin)
+- [![Documentation](https://img.shields.io/badge/plugin-documentation-lightgrey)](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin)
 - Add to project:
   ```xml
   <plugin>
@@ -68,7 +68,7 @@ This project contains various building blocks for the Kubernetes Java developer 
 ### Kubernetes Gradle Plugin
 
 - [![Maven Central](https://img.shields.io/maven-central/v/org.eclipse.jkube.kubernetes/org.eclipse.jkube.kubernetes.gradle.plugin.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.eclipse.jkube.kubernetes%22%20AND%20a:%22org.eclipse.jkube.kubernetes.gradle.plugin%22)
-- [![Documentation](https://img.shields.io/badge/plugin-documentation-lightgrey)](https://www.eclipse.org/jkube/docs/kubernetes-gradle-plugin/)
+- [![Documentation](https://img.shields.io/badge/plugin-documentation-lightgrey)](https://www.eclipse.dev/jkube/docs/kubernetes-gradle-plugin/)
 - Add to project:
   ```groovy
   plugins {
@@ -86,7 +86,7 @@ This project contains various building blocks for the Kubernetes Java developer 
 ### OpenShift Gradle Plugin
 
 - [![Maven Central](https://img.shields.io/maven-central/v/org.eclipse.jkube.openshift/org.eclipse.jkube.openshift.gradle.plugin.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.eclipse.jkube.openshift%22%20AND%20a:%22org.eclipse.jkube.openshift.gradle.plugin%22)
-- [![Documentation](https://img.shields.io/badge/plugin-documentation-lightgrey)](https://www.eclipse.org/jkube/docs/openshift-gradle-plugin/)
+- [![Documentation](https://img.shields.io/badge/plugin-documentation-lightgrey)](https://www.eclipse.dev/jkube/docs/openshift-gradle-plugin/)
 - Add to project:
   ```groovy
   plugins {
@@ -104,7 +104,7 @@ This project contains various building blocks for the Kubernetes Java developer 
 ### OpenShift Maven Plugin
 
 - [![Maven Central](https://img.shields.io/maven-central/v/org.eclipse.jkube/openshift-maven-plugin.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.eclipse.jkube%22%20AND%20a:%22openshift-maven-plugin%22)
-- [![Documentation](https://img.shields.io/badge/plugin-documentation-lightgrey)](https://www.eclipse.org/jkube/docs/openshift-maven-plugin)
+- [![Documentation](https://img.shields.io/badge/plugin-documentation-lightgrey)](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin)
 - Add to project:
   ```xml
   <plugin>

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/auth/AuthConfigFactory.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/auth/AuthConfigFactory.java
@@ -539,7 +539,7 @@ public class AuthConfigFactory {
         if (!credProviderPresent) {
             log.info("It appears that you're using AWS ECR." +
                     " Consider integrating the AWS SDK in order to make use of common AWS authentication mechanisms," +
-                    " see https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#extended-authentication");
+                    " see https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin#extended-authentication");
             return null;
         }
         return new AwsSdkAuthConfigFactory(log, awsSdkHelper).createAuthConfig();

--- a/jkube-kit/common-maven/src/test/java/org/eclipse/jkube/kit/common/util/MavenUtilTest.java
+++ b/jkube-kit/common-maven/src/test/java/org/eclipse/jkube/kit/common/util/MavenUtilTest.java
@@ -87,7 +87,7 @@ class MavenUtilTest {
     assertThat(project.getDescription()).isEqualTo("test description");
     assertThat(project.getOutputDirectory()).hasName("target");
     assertThat(project.getBuildDirectory()).hasName(".");
-    assertThat(project.getDocumentationUrl()).isEqualTo("https://www.eclipse.org/jkube/");
+    assertThat(project.getDocumentationUrl()).isEqualTo("https://www.eclipse.dev/jkube/");
     assertThat(mavenProject.getCompileClasspathElements()).hasSize(1);
     assertThat(mavenProject.getCompileClasspathElements()).first().isEqualTo("./target");
     assertThat(project.getProperties()).contains(entry("foo", "bar"));
@@ -178,7 +178,7 @@ class MavenUtilTest {
     mavenProject.setBuild(build);
     DistributionManagement distributionManagement = new DistributionManagement();
     Site site = new Site();
-    site.setUrl("https://www.eclipse.org/jkube/");
+    site.setUrl("https://www.eclipse.dev/jkube/");
     distributionManagement.setSite(site);
     mavenProject.setDistributionManagement(distributionManagement);
     mavenProject.setUrl("https://projects.eclipse.org/projects/ecd.jkube");

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -359,7 +359,7 @@ public class KubernetesHelper {
         if (cause instanceof UnknownHostException) {
             logger.error( "Could not connect to kubernetes cluster!");
             logger.error("Have you started a local cluster or connected to a remote cluster via `kubectl`?");
-            logger.info("For more help see: https://www.eclipse.org/jkube/docs/#getting-started");
+            logger.info("For more help see: https://www.eclipse.dev/jkube/docs/#getting-started");
             logger.error( "Connection error: %s", cause);
 
             String message = "Could not connect to kubernetes cluster. Have you started a local cluster or connected to a remote cluster via `kubectl`? Error: " + cause;

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
@@ -102,7 +102,7 @@ public class WebAppGenerator extends BaseGenerator {
     ) {
       throw new IllegalArgumentException("S2I not yet supported for the webapp-generator. Use " +
           "-Djkube.build.strategy=docker for OpenShift mode. Please refer to the reference manual at " +
-          "https://www.eclipse.org/jkube/docs for details about build modes.");
+          "https://www.eclipse.dev/jkube/docs for details about build modes.");
     }
 
 
@@ -186,7 +186,7 @@ public class WebAppGenerator extends BaseGenerator {
 
   private AssemblyConfiguration createAssembly(AppServerHandler handler) {
     final File sourceFile = Objects.requireNonNull(JKubeProjectUtil.getFinalOutputArtifact(getProject()),
-        "Final output artifact file was not detected. The project may have not been built. HINT: try to compile and package your application prior to running the container image build task."); 
+        "Final output artifact file was not detected. The project may have not been built. HINT: try to compile and package your application prior to running the container image build task.");
     final String targetFilename;
     final String extension = FilenameUtils.getExtension(sourceFile.getName());
     final String path = getConfig(Config.PATH);

--- a/kubernetes-maven-plugin/README.md
+++ b/kubernetes-maven-plugin/README.md
@@ -21,13 +21,16 @@ To enable kubernetes maven plugin on your project just add this to the plugins s
       </plugin>
 ```
 
-| Goal                                          | Description                           |
-| --------------------------------------------- | ------------------------------------- |
-| [`k8s:resource`](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#k8s:resource) | Create Kubernetes resource descriptors |
-| [`k8s:build`](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#k8s:build) | Build Docker images |
-| [`k8s:push`](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#k8s:push) | Push Docker images to a registry  |
-| [`k8s:deploy`](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#k8s:deploy) | Deploy Kubernetes resource objects to a cluster  |
-| [`k8s:watch`](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin#k8s:watch) | Watch for doing rebuilds and restarts |
+| Goal                                                                                            | Description                                                                                    |
+|-------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| [`k8s:resource`](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin#jkube:resource)     | Create Kubernetes resource descriptors                                                         |
+| [`k8s:build`](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin#jkube:build)           | Build Docker images                                                                            |
+| [`k8s:push`](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin#jkube:push)             | Push Docker images to a registry                                                               |
+| [`k8s:deploy`](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin#jkube:deploy)         | Deploy Kubernetes resource objects to a cluster                                                |
+| [`k8s:helm`](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin#jkube:helm)             | Generate Helm charts for your application                                                      |
+| [`k8s:helm-push`](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin#jkube:helm-push)   | Push generated Helm Charts to remote repository                                                |
+| [`k8s:remote-dev`](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin#jkube:remote-dev) | Run and debug code in your local machine while connected to services available in your cluster |
+| [`k8s:watch`](https://www.eclipse.dev/jkube/docs/kubernetes-maven-plugin#jkube:watch)           | Watch for doing rebuilds and restarts                                                          |
 
 ### Features
 

--- a/openshift-maven-plugin/README.md
+++ b/openshift-maven-plugin/README.md
@@ -21,13 +21,17 @@ To enable OpenShift maven plugin on your project just add this to the plugins se
       </plugin>
 ```
 
-| Goal                                          | Description                           |
-| --------------------------------------------- | ------------------------------------- |
-| [`oc:resource`](https://www.eclipse.org/jkube/docs/openshift-maven-plugin#oc:resource) | Create OpenShift resource descriptors |
-| [`oc:build`](https://www.eclipse.org/jkube/docs/openshift-maven-plugin#oc:build) | Build Docker images |
-| [`oc:push`](https://www.eclipse.org/jkube/docs/openshift-maven-plugin#oc:push) | Push Docker images to a registry  |
-| [`oc:deploy`](https://www.eclipse.org/jkube/docs/openshift-maven-plugin#oc:deploy) | Deploy OpenShift resource objects to a cluster  |
-| [`oc:watch`](https://www.eclipse.org/jkube/docs/openshift-maven-plugin#oc:watch) | Watch for doing rebuilds and restarts |
+| Goal                                                                                          | Description                                                                                    |
+|-----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| [`oc:resource`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:resource)     | Create Kubernetes resource descriptors                                                         |
+| [`oc:build`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:build)           | Build Docker images                                                                            |
+| [`oc:push`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:push)             | Push Docker images to a registry                                                               |
+| [`oc:deploy`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:deploy)         | Deploy Kubernetes resource objects to a cluster                                                |
+| [`oc:helm`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:helm)             | Generate Helm charts for your application                                                      |
+| [`oc:helm-push`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:helm-push)   | Push generated Helm Charts to remote repository                                                |
+| [`oc:remote-dev`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:remote-dev) | Run and debug code in your local machine while connected to services available in your cluster |
+| [`oc:watch`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:watch)           | Watch for doing rebuilds and restarts                                                          |
+
 
 ### Features
 

--- a/quickstarts/maven/ibm-javaee8-webprofile-liberty/README.md
+++ b/quickstarts/maven/ibm-javaee8-webprofile-liberty/README.md
@@ -198,5 +198,5 @@ Server was started
 ```
 
 [openliberty]: http://openliberty.io/
-[k-m-p]: https://www.eclipse.org/jkube
+[k-m-p]: https://www.eclipse.dev/jkube
 [minikube]: https://github.com/kubernetes/minikube

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -116,7 +116,7 @@ function emailTemplate() {
   lines+="$numberedChangelog\n\n"
   lines+="Your feedback is highly appreciated, you can provide it by replying to the mailing list or through the usual channels. $githubLinkId $gitterLinkId\n\n"
   lines+="[1] https://repo1.maven.org/maven2/org/eclipse/jkube/kubernetes-maven-plugin/$1/\n"
-  lines+="[2] https://www.eclipse.org/jkube/docs/migration-guide/\n"
+  lines+="[2] https://www.eclipse.dev/jkube/docs/migration-guide/\n"
   lines+="$changelogLinks\n"
   lines+="$githubLinkId https://github.com/eclipse/jkube\n"
   lines+="$gitterLinkId https://gitter.im/eclipse/jkube\n"


### PR DESCRIPTION
## Description

Fix #2148

fix: project website url is now based on eclipse.dev/jkube

Moved from eclipse.org/jkube
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3069

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
