### PR TITLE
fix (jkube-kit/generator) : Do not add build timestamp to `org.label-schema.build-date` LABEL to better utilize docker cache (#2393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@ Usage:
 * Fix #2369: Helm chart apiVersion can be configured
 * Fix #2386: Helm icon inferred from annotations in independent resource files (not aggregated kubernetes/openshift.yaml)
 * Fix #2397: Default JKube work directory (`jkube.workDir`) changed from `${project.build.directory}/jkube` to `${project.build.directory}/jkube-temp`
+* Fix #2393: Remove timestamp from `org.label-schema.build-date` LABEL to utilize docker cache
 * Fix #2399: Helm no longer generates default function; broadens support for different value types
+
+_**Note**_:
+- Container Images generated using jkube opinionated defaults no longer contain full timestamp in `org.label-schema.build-date` label. The label contains the build date in the format `yyyy-MM-dd`.
 
 ### 1.14.0 (2023-08-31)
 * Fix #1674: SpringBootGenerator utilizes the layered jar if present and use it as Docker layers

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
@@ -15,6 +15,9 @@ package org.eclipse.jkube.generator.api.support;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.FormatStyle;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -256,7 +259,7 @@ public abstract class BaseGenerator implements Generator {
         String docURL = project.getDocumentationUrl();
         Map<String, String> labels = new HashMap<>();
 
-        labels.put(BuildLabelAnnotations.BUILD_DATE.value(), LocalDateTime.now().toString());
+        labels.put(BuildLabelAnnotations.BUILD_DATE.value(), LocalDateTime.now().format(DateTimeFormatter.ISO_DATE));
         labels.put(BuildLabelAnnotations.NAME.value(), project.getName());
         labels.put(BuildLabelAnnotations.DESCRIPTION.value(), project.getDescription());
         if (docURL != null) {


### PR DESCRIPTION
## Description

Fixes #2393

We add `org.label-schema.build-date` LABEL to image while creating opinionated container images. This causes Dockerfile to be different for every build and it doesn't utilize Docker cache properly. It causes the following layers to always be rebuild without using cache.

:heavy_check_mark: `FROM quay.io/jkube/jkube-java:0.0.19`
:heavy_check_mark:  `ENV JAVA_MAIN_CLASS=org.springframework.boot.loader.JarLauncher JAVA_APP_DIR=/deployments`
:x: `LABEL org.label-schema.build-date=2023-09-27T22:11:40.590328158` 
:x: `EXPOSE 8080 8778 9779`
:x: `COPY /dependencies/deployments /deployments/`
:x: `COPY /spring-boot-loader/deployments /deployments/`
:x: `COPY /application/deployments /deployments/`
:x: `WORKDIR /deployments`
:x: `ENTRYPOINT ["java","org.springframework.boot.loader.JarLauncher"]`

Update `org.label-schema.build-date` label to specify only date so that docker cache can be reused for subsequent rebuilds.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
