### PR TITLE
fix (jkube-kit) : lastModified timestamps should be preserved while preparing assembly

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/FileUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/FileUtil.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 /**
@@ -201,7 +202,7 @@ public class FileUtil {
     }
 
     public static void copy(Path sourcePath, Path targetPath) throws IOException {
-        Files.copy(sourcePath, targetPath, REPLACE_EXISTING);
+        Files.copy(sourcePath, targetPath, REPLACE_EXISTING, COPY_ATTRIBUTES);
     }
 
     public static void copyDirectoryIfNotExists(File sourceDir, File targetDir) throws IOException {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/FileUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/FileUtilTest.java
@@ -15,7 +15,10 @@ package org.eclipse.jkube.kit.common.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -149,6 +152,23 @@ class FileUtilTest {
     relativeFile = getRelativePath(folder,
         new File(folder.getAbsolutePath() + File.separator + "foo" + File.separator + "fileInFoo1"));
     assertThat(relativeFile.getPath()).isEqualTo("foo" + File.separator + "fileInFoo1");
+  }
+
+  @Test
+  void copy_whenFileCopied_shouldPreserveLastModifiedTimestamp() throws IOException {
+    // Given
+    File sourceFile = new File(folder, "source");
+    Files.write(sourceFile.toPath(), "testdata".getBytes(StandardCharsets.UTF_8));
+    long originalTimestamp = new Date().getTime() - 10;
+    assertThat(sourceFile.setLastModified(originalTimestamp)).isTrue();
+    Path targetFilePath = folder.toPath().resolve("target");
+
+    // When
+    FileUtil.copy(sourceFile.toPath(), targetFilePath);
+
+    // Then
+    assertThat(targetFilePath.toFile()).hasSameTextualContentAs(sourceFile);
+    assertThat(targetFilePath.toFile().lastModified()).isEqualTo(originalTimestamp);
   }
 
   private void prepareDirectory() throws IOException {


### PR DESCRIPTION
## Description

We don't seem to be preserving lastModified timestamps of files that are being copied while preparing the assembly for image. Make sure we're copying all the metadata of files/directories as well while copying them.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
