### PR TITLE
fix: docker pull rate limit in tests

### DIFF
--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceBuildIntegrationTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceBuildIntegrationTest.java
@@ -106,6 +106,7 @@ class JibBuildServiceBuildIntegrationTest {
     FileUtils.touch(otherFile);
     final ImageConfiguration ic = imageConfiguration.toBuilder()
         .build(BuildConfiguration.builder()
+            .from("gcr.io/distroless/base")
             .assembly(AssemblyConfiguration.builder()
                 .name("custom")
                 .targetDir("/deployments")
@@ -121,13 +122,14 @@ class JibBuildServiceBuildIntegrationTest {
                         .destName(otherFile.getName()).build())
                     .build())
                 .build())
+            .volume("/deployments")
             .build())
         .build();
     // When
     jibBuildService.build(ic);
     // Then
     assertDockerFile()
-        .hasContent("FROM busybox\n" +
+        .hasContent("FROM gcr.io/distroless/base\n" +
             "COPY /deployments-layer/deployments /deployments/\n" +
             "COPY /other-layer/deployments /deployments/\n" +
             "COPY /jkube-generated-layer-final-artifact/deployments /deployments/\n" +
@@ -150,9 +152,9 @@ class JibBuildServiceBuildIntegrationTest {
         );
     ArchiveAssertions.assertThat(resolveDockerBuildDirs().resolve("tmp").resolve("docker-build.tar").toFile())
       .fileTree()
-      .hasSize(6)
+      .hasSize(17)
       .contains("config.json", "manifest.json")
-      .haveExactly(4, new Condition<>(s -> s.endsWith(".tar.gz"), "Tar File layers"));
+      .haveExactly(15, new Condition<>(s -> s.endsWith(".tar.gz"), "Tar File layers"));
   }
 
 


### PR DESCRIPTION
## Description



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
