### PR TITLE
fix: enrichers with NAME configuration override fragments with default names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Usage:
 * Fix #2301: Add compatibility with SemVer versions
 * Fix #2302 Bump Kubernetes Client version to 6.8.0
 * Fix #2324: Update SpringBootConfigurationHelper for Spring Boot 3.x
+* Fix #2350: Enrichers with NAME configuration override fragments with default names
 
 ### 1.13.1 (2023-06-16)
 * Fix #2212: Bump Kubernetes Client version to 6.7.2 (fixes issues when trace-logging OpenShift builds -regression in 6.7.1-)

--- a/gradle-plugin/it/src/it/controller-name-fragment/build.gradle
+++ b/gradle-plugin/it/src/it/controller-name-fragment/build.gradle
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+plugins {
+    id 'org.eclipse.jkube.kubernetes' version "${jKubeVersion}"
+    id 'org.eclipse.jkube.openshift' version "${jKubeVersion}"
+    id 'java'
+}
+
+group = 'org.eclipse.jkube.integration.tests.gradle'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '11'
+
+repositories {
+    mavenCentral()
+}
+
+def extensionConfig = {
+    offline = true
+    enricher {
+        config {
+            'jkube-controller-from-configuration' {
+                name = 'customized-name'
+            }
+        }
+    }
+    images {
+        image {
+            name = 'repository/controller-name-fragment:latest'
+            build {
+                from = 'quay.io/jkube/jkube-java'
+            }
+        }
+    }
+}
+
+kubernetes(extensionConfig)
+openshift(extensionConfig)

--- a/gradle-plugin/it/src/it/controller-name-fragment/expected/kubernetes.yml
+++ b/gradle-plugin/it/src/it/controller-name-fragment/expected/kubernetes.yml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: controller-name-fragment
+        provider: jkube
+        version: "@ignore@"
+        group: org.eclipse.jkube.integration.tests.gradle
+      name: customized-name
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          app: controller-name-fragment
+          provider: jkube
+          group: org.eclipse.jkube.integration.tests.gradle
+      template:
+        metadata:
+          annotations:
+            jkube.eclipse.org/git-url: "@ignore@"
+            jkube.eclipse.org/git-commit: "@ignore@"
+            jkube.eclipse.org/git-branch: "@ignore@"
+          labels:
+            app: controller-name-fragment
+            provider: jkube
+            version: "@ignore@"
+            group: org.eclipse.jkube.integration.tests.gradle
+        spec:
+          containers:
+            - env:
+                - name: ADDITIONAL_VARIABLE
+                  value: additional-value
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: repository/controller-name-fragment:latest
+              imagePullPolicy: IfNotPresent
+              name: repository-controller-name-fragment
+              securityContext:
+                privileged: false

--- a/gradle-plugin/it/src/it/controller-name-fragment/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/controller-name-fragment/expected/openshift.yml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-branch: "@ignore@"
+    labels:
+      app: controller-name-fragment
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: customized-name
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: controller-name-fragment
+      provider: jkube
+      group: org.eclipse.jkube.integration.tests.gradle
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        annotations:
+          app.openshift.io/vcs-ref: "@ignore@"
+          jkube.eclipse.org/git-url: "@ignore@"
+          app.openshift.io/vcs-uri: "@ignore@"
+          jkube.eclipse.org/git-commit: "@ignore@"
+          jkube.eclipse.org/git-branch: "@ignore@"
+        labels:
+          app: controller-name-fragment
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube.integration.tests.gradle
+      spec:
+        containers:
+        - env:
+          - name: ADDITIONAL_VARIABLE
+            value: additional-value
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: repository/controller-name-fragment:latest
+          imagePullPolicy: IfNotPresent
+          name: repository-controller-name-fragment
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - repository-controller-name-fragment
+        from:
+          kind: ImageStreamTag
+          name: controller-name-fragment:latest
+      type: ImageChange

--- a/gradle-plugin/it/src/it/controller-name-fragment/src/main/jkube/deployment.yml
+++ b/gradle-plugin/it/src/it/controller-name-fragment/src/main/jkube/deployment.yml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+spec:
+  template:
+    spec:
+      containers:
+        - env:
+            - name: ADDITIONAL_VARIABLE
+              value: additional-value

--- a/gradle-plugin/it/src/it/service-name-fragment/build.gradle
+++ b/gradle-plugin/it/src/it/service-name-fragment/build.gradle
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+plugins {
+    id 'org.eclipse.jkube.kubernetes' version "${jKubeVersion}"
+    id 'org.eclipse.jkube.openshift' version "${jKubeVersion}"
+    id 'java'
+}
+
+group = 'org.eclipse.jkube.integration.tests.gradle'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '11'
+
+repositories {
+    mavenCentral()
+}
+
+def extensionConfig = {
+  offline = true
+  images {
+    image {
+      name = 'repository/service-name-fragment:latest'
+      build {
+        from = 'quay.io/jkube/jkube-java'
+        ports = ['8080']
+      }
+    }
+  }
+  enricher {
+    config {
+      'jkube-service' {
+        name = 'customized-name'
+      }
+    }
+  }
+}
+
+kubernetes(extensionConfig)
+openshift(extensionConfig)

--- a/gradle-plugin/it/src/it/service-name-fragment/expected/kubernetes.yml
+++ b/gradle-plugin/it/src/it/service-name-fragment/expected/kubernetes.yml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+      jkube.eclipse.org/git-branch: "@ignore@"
+    labels:
+      app: service-name-fragment
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: customized-name
+  spec:
+    ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: service-name-fragment
+      provider: jkube
+      group: org.eclipse.jkube.integration.tests.gradle
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+      jkube.eclipse.org/git-branch: "@ignore@"
+    labels:
+      app: service-name-fragment
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: service-name-fragment
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      matchLabels:
+        app: service-name-fragment
+        provider: jkube
+        group: org.eclipse.jkube.integration.tests.gradle
+    template:
+      metadata:
+        annotations:
+          jkube.eclipse.org/git-commit: "@ignore@"
+          jkube.eclipse.org/git-url: "@ignore@"
+          jkube.eclipse.org/git-branch: "@ignore@"
+        labels:
+          app: service-name-fragment
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube.integration.tests.gradle
+        name: service-name-fragment
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: repository/service-name-fragment:latest
+          imagePullPolicy: IfNotPresent
+          name: repository-service-name-fragment
+          securityContext:
+            privileged: false

--- a/gradle-plugin/it/src/it/service-name-fragment/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/service-name-fragment/expected/openshift.yml
@@ -1,0 +1,112 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      jkube.eclipse.org/git-commit: "@ignore@"
+      app.openshift.io/vcs-ref: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.eclipse.org/git-branch: "@ignore@"
+    labels:
+      app: service-name-fragment
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: customized-name
+  spec:
+    ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: service-name-fragment
+      provider: jkube
+      group: org.eclipse.jkube.integration.tests.gradle
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+      app.openshift.io/vcs-ref: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.eclipse.org/git-branch: "@ignore@"
+    labels:
+      app: service-name-fragment
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: service-name-fragment
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: service-name-fragment
+      provider: jkube
+      group: org.eclipse.jkube.integration.tests.gradle
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        annotations:
+          jkube.eclipse.org/git-commit: "@ignore@"
+          jkube.eclipse.org/git-url: "@ignore@"
+          app.openshift.io/vcs-ref: "@ignore@"
+          app.openshift.io/vcs-uri: "@ignore@"
+          jkube.eclipse.org/git-branch: "@ignore@"
+        labels:
+          app: service-name-fragment
+          provider: jkube
+          version: "@ignore@"
+          group: org.eclipse.jkube.integration.tests.gradle
+        name: service-name-fragment
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: repository/service-name-fragment:latest
+          imagePullPolicy: IfNotPresent
+          name: repository-service-name-fragment
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - repository-service-name-fragment
+        from:
+          kind: ImageStreamTag
+          name: service-name-fragment:latest
+      type: ImageChange
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+      app.openshift.io/vcs-ref: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.eclipse.org/git-branch: "@ignore@"
+    labels:
+      app: service-name-fragment
+      provider: jkube
+      version: "@ignore@"
+      group: org.eclipse.jkube.integration.tests.gradle
+    name: customized-name
+  spec:
+    port:
+      targetPort: 9090
+    to:
+      kind: Service
+      name: customized-name

--- a/gradle-plugin/it/src/it/service-name-fragment/src/main/jkube/service.yaml
+++ b/gradle-plugin/it/src/it/service-name-fragment/src/main/jkube/service.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+spec:
+  ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: 8080

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ControllerNameAndFragmentIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ControllerNameAndFragmentIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.tests;
+
+import net.minidev.json.parser.ParseException;
+import org.eclipse.jkube.kit.common.ResourceVerify;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DisplayName("Controller can have name overridden by configuration when there's a Deployment fragment")
+class ControllerNameAndFragmentIT {
+
+  private static final String TEST_PROJECT = "controller-name-fragment";
+
+  @RegisterExtension
+  protected final ITGradleRunnerExtension gradleRunner = new ITGradleRunnerExtension();
+
+  @Test
+  void k8sResourceTask() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject(TEST_PROJECT)
+        .withArguments("k8sResource", "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
+        gradleRunner.resolveFile("expected", "kubernetes.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Using resource templates from")
+        .contains("Adding revision history limit to 2")
+        .contains("validating");
+  }
+
+  @Test
+  void ocResourceTask() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject(TEST_PROJECT)
+        .withArguments("ocResource", "--stacktrace")
+        .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
+        gradleRunner.resolveFile("expected", "openshift.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+        .contains("Using resource templates from")
+        .contains("Adding revision history limit to 2")
+        .contains("validating");
+  }
+}

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceNameAndFragmentIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceNameAndFragmentIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.gradle.plugin.tests;
+
+import net.minidev.json.parser.ParseException;
+import org.eclipse.jkube.kit.common.ResourceVerify;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DisplayName("Service can have name overridden by configuration when there's a service fragment")
+class ServiceNameAndFragmentIT {
+
+  private static final String TEST_PROJECT = "service-name-fragment";
+
+  @RegisterExtension
+  protected final ITGradleRunnerExtension gradleRunner = new ITGradleRunnerExtension();
+
+  @Test
+  void k8sResourceTask() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject(TEST_PROJECT)
+      .withArguments("k8sResource", "--stacktrace")
+      .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultKubernetesResourceFile(),
+      gradleRunner.resolveFile("expected", "kubernetes.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+      .contains("Using resource templates from")
+      .contains("Adding a default Deployment")
+      .contains("Adding revision history limit to 2")
+      .contains("validating");
+  }
+
+  @Test
+  void ocResourceTask() throws IOException, ParseException {
+    // When
+    final BuildResult result = gradleRunner.withITProject(TEST_PROJECT)
+      .withArguments("ocResource", "--stacktrace")
+      .build();
+    // Then
+    ResourceVerify.verifyResourceDescriptors(gradleRunner.resolveDefaultOpenShiftResourceFile(),
+      gradleRunner.resolveFile("expected", "openshift.yml"));
+    assertThat(result).extracting(BuildResult::getOutput).asString()
+      .contains("Using resource templates from")
+      .contains("Adding a default Deployment")
+      .contains("Adding revision history limit to 2")
+      .contains("validating");
+  }
+}

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/GroupArtifactVersion.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/GroupArtifactVersion.java
@@ -37,14 +37,10 @@ public class GroupArtifactVersion {
      * @return Sanitized Kubernetes name.
      */
     public String getSanitizedArtifactId() {
-        return sanitize(getArtifactId());
-    }
-
-    public static String sanitize(String coordinate) {
-        if (coordinate != null && !coordinate.isEmpty() && Character.isDigit(coordinate.charAt(0))) {
-            return PREFIX + coordinate;
+        if (getArtifactId() != null && !getArtifactId().isEmpty() && Character.isDigit(getArtifactId().charAt(0))) {
+            return PREFIX + getArtifactId();
         }
-        return coordinate;
+        return getArtifactId();
     }
 }
 

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceFragmentsTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceFragmentsTest.java
@@ -87,7 +87,7 @@ public class KubernetesResourceFragmentsTest {
       KubernetesResourceFragments.updateKindFilenameMappings(mappingConfigs);
       // Then
       assertThat(getNameWithSuffix("the-foo-tab", "FooTab")).isEqualTo("the-foo-tab-ft");
-      assertThat(readResourceFragmentsFrom("app", fooTabYaml).buildItems())
+      assertThat(readResourceFragmentsFrom(fooTabYaml).buildItems())
         .singleElement()
         .hasFieldOrPropertyWithValue("kind", "FooTab");
     }
@@ -135,7 +135,7 @@ public class KubernetesResourceFragmentsTest {
     void withValidDirectory_shouldReadAllFragments() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "pong", new File(fragmentsDir, "complete-directory")
+        new File(fragmentsDir, "complete-directory")
           .listFiles());
       // Then
       assertThat(result.build().getItems())
@@ -159,7 +159,7 @@ public class KubernetesResourceFragmentsTest {
       ));
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "pong", new File(fragmentsDir, "complete-directory-custom-mappings")
+        new File(fragmentsDir, "complete-directory-custom-mappings")
           .listFiles());
       // Then
       assertThat(result.build().getItems())
@@ -187,8 +187,7 @@ public class KubernetesResourceFragmentsTest {
         Files.write(resourceDir.resolve("named-cm.yaml"), "field: value".getBytes()).toFile().getAbsoluteFile()
       };
       // When
-      final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "pong", resourceFiles);
+      final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(resourceFiles);
       // Then
       assertThat(result.buildItems()).hasSize(2)
         .extracting("additionalProperties.field")
@@ -199,7 +198,7 @@ public class KubernetesResourceFragmentsTest {
     void withYamlFileAndVersionKindNameFromFile_shouldReturnValidResource() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "simple-rc.yaml"));
+        new File(fragmentsDir, "simple-rc.yaml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
@@ -214,7 +213,7 @@ public class KubernetesResourceFragmentsTest {
     void withJsonFileAndVersionKindNameFromFile_shouldReturnValidResource() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "simple-rc.json"));
+        new File(fragmentsDir, "simple-rc.json"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
@@ -229,7 +228,7 @@ public class KubernetesResourceFragmentsTest {
     void withEmptyFileAndNameAndKindInFileName_shouldReturnEmptyResource() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "empty-file-svc.yml"));
+        new File(fragmentsDir, "empty-file-svc.yml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
@@ -246,7 +245,7 @@ public class KubernetesResourceFragmentsTest {
       final File resource = new File(fragmentsDir, "simple-rc.txt");
       // When & Then
       assertThatIllegalArgumentException()
-        .isThrownBy(() -> KubernetesResourceFragments.readResourceFragmentsFrom("app", resource))
+        .isThrownBy(() -> KubernetesResourceFragments.readResourceFragmentsFrom(resource))
         .withMessage("Resource file name 'simple-rc.txt' does not match pattern <name>-<type>.(yaml|yml|json)");
 
     }
@@ -258,7 +257,7 @@ public class KubernetesResourceFragmentsTest {
       final File resource = new File(fragmentsDir, "contains_no_kind.yml");
       // When & Then
       assertThatIllegalArgumentException()
-        .isThrownBy(() -> KubernetesResourceFragments.readResourceFragmentsFrom("app", resource))
+        .isThrownBy(() -> KubernetesResourceFragments.readResourceFragmentsFrom(resource))
         .withMessageStartingWith("No type given as part of the file name (e.g. 'app-rc.yml') and no 'kind' defined in resource descriptor contains_no_kind.yml");
     }
 
@@ -269,7 +268,7 @@ public class KubernetesResourceFragmentsTest {
       final File resource = new File(fragmentsDir, "invalid-metadata-pod.yaml");
       // When & Then
       assertThatIllegalArgumentException()
-        .isThrownBy(() -> KubernetesResourceFragments.readResourceFragmentsFrom("app", resource))
+        .isThrownBy(() -> KubernetesResourceFragments.readResourceFragmentsFrom(resource))
         .withMessageStartingWith("Metadata is expected to be a Map, not a");
     }
 
@@ -280,7 +279,7 @@ public class KubernetesResourceFragmentsTest {
       final File resource = new File(fragmentsDir, "I-Dont-EXIST.yaml");
       // When & Then
       assertThatIOException()
-        .isThrownBy(() -> KubernetesResourceFragments.readResourceFragmentsFrom("app", resource))
+        .isThrownBy(() -> KubernetesResourceFragments.readResourceFragmentsFrom(resource))
         .withMessageContaining("I-Dont-EXIST.yaml")
         .isInstanceOf(NoSuchFileException.class);
     }
@@ -290,7 +289,7 @@ public class KubernetesResourceFragmentsTest {
     void withNameInFieldAndFilename_shouldBeNamedFromField() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "named-svc.yaml"));
+        new File(fragmentsDir, "named-svc.yaml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
@@ -305,7 +304,7 @@ public class KubernetesResourceFragmentsTest {
     void withNameInField_shouldBeamedFromField() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "rc.yml"));
+        new File(fragmentsDir, "rc.yml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
@@ -320,14 +319,14 @@ public class KubernetesResourceFragmentsTest {
     void withNoNameInFieldAndNoNameInFilename_shouldBeNamedFromDefaultName() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "default-app", new File(fragmentsDir, "svc.yml"));
+        new File(fragmentsDir, "svc.yml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
         .isInstanceOf(Service.class)
         .hasFieldOrPropertyWithValue("apiVersion", "v1")
         .hasFieldOrPropertyWithValue("kind", "Service")
-        .hasFieldOrPropertyWithValue("metadata.name", "default-app");
+        .hasFieldOrPropertyWithValue("metadata.name", null);
     }
 
     @Test
@@ -335,7 +334,7 @@ public class KubernetesResourceFragmentsTest {
     void withKindInFieldAndNotInFilename_shouldGetKindFromValue() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "contains_kind.yml"));
+        new File(fragmentsDir, "contains_kind.yml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
@@ -349,14 +348,14 @@ public class KubernetesResourceFragmentsTest {
     void withKindFromFilename_shouldGetKindFromFilename() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "job.yml"));
+        new File(fragmentsDir, "job.yml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
         .isInstanceOf(Job.class)
         .hasFieldOrPropertyWithValue("apiVersion", "batch/v1")
         .hasFieldOrPropertyWithValue("kind", "Job")
-        .hasFieldOrPropertyWithValue("metadata.name", "app");
+        .hasFieldOrPropertyWithValue("metadata.name", null);
     }
 
     @Test
@@ -364,7 +363,7 @@ public class KubernetesResourceFragmentsTest {
     void withKindInFieldAndInFilename_shouldGetKindFromField() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "override-kind-pod.yml"));
+        new File(fragmentsDir, "override-kind-pod.yml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
@@ -378,7 +377,7 @@ public class KubernetesResourceFragmentsTest {
     void withValueInKindAndFilenameWithDashes_shouldGetKindFromValue() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "file-name-with-dashes-kind-in-field.yml"));
+        new File(fragmentsDir, "file-name-with-dashes-kind-in-field.yml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
@@ -392,7 +391,7 @@ public class KubernetesResourceFragmentsTest {
     void withNetworkV1Ingress_shouldLoadNetworkV1Ingress() throws IOException {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "network-v1-ingress.yml"));
+        new File(fragmentsDir, "network-v1-ingress.yml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()
@@ -407,7 +406,7 @@ public class KubernetesResourceFragmentsTest {
     void withNetworkPolicyV1_shouldLoadV1NetworkPolicy() throws Exception {
       // When
       final KubernetesListBuilder result = KubernetesResourceFragments.readResourceFragmentsFrom(
-        "app", new File(fragmentsDir, "networking-v1-np.yml"));
+        new File(fragmentsDir, "networking-v1-np.yml"));
       // Then
       assertThat(result.buildItems())
         .singleElement()

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
@@ -35,6 +35,8 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.enricher.api.ServiceExposer;
 
+import java.util.Objects;
+
 import static org.eclipse.jkube.enricher.generic.DefaultServiceEnricher.getPortToExpose;
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.mergeMetadata;
 import static org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil.mergeSimpleFields;
@@ -187,14 +189,15 @@ public class RouteEnricher extends BaseEnricher implements ServiceExposer {
 
     static int getRouteIndexWithName(final KubernetesListBuilder listBuilder, final String name) {
         int routeInListIndex = -1;
-        for (int index = 0; index < listBuilder.buildItems().size(); index++) {
-            HasMetadata item = listBuilder.buildItems().get(index);
+        int index = 0;
+        for (HasMetadata item : listBuilder.buildItems()) {
             if (item != null &&
-                    item.getMetadata() != null &&
-                    item.getMetadata().getName().equals(name) &&
-                    item instanceof Route) {
+              item.getMetadata() != null &&
+              Objects.equals(item.getMetadata().getName(), name) &&
+              item instanceof Route) {
                 routeInListIndex = index;
             }
+            index++;
         }
         return routeInListIndex;
     }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DependencyEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DependencyEnricherTest.java
@@ -86,9 +86,7 @@ class DependencyEnricherTest {
          * Our override file also contains a ConfigMap item with name jenkins, load it while
          * loading Kubernetes resources.
          */
-        return KubernetesResourceFragments.readResourceFragmentsFrom(
-                "the-project",
-                resourceList.toArray(new File[0]));
+        return KubernetesResourceFragments.readResourceFragmentsFrom(resourceList.toArray(new File[0]));
     }
 
     private boolean checkUniqueResources(List<HasMetadata> resourceList) {

--- a/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/DefaultResourceService.java
+++ b/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/DefaultResourceService.java
@@ -22,7 +22,6 @@ import javax.validation.ConstraintViolationException;
 
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.ResourceFileType;
-import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
 import org.eclipse.jkube.kit.common.util.ResourceClassifier;
 import org.eclipse.jkube.kit.common.util.ValidationUtil;
 import org.eclipse.jkube.kit.config.resource.EnricherManager;
@@ -40,7 +39,6 @@ import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 
 import static org.eclipse.jkube.kit.common.util.KubernetesHelper.listResourceFragments;
-import static org.eclipse.jkube.kit.config.resource.GroupArtifactVersion.sanitize;
 import static org.eclipse.jkube.kit.resource.service.TemplateUtil.interpolateTemplateVariables;
 import static org.eclipse.jkube.kit.resource.service.WriteUtil.writeResourcesIndividualAndComposite;
 
@@ -139,9 +137,7 @@ public class DefaultResourceService implements ResourceService {
   }
 
   private KubernetesListBuilder readResourceFragments(File[] resourceFiles) throws IOException {
-    return KubernetesResourceFragments.readResourceFragmentsFrom(
-        JKubeProjectUtil.createDefaultResourceName(sanitize(resourceServiceConfig.getProject().getArtifactId())),
-        resourceFiles);
+    return KubernetesResourceFragments.readResourceFragmentsFrom(resourceFiles);
   }
 
   private File[] processResourceFiles(File[] resourceFiles) throws IOException {


### PR DESCRIPTION
## Description

Fix #2350

Fragments are no longer initiated with a default name (was never necessary).

Either the `jkube-name` enricher or any of the other enrichers that merge opinionated defaults with the provided fragments (service, controller) will take care of providing a default metadata.name for the fragment in case it doesn't have one.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
