### PR TITLE
fix (jkube-kit) : Fix `Fabric8HttpUtil.extractAuthenticationChallengeIntoMap` www-authenticate header parsing logic (#2419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Usage:
 * Fix #2400: Helm supports complex values in `values.yaml` fragments (such as annotations or arrays)
 * Fix #2414: OpenShift Gradle Plugin picks up `jkube.build.pushSecret` property
 * Fix #2417: Don't pass Invalid port in host headers for Helm OCI push
+* Fix #2419: Fix `Fabric8HttpUtil.extractAuthenticationChallengeIntoMap` www-authenticate header parsing logic
 * Fix #2425: Bump JKube Base images to 0.0.20
 
 _**Note**_:

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/Fabric8HttpUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/Fabric8HttpUtil.java
@@ -13,16 +13,16 @@
  */
 package org.eclipse.jkube.kit.common.util;
 
-import io.fabric8.kubernetes.client.http.HttpResponse;
-import org.apache.commons.lang3.StringUtils;
-
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang3.StringUtils.strip;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+
+import static org.eclipse.jkube.kit.common.util.okhttp.HttpHeaders.parseWwwAuthenticateChallengeHeaders;
 
 public class Fabric8HttpUtil {
   private static final String WWW_AUTHENTICATE = "WWW-Authenticate";
@@ -30,28 +30,14 @@ public class Fabric8HttpUtil {
   private Fabric8HttpUtil() { }
 
   /**
-   * Parse WWW-Authenticate Header as map
+   * Parse WWW-Authenticate Header challenges as map
    *
    * @param response Http Response of a particular request
-   * @return map containing various components of header as key value pairs
+   * @return list of maps containing various authentication challenges which each authentication challenge as map
    */
-  public static Map<String, String> extractAuthenticationChallengeIntoMap(HttpResponse<?> response) {
-    Map<String, String> result = new HashMap<>();
-    String wwwAuthenticateHeader = response.header(WWW_AUTHENTICATE);
-    if (StringUtils.isNotBlank(wwwAuthenticateHeader)) {
-      String[] wwwAuthenticateHeaders = wwwAuthenticateHeader.split(",");
-      for (String challenge : wwwAuthenticateHeaders) {
-        if (challenge.contains("=")) {
-          String[] challengeParts = challenge.split("=");
-          if (challengeParts.length == 2) {
-            result.put(challengeParts[0], strip(challengeParts[1], "\""));
-          }
-        }
-      }
-    }
-    return result;
+  public static List<Map<String, String>> extractAuthenticationChallengeIntoMap(HttpResponse<?> response) throws IOException {
+    return parseWwwAuthenticateChallengeHeaders(response.header(WWW_AUTHENTICATE));
   }
-
 
   /**
    * Create Form Data String from map

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/okhttp/BufferStringReader.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/okhttp/BufferStringReader.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util.okhttp;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+
+/**
+ * Slightly modified adaptation of <a href="https://github.com/square/okio/blob/okio-parent-1.15.0/okio/src/main/java/okio/Buffer.java">Okio</a>'s Buffer
+ * using StringReader.
+ * <p>
+ * It only implements required methods for {@link HttpHeaders#parseWwwAuthenticateChallengeHeaders(String)}
+ */
+public class BufferStringReader extends StringReader {
+  private static final int READ_AHEAD_LIMIT = Integer.MAX_VALUE;
+
+  public BufferStringReader(String s) {
+    super(s);
+  }
+
+  /**
+   * Check whether stream is empty or not.
+   * @return boolean value whether stream is empty or not
+   * @throws IOException in case of error while reading stream
+   */
+  public boolean exhausted() throws IOException {
+    mark(READ_AHEAD_LIMIT);
+    int charRead = read();
+    boolean exhausted = true;
+    if (charRead != -1) {
+      exhausted = false;
+      reset();
+    }
+    return exhausted;
+  }
+
+  /**
+   * Consume single character (byte) from stream
+   * @return character read in front of stream
+   * @throws IOException in case of error while reading the character
+   */
+  public char readByte() throws IOException {
+    return fetchCharAt(0, false);
+  }
+
+  /**
+   * Get current character at the beginning of the character stream. This does not
+   * remove the character from stream. It's only a read only operation.
+   *
+   * @return character in front of stream
+   * @throws IOException in case of error while reading the character
+   */
+  public char getByte() throws IOException {
+    return fetchCharAt(0, true);
+  }
+
+  /**
+   * Get Nth character from the beginning of the character stream. This does not
+   * remove the character from stream. It's only a read only operation.
+   *
+   * @param index index of character from the beginning of the stream
+   * @return character found at Nth position
+   * @throws IOException in case of error while reading the character
+   */
+  public char getByte(long index) throws IOException {
+    return fetchCharAt(index, true);
+  }
+
+  /**
+   * Get nearest index of one of the given set of characters
+   *
+   * @param sequences list of characters that need to be searched in stream
+   * @return nearest index of the provided character, otherwise -1
+   * @throws IOException in case of error while reading the characters from stream
+   */
+  public int indexOfElement(List<Character> sequences) throws IOException {
+    mark(READ_AHEAD_LIMIT);
+    String remainingString = readUtf8(size());
+    int foundIndex = -1;
+    int nearestIndex = Integer.MAX_VALUE;
+    for (Character ch : sequences) {
+      int indexOfCh = remainingString.indexOf(ch);
+      if (indexOfCh >= 0) {
+        foundIndex = indexOfCh;
+        nearestIndex = Math.min(foundIndex, nearestIndex);
+      }
+    }
+    reset();
+    return foundIndex != -1 ? nearestIndex : foundIndex;
+  }
+
+  /**
+   * Get size of stream.
+   * @return integer representing number of characters left in stream to be read.
+   * @throws IOException in case of error while reading the characters.
+   */
+  public int size() throws IOException {
+    mark(READ_AHEAD_LIMIT);
+    int size = 0;
+    int charRead = 0;
+    while (charRead != -1) {
+      charRead = read();
+      if (charRead != -1) {
+        size++;
+      }
+    }
+    reset();
+    return size;
+  }
+
+  /**
+   * Read a string of given length from stream
+   * @param size size of String
+   * @return a string extracted from character stream
+   * @throws IOException in case of error while reading characters from steram
+   */
+  public String readUtf8(long size) throws IOException {
+    StringBuilder stringBuilder = new StringBuilder();
+    mark(READ_AHEAD_LIMIT);
+    int readChars = 0;
+    int charRead = 0;
+    while (charRead != -1 && readChars < size) {
+      charRead = read();
+      if (charRead != -1) {
+        char ch = (char) charRead;
+        stringBuilder.append(ch);
+        readChars++;
+      }
+    }
+    return stringBuilder.toString();
+  }
+
+  private char fetchCharAt(long index, boolean resetMarkAfterRead) throws IOException {
+    if (resetMarkAfterRead) {
+      mark(READ_AHEAD_LIMIT);
+    }
+    long count = 0;
+    long charRead = 0;
+    while (count < index+1 && charRead != -1) {
+      charRead = read();
+      count++;
+    }
+    if (resetMarkAfterRead) {
+      reset();
+    }
+    return (char) charRead;
+  }
+}

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/okhttp/HttpHeaders.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/okhttp/HttpHeaders.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util.okhttp;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Originally ported from OkHttp's <a href="https://github.com/square/okhttp/blob/parent-3.14.9/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.java#L180">HttpHeaders</a>
+ * <p>
+ * We have runtime dependency on OkHttp which is a transitive dependency coming from Fabric8 Kubernetes Client. We needed
+ * only parseChallengeHeader method for parsing WWW-Authenticate header for fetching authentication challenges. It seemed
+ * a better option to port the required method instead of adding okhttp dependency to the project.
+ */
+public class HttpHeaders {
+  private static final int MARK_LIMIT = Integer.MAX_VALUE;
+  private static final List<Character> QUOTED_STRING_DELIMITERS = Arrays.asList('\\', '\"');
+  private static final List<Character> TOKEN_DELIMITERS = Arrays.asList('\t', ' ', ',', '=');
+
+  private HttpHeaders() { }
+
+  /**
+   * Parse WWW-Authenticate header contents as a list of maps, with each map representing
+   * an authentication challenge.
+   *
+   * @param header string containing header value
+   * @return list of maps containing values of each authentication challenge
+   * @throws IOException in case of parsing string
+   */
+  public static List<Map<String, String>> parseWwwAuthenticateChallengeHeaders(String header) throws IOException {
+    String peek = null;
+    List<Map<String, String>> challenges = new ArrayList<>();
+
+    BufferStringReader stringReader = new BufferStringReader(header);
+    while (true) {
+      // Read a scheme name for this challenge if we don't have one already.
+      if (peek == null) {
+        skipWhitespaceAndCommas(stringReader);
+        peek = readToken(stringReader);
+        if (peek == null) return challenges;
+      }
+
+      String schemeName = peek;
+
+      // Read a token68, a sequence of parameters, or nothing.
+      boolean commaPrefixed = skipWhitespaceAndCommas(stringReader);
+      peek = readToken(stringReader);
+      if (peek == null) {
+        if (!stringReader.exhausted()) {
+          return challenges; // Expected a token; got something else.
+        }
+        challenges.add(createNewChallenge(schemeName, Collections.emptyMap()));
+        return challenges;
+      }
+
+      int eqCount = skipAll(stringReader, '=');
+      boolean commaSuffixed = skipWhitespaceAndCommas(stringReader);
+
+      // It's a token68 because there isn't a value after it.
+      if (!commaPrefixed && (commaSuffixed || stringReader.exhausted())) {
+        challenges.add(createNewChallenge(schemeName, Collections.singletonMap(null, peek + repeat('=', eqCount))));
+        peek = null;
+        continue;
+      }
+
+      // It's a series of parameter names and values.
+      Map<String, String> parameters = new LinkedHashMap<>();
+      eqCount += skipAll(stringReader, '=');
+      while (true) {
+        if (peek == null) {
+          peek = readToken(stringReader);
+          if (skipWhitespaceAndCommas(stringReader)) break; // We peeked a scheme name followed by ','.
+          eqCount = skipAll(stringReader, '=');
+        }
+        if (eqCount == 0) break; // We peeked a scheme name.
+        if (eqCount > 1) return challenges; // Unexpected '=' characters.
+        if (skipWhitespaceAndCommas(stringReader)) return challenges; // Unexpected ','.
+
+        String parameterValue = !stringReader.exhausted() && stringReader.getByte(0) == '"'
+            ? readQuotedString(stringReader)
+            : readToken(stringReader);
+        if (parameterValue == null) return challenges; // Expected a value.
+        String replaced = parameters.put(peek, parameterValue);
+        peek = null;
+        if (replaced != null) return challenges; // Unexpected duplicate parameter.
+        if (!skipWhitespaceAndCommas(stringReader) && !stringReader.exhausted()) return challenges; // Expected ',' or EOF.
+      }
+      challenges.add(createNewChallenge(schemeName, parameters));
+    }
+  }
+
+  private static Map<String, String> createNewChallenge(String scheme, Map<String, String> authParams) {
+    Map<String, String> challengeAsMap = new HashMap<>();
+    challengeAsMap.put("scheme", scheme);
+    challengeAsMap.putAll(authParams);
+    return challengeAsMap;
+  }
+
+  private static boolean skipWhitespaceAndCommas(StringReader buffer) throws IOException {
+    boolean commaFound = false;
+    int charRead = 0;
+    while (charRead != -1) {
+      buffer.mark(MARK_LIMIT);
+      charRead = buffer.read();
+      char b = (char) charRead;
+      if (b == ',' || b == ' ' || b == '\t') {
+        if (b == ',') {
+          commaFound = true;
+        }
+      } else if (charRead != -1){
+        buffer.reset();
+        break;
+      }
+    }
+    return commaFound;
+  }
+
+  private static int skipAll(BufferStringReader buffer, char b) throws IOException {
+    int count = 0;
+    int charRead;
+    char curChar;
+    do {
+      buffer.mark(MARK_LIMIT);
+      charRead = buffer.read();
+      curChar = (char) charRead;
+      if (charRead != -1 && curChar == b) {
+        count++;
+      } else if (curChar != b) {
+        buffer.reset();
+      }
+    } while (charRead != -1 && curChar == b);
+    return count;
+  }
+
+  /**
+   * Reads a double-quoted string, unescaping quoted pairs like {@code \"} to the 2nd character in
+   * each sequence. Returns the unescaped string, or null if the buffer isn't prefixed with a
+   * double-quoted string.
+   */
+  private static String readQuotedString(BufferStringReader buffer) throws IOException {
+    if (buffer.readByte() != '\"') throw new IllegalArgumentException();
+    StringBuilder result = new StringBuilder();
+    while (true) {
+      long i = buffer.indexOfElement(QUOTED_STRING_DELIMITERS);
+      if (i == -1L) return null; // Unterminated quoted string.
+
+      if (buffer.getByte(i) == '"') {
+        String quoteString = buffer.readUtf8(i);
+        result.append(quoteString);
+        buffer.readByte(); // Consume '"'.
+        return result.toString();
+      }
+
+      if (buffer.size() == i + 1L) return null; // Dangling escape.
+      result.append(buffer.readUtf8(i));
+      buffer.readByte(); // Consume '\'.
+      result.append(buffer.readUtf8(1)); // The escaped character.
+    }
+  }
+
+  /**
+   * Consumes and returns a non-empty token, terminating at special characters in. Returns null if the buffer is empty or prefixed with a delimiter.
+   */
+  private static String readToken(BufferStringReader buffer) {
+    try {
+      long tokenSize = buffer.indexOfElement(TOKEN_DELIMITERS);
+      if (tokenSize == -1L) tokenSize = buffer.size();
+
+      return tokenSize != 0L
+          ? buffer.readUtf8(tokenSize)
+          : null;
+    } catch (IOException e) {
+      throw new AssertionError();
+    }
+  }
+
+  private static String repeat(char c, int count) {
+    char[] array = new char[count];
+    Arrays.fill(array, c);
+    return new String(array);
+  }
+}

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/Fabric8HttpUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/Fabric8HttpUtilTest.java
@@ -13,18 +13,20 @@
  */
 package org.eclipse.jkube.kit.common.util;
 
-import io.fabric8.kubernetes.client.http.HttpResponse;
-import io.fabric8.kubernetes.client.http.TestHttpResponse;
-import org.junit.jupiter.api.Test;
-
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.fabric8.kubernetes.client.http.HttpResponse;
+import io.fabric8.kubernetes.client.http.TestHttpResponse;
+import org.junit.jupiter.api.Test;
+
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 
 class Fabric8HttpUtilTest {
 
@@ -49,7 +51,101 @@ class Fabric8HttpUtilTest {
   }
 
   @Test
-  void extractAuthenticationChallengeIntoMap_whenWwwHeaderProvided_thenParseDataIntoMap() {
+  void extractAuthenticationChallengeIntoMap_whenEmptyHeaderProvided_thenReturnEmptyMap() throws IOException {
+    // Given
+    Map<String, List<String>> responseHeaders = new HashMap<>();
+    responseHeaders.put("WWW-Authenticate", Collections.singletonList(""));
+    HttpResponse<byte[]> response = new TestHttpResponse<byte[]>(responseHeaders).withCode(HTTP_OK);
+    // When
+    List<Map<String, String>> result = Fabric8HttpUtil.extractAuthenticationChallengeIntoMap(response);
+    // Then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void extractAuthenticationChallengeIntoMap_whenBasicAuthenticationRealm_thenParseDataIntoMap() throws IOException {
+    // Given
+    Map<String, List<String>> responseHeaders = new HashMap<>();
+    responseHeaders.put("WWW-Authenticate", Collections.singletonList("Basic realm=\"Access to the staging site\", charset=\"UTF-8\""));
+    HttpResponse<byte[]> response = new TestHttpResponse<byte[]>(responseHeaders).withCode(HTTP_OK);
+    // When
+    List<Map<String, String>> result = Fabric8HttpUtil.extractAuthenticationChallengeIntoMap(response);
+    // Then
+    assertThat(result)
+        .singleElement(MAP)
+        .hasSize(3)
+        .containsEntry("scheme", "Basic")
+        .containsEntry("realm", "Access to the staging site")
+        .containsEntry("charset", "UTF-8");
+  }
+
+  @Test
+  void extractAuthenticationChallengeIntoMap_whenMultipleChallenges_thenParseDataIntoMap() throws IOException {
+    // Given
+    Map<String, List<String>> responseHeaders = new HashMap<>();
+    responseHeaders.put("WWW-Authenticate", Collections.singletonList("Newauth realm=\"apps\", type=1" +
+        ", title=\"Login to \\\"apps\\\"\"" +
+        ", Basic realm=\"simple\""));
+    HttpResponse<byte[]> response = new TestHttpResponse<byte[]>(responseHeaders).withCode(HTTP_OK);
+    // When
+    List<Map<String, String>> result = Fabric8HttpUtil.extractAuthenticationChallengeIntoMap(response);
+    // Then
+    assertThat(result)
+        .hasSize(2)
+        .satisfies(r -> assertThat(r.get(0))
+            .containsEntry("scheme", "Newauth")
+            .containsEntry("realm", "apps")
+            .containsEntry("type", "1")
+            .containsEntry("title", "Login to \"apps\""))
+        .satisfies(r -> assertThat(r.get(1))
+            .containsEntry("scheme", "Basic")
+            .containsEntry("realm", "simple"));
+  }
+
+  @Test
+  void extractAuthenticationChallengeIntoMap_whenDigestAuthenticationChallenge_thenParseDataIntoMap() throws IOException {
+    // Given
+    Map<String, List<String>> responseHeaders = new HashMap<>();
+    responseHeaders.put("WWW-Authenticate", Collections.singletonList("Digest realm=\"http-auth@example.org\"," +
+        "    qop=\"auth, auth-int\"," +
+        "    algorithm=SHA-256," +
+        "    nonce=\"MTQ0NDMyOTA1OTowOTcwOTBhMmU4MGM4OTEyZGY2OGY5NzIyZjMyZTM0MA==\"," +
+        "    opaque=\"FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS\""));
+    HttpResponse<byte[]> response = new TestHttpResponse<byte[]>(responseHeaders).withCode(HTTP_OK);
+    // When
+    List<Map<String, String>> result = Fabric8HttpUtil.extractAuthenticationChallengeIntoMap(response);
+    // Then
+    assertThat(result)
+        .singleElement(MAP)
+        .hasSize(6)
+        .containsEntry("scheme", "Digest")
+        .containsEntry("realm", "http-auth@example.org")
+        .containsEntry("algorithm", "SHA-256")
+        .containsEntry("nonce", "MTQ0NDMyOTA1OTowOTcwOTBhMmU4MGM4OTEyZGY2OGY5NzIyZjMyZTM0MA==")
+        .containsEntry("opaque", "FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS")
+        .containsEntry("qop", "auth, auth-int");
+  }
+
+  @Test
+  void extractAuthenticationChallengeIntoMap_whenHOBAAuthenticationChallenge_thenParseDataIntoMap() throws IOException {
+    // Given
+    Map<String, List<String>> responseHeaders = new HashMap<>();
+    responseHeaders.put("WWW-Authenticate", Collections.singletonList("HOBA max-age=\"180\"," +
+        " challenge=\"16:MTEyMzEyMzEyMw==1:028:https://www.example.com:80800:3:MTI48:NjgxNDdjOTctNDYxYi00MzEwLWJlOWItNGM3MDcyMzdhYjUz\""));
+    HttpResponse<byte[]> response = new TestHttpResponse<byte[]>(responseHeaders).withCode(HTTP_OK);
+    // When
+    List<Map<String, String>> result = Fabric8HttpUtil.extractAuthenticationChallengeIntoMap(response);
+    // Then
+    assertThat(result)
+        .singleElement(MAP)
+        .hasSize(3)
+        .containsEntry("scheme", "HOBA")
+        .containsEntry("max-age", "180")
+        .containsEntry("challenge", "16:MTEyMzEyMzEyMw==1:028:https://www.example.com:80800:3:MTI48:NjgxNDdjOTctNDYxYi00MzEwLWJlOWItNGM3MDcyMzdhYjUz");
+  }
+
+  @Test
+  void extractAuthenticationChallengeIntoMap_whenWwwHeaderProvided_thenParseDataIntoMap() throws IOException {
     // Given
     String wwwAuthenticateValue = "Bearer realm=\"https://auth.example.com/token\",service=\"registry.example.com\",scope=\"repository:myuser/test-chart:pull\"";
     Map<String, List<String>> responseHeaders = new HashMap<>();
@@ -57,13 +153,38 @@ class Fabric8HttpUtilTest {
     HttpResponse<byte[]> response = new TestHttpResponse<byte[]>(responseHeaders).withCode(HTTP_OK);
 
     // When
-    Map<String, String> wwwAuthenticateAsMap = Fabric8HttpUtil.extractAuthenticationChallengeIntoMap(response);
+    List<Map<String, String>> wwwAuthenticateAsMap = Fabric8HttpUtil.extractAuthenticationChallengeIntoMap(response);
 
     // Then
     assertThat(wwwAuthenticateAsMap)
-        .hasSize(3)
-        .containsEntry("Bearer realm", "https://auth.example.com/token")
+        .singleElement(MAP)
+        .hasSize(4)
+        .containsEntry("scheme", "Bearer")
+        .containsEntry("realm", "https://auth.example.com/token")
         .containsEntry("service", "registry.example.com")
         .containsEntry("scope", "repository:myuser/test-chart:pull");
+  }
+
+  @Test
+  void extractAuthenticationChallengeIntoMap_whenWwwHeaderContainsPushScope_thenParseDataIntoMap() throws IOException {
+    // Given
+    String wwwAuthenticateValue = "Bearer realm=\"https://auth.example.com/token\",service=\"registry.example.com\"," +
+        "scope=\"repository:myuser/test-chart:pull,push\",error=\"insufficient_scope\"";
+    Map<String, List<String>> responseHeaders = new HashMap<>();
+    responseHeaders.put("WWW-Authenticate", Collections.singletonList(wwwAuthenticateValue));
+    HttpResponse<byte[]> response = new TestHttpResponse<byte[]>(responseHeaders).withCode(HTTP_OK);
+
+    // When
+    List<Map<String, String>> wwwAuthenticateAsMap = Fabric8HttpUtil.extractAuthenticationChallengeIntoMap(response);
+
+    // Then
+    assertThat(wwwAuthenticateAsMap)
+        .singleElement(MAP)
+        .hasSize(5)
+        .containsEntry("scheme", "Bearer")
+        .containsEntry("realm", "https://auth.example.com/token")
+        .containsEntry("service", "registry.example.com")
+        .containsEntry("scope", "repository:myuser/test-chart:pull,push")
+        .containsEntry("error", "insufficient_scope");
   }
 }

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/okhttp/BufferStringReaderTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/okhttp/BufferStringReaderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util.okhttp;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class BufferStringReaderTest {
+  @Test
+  void exhausted_whenStreamNotExhausted_thenReturnFalse() throws IOException {
+    // Given
+    BufferStringReader buffer = new BufferStringReader("foo");
+    // When
+    buffer.readByte();
+    boolean result = buffer.exhausted();
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void exhausted_whenStreamEmpty_thenReturnTrue() throws IOException {
+    // Given
+    BufferStringReader buffer = new BufferStringReader("f");
+    // When
+    buffer.readByte();
+    boolean result = buffer.exhausted();
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void readByte_whenInvoked_shouldConsumeOneCharacterFromStream() throws IOException {
+    // Given
+    BufferStringReader buffer = new BufferStringReader("foo");
+    // When + Then
+    assertThat(buffer.readByte()).isEqualTo('f');
+    assertThat(buffer.readByte()).isEqualTo('o');
+    assertThat(buffer.readByte()).isEqualTo('o');
+    assertThat(buffer.exhausted()).isTrue();
+  }
+
+  @Test
+  void getByte_whenInvoked_shouldReturnFirstCharacterFromStream() throws IOException {
+    // Given
+    BufferStringReader buffer = new BufferStringReader("foo");
+    // When
+    char ch = buffer.getByte();
+    // Then
+    assertThat(ch).isEqualTo('f');
+    assertThat(buffer.size()).isEqualTo(3);
+  }
+
+  @Test
+  void getByte_whenIndexProvided_shouldReturnCharacterAtSpecifiedIndex() throws IOException {
+    // Given
+    BufferStringReader buffer = new BufferStringReader("foo");
+    // When + Then
+    assertThat(buffer.getByte(0)).isEqualTo('f');
+    assertThat(buffer.getByte(1)).isEqualTo('o');
+    assertThat(buffer.getByte(2)).isEqualTo('o');
+    assertThat(buffer.size()).isEqualTo(3);
+  }
+
+  @Test
+  void indexOfElement_whenCharSequencePresent_thenReturnNearestIndex() throws IOException {
+    // Given
+    BufferStringReader buffer = new BufferStringReader("my\\\"realm");
+    // When
+    int index = buffer.indexOfElement(Arrays.asList('\\', '\"'));
+    // Then
+    assertThat(index).isEqualTo(2);
+  }
+
+  @Test
+  void indexOfElement_whenCharSequenceAbsent_thenReturnNegativeIndex() throws IOException {
+    // Given
+    BufferStringReader buffer = new BufferStringReader("my\"realm");
+    // When
+    int index = buffer.indexOfElement(Collections.singletonList(','));
+    // Then
+    assertThat(index).isEqualTo(-1);
+  }
+
+  @Test
+  void readUtf8_whenInvoked_shouldReadCharactersIntoString() throws IOException {
+    // Given
+    BufferStringReader buffer = new BufferStringReader("Bearer realm=\"myrealm\"");
+    // When + Then
+    assertThat(buffer.readUtf8(6)).isEqualTo("Bearer");
+    assertThat(buffer.readUtf8(16)).isEqualTo(" realm=\"myrealm\"");
+  }
+}

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/okhttp/HttpHeadersTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/okhttp/HttpHeadersTest.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util.okhttp;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * These tests are ported from OkHttp's <a href="https://github.com/square/okhttp/blob/parent-3.14.9/okhttp-tests/src/test/java/okhttp3/HeadersTest.java#L439">HeaderTests</a>
+ * All the tests related to WWW-Authenticate parsing.
+ */
+class HttpHeadersTest {
+  @Test
+  void testDigestChallengeWithStrictRfc2617Header() throws IOException {
+    // Given
+    String responseHeader = "Digest realm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaks"
+        + "jdflkasdf\", qop=\"auth\", stale=\"FALSE\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "Digest")
+        .containsEntry("realm", "myrealm")
+        .containsEntry("nonce", "fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf")
+        .containsEntry("qop", "auth")
+        .containsEntry("stale", "FALSE");
+  }
+
+  @Test
+  void testDigestChallengeWithDifferentlyOrderedAuthParams() throws IOException {
+    // Given
+    String responseHeader = "Digest qop=\"auth\", realm=\"myrealm\", nonce=\"fjalskdflwejrlask"
+        + "dfjlaskdjflaksjdflkasdf\", stale=\"FALSE\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "Digest")
+        .containsEntry("realm", "myrealm")
+        .containsEntry("nonce", "fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf")
+        .containsEntry("qop", "auth")
+        .containsEntry("stale", "FALSE");
+  }
+
+  @Test
+  void testDigestChallengeWithDifferentlyOrderedAuthParams2() throws IOException {
+    // Given
+    String responseHeader = "Digest qop=\"auth\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaksjdflk"
+        + "asdf\", realm=\"myrealm\", stale=\"FALSE\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "Digest")
+        .containsEntry("realm", "myrealm")
+        .containsEntry("nonce", "fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf")
+        .containsEntry("qop", "auth")
+        .containsEntry("stale", "FALSE");
+  }
+
+  @Test
+  void testDigestChallengeWithMissingRealm() throws IOException {
+    String responseHeader = "Digest qop=\"auth\", underrealm=\"myrealm\", nonce=\"fjalskdflwej"
+        + "rlaskdfjlaskdjflaksjdflkasdf\", stale=\"FALSE\"";
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "Digest")
+        .containsEntry("underrealm", "myrealm")
+        .containsEntry("nonce", "fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf")
+        .containsEntry("qop", "auth")
+        .containsEntry("stale", "FALSE");
+  }
+
+  @Test
+  void testDigestChallengeWithAdditionalSpaces() throws IOException {
+    // Given
+    String responseHeader = "Digest qop=\"auth\",    realm=\"myrealm\", nonce=\"fjalskdflwejrl"
+        + "askdfjlaskdjflaksjdflkasdf\", stale=\"FALSE\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "Digest")
+        .containsEntry("realm", "myrealm")
+        .containsEntry("nonce", "fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf")
+        .containsEntry("qop", "auth")
+        .containsEntry("stale", "FALSE");
+  }
+
+  @Test
+  void testDigestChallengeWithAdditionalSpacesBeforeFirstAuthParam() throws IOException {
+    // Given
+    String responseHeader = "Digest    realm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjfl"
+        + "aksjdflkasdf\", qop=\"auth\", stale=\"FALSE\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "Digest")
+        .containsEntry("realm", "myrealm")
+        .containsEntry("nonce", "fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf")
+        .containsEntry("qop", "auth")
+        .containsEntry("stale", "FALSE");
+  }
+
+  @Test
+  void testDigestChallengeWithCamelCasedNames() throws IOException {
+    // Given
+    String responseHeader = "DiGeSt qop=\"auth\", rEaLm=\"myrealm\", nonce=\"fjalskdflwejrlask"
+        + "dfjlaskdjflaksjdflkasdf\", stale=\"FALSE\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "DiGeSt")
+        .containsEntry("rEaLm", "myrealm")
+        .containsEntry("nonce", "fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf")
+        .containsEntry("qop", "auth")
+        .containsEntry("stale", "FALSE");
+  }
+
+  @Test
+  void testDigestChallengeWithCamelCasedNames2() throws IOException {
+    // Given
+    String responseHeader = "DIgEsT rEaLm=\"myrealm\", nonce=\"fjalskdflwejrlaskdfjlaskdjflaks"
+        + "jdflkasdf\", qop=\"auth\", stale=\"FALSE\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "DIgEsT")
+        .containsEntry("rEaLm", "myrealm")
+        .containsEntry("nonce", "fjalskdflwejrlaskdfjlaskdjflaksjdflkasdf")
+        .containsEntry("qop", "auth")
+        .containsEntry("stale", "FALSE");
+  }
+
+  @Test
+  void testDigestChallengeWithTokenFormOfAuthParam() throws IOException {
+    // Given
+    String responseHeader = "Digest realm=myrealm";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .satisfies(c -> assertChallenge(c.get(0), "Digest", "myrealm"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "Digest",
+      "Digest,,,, Basic ,,,realm=\"my\\\\\\\\\"r\\ealm\"",
+      "Digest,,,, Basic ,,,realm=\"my\"realm\""
+  })
+  void parseWwwAuthenticateChallengeHeaders_whenOnlyFirstChallengeParsable_thenReturnSingleChallenge(String responseHeader) throws IOException {
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .satisfies(c -> assertChallenge(c.get(0), "Digest", null));
+  }
+
+  @Test
+  void basicChallenge() throws IOException {
+    // Given
+    String responseHeader = "Basic realm=\"protected area\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .satisfies(c -> assertChallenge(c.get(0), "Basic", "protected area"));
+  }
+
+  @Test
+  void basicChallengeWithCharset() throws IOException {
+    // Given
+    String responseHeader = "Basic realm=\"protected area\", charset=\"UTF-8\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .satisfies(c -> assertChallenge(c.get(0), "Basic", "protected area"))
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("charset", "UTF-8");
+  }
+
+  @Test
+  void basicChallengeWithUnexpectedCharset() throws IOException {
+    // Given
+    String responseHeader = "Basic realm=\"protected area\", charset=\"US-ASCII\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .satisfies(c -> assertChallenge(c.get(0), "Basic", "protected area"))
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("charset", "US-ASCII");
+  }
+
+  @Test
+  void separatorsBeforeFirstChallenge() throws IOException {
+    // Given
+    String responseHeader = " ,  , Basic realm=myrealm";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .satisfies(c -> assertChallenge(c.get(0), "Basic", "myrealm"));
+  }
+
+  @Test
+  void spacesAroundKeyValueSeparator() throws IOException {
+    // Given
+    String responseHeader = "Basic realm = \"myrealm\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .satisfies(c -> assertChallenge(c.get(0), "Basic", "myrealm"));
+  }
+
+  @Test
+  void multipleChallengesInOneHeader() throws IOException {
+    // Given
+    String responseHeader = "Basic realm = \"myrealm\",Digest";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(2)
+        .satisfies(c -> assertChallenge(c.get(0), "Basic", "myrealm"))
+        .satisfies(c -> assertChallenge(c.get(1), "Digest", null));
+  }
+
+  @Test
+  void multipleChallengesWithSameSchemeButDifferentRealmInOneHeader() throws IOException {
+    // Given
+    String responseHeader = "Basic realm = \"myrealm\",Basic realm=myotherrealm";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(2)
+        .satisfies(c -> assertChallenge(c.get(0), "Basic", "myrealm"))
+        .satisfies(c -> assertChallenge(c.get(1), "Basic", "myotherrealm"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "Digest, Basic ,,realm=\"myrealm\"",
+      "Digest,Basic realm=\"myrealm\"",
+      "Digest,,,, Basic ,,realm=\"myrealm\"",
+  })
+  void parseWwwAuthenticateChallengeHeaders_withDigestAndAuthParam_shouldParseBoth(String responseHeader) throws IOException {
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges).hasSize(2);
+    assertThat(challenges.get(0))
+        .containsEntry("scheme", "Digest");
+    assertThat(challenges.get(1))
+        .containsEntry("scheme", "Basic")
+        .containsEntry("realm", "myrealm");
+  }
+
+  @Test
+  void unknownAuthParams() throws IOException {
+    // Given
+    String responseHeader = "Digest,,,, Basic ,,foo=bar,realm=\"myrealm\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(2)
+        .satisfies(c -> assertChallenge(c.get(0), "Digest", null))
+        .satisfies(c -> assertChallenge(c.get(1), "Basic", "myrealm"))
+        .element(1)
+        .asInstanceOf(InstanceOfAssertFactories.MAP)
+        .containsEntry("foo", "bar");
+  }
+
+  @Test
+  void escapedCharactersInQuotedString() throws IOException {
+    // Given
+    String responseHeader = "Digest,,,, Basic ,,,realm=\"my\\\\\\\"r\\ealm\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(2)
+        .satisfies(c -> assertChallenge(c.get(0), "Digest", null))
+        .satisfies(c -> assertChallenge(c.get(1), "Basic", "my\\\"realm"));
+  }
+
+  @Test
+  void commaInQuotedStringAndBeforeFirstChallenge() throws IOException {
+    // Given
+    String responseHeader = ",Digest,,,, Basic ,,,realm=\"my, realm,\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(2)
+        .satisfies(c -> assertChallenge(c.get(0), "Digest", null))
+        .satisfies(c -> assertChallenge(c.get(1), "Basic", "my, realm,"));
+  }
+
+  @Test
+  void unescapedDoubleQuoteInQuotedStringWithEvenNumberOfBackslashesInFront() throws IOException {
+    // Given
+    String responseHeader = "Digest,,,, Basic ,,,realm=\"my\\\\\\\\\"r\\ealm\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .satisfies(c -> assertChallenge(c.get(0), "Digest", null));
+  }
+
+  @Test
+  void unescapedDoubleQuoteInQuotedString() throws IOException {
+    // Given
+    String responseHeader = "Digest,,,, Basic ,,,realm=\"my\"realm\"";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .satisfies(c -> assertChallenge(c.get(0), "Digest", null));
+  }
+
+  @Test
+  void token68InsteadOfAuthParams() throws IOException {
+    // Given
+    String responseHeader = "Other abc==";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "Other")
+        .containsEntry(null, "abc==");
+  }
+
+  @Test
+  void token68AndAuthParams() throws IOException {
+    // Given
+    String responseHeader = "Other abc==, realm=myrealm";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(1)
+        .singleElement(InstanceOfAssertFactories.MAP)
+        .containsEntry("scheme", "Other")
+        .containsEntry(null, "abc==");
+  }
+
+  @Test
+  void repeatedAuthParamKey() throws IOException {
+    // Given
+    String responseHeader = "Other realm=myotherrealm, realm=myrealm";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges).isEmpty();
+  }
+
+  @Test
+  void multipleAuthenticateHeaders() throws IOException {
+    // Given
+    String responseHeader = "Digest, Basic realm=myrealm";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(2)
+        .satisfies(c -> assertChallenge(c.get(0), "Digest", null))
+        .satisfies(c -> assertChallenge(c.get(1), "Basic", "myrealm"));
+  }
+
+  @Test
+  void multipleAuthenticateHeadersInDifferentOrder() throws IOException {
+    // Given
+    String responseHeader = "Basic realm=myrealm, Digest";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(2)
+        .satisfies(c -> assertChallenge(c.get(0), "Basic", "myrealm"))
+        .satisfies(c -> assertChallenge(c.get(1), "Digest", null));
+  }
+
+  @Test
+  void multipleBasicAuthenticateHeaders() throws IOException {
+    // Given
+    String responseHeader = "Basic realm=myrealm, Basic realm=myotherrealm";
+    // When
+    List<Map<String, String>> challenges = HttpHeaders.parseWwwAuthenticateChallengeHeaders(responseHeader);
+    // Then
+    assertThat(challenges)
+        .hasSize(2)
+        .satisfies(c -> assertChallenge(c.get(0), "Basic", "myrealm"))
+        .satisfies(c -> assertChallenge(c.get(1), "Basic", "myotherrealm"));
+  }
+
+  private void assertChallenge(Map<String, String> challengeHeader, String scheme, String realm) {
+    assertThat(challengeHeader).containsEntry("scheme", scheme);
+    if (StringUtils.isNotBlank(realm)) {
+      assertThat(challengeHeader).containsEntry("realm", realm);
+    }
+  }
+}

--- a/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/oci/OCIRegistryInterceptor.java
+++ b/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/oci/OCIRegistryInterceptor.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -92,8 +93,11 @@ public class OCIRegistryInterceptor implements Interceptor {
   }
 
   private String submitHttpRequestForAuthenticationChallenge(HttpResponse<?> response) throws IOException {
-    Map<String, String> authChallengeHeader = extractAuthenticationChallengeIntoMap(response);
-    String authenticationUrl = authChallengeHeader.get("Bearer realm");
+    Map<String, String> authChallengeHeader = extractAuthenticationChallengeIntoMap(response).stream()
+        .filter(c -> c.get("scheme").equals("Bearer"))
+        .findFirst()
+        .orElse(Collections.emptyMap());
+    String authenticationUrl = authChallengeHeader.get("realm");
     String scope = authChallengeHeader.get("scope");
     if (!scope.contains("push")) {
       scope += ",push";


### PR DESCRIPTION
## Description

Fixes #2419

We try to add push scope to scope field extracted from Www-Authenticate header if it doesn't already exist. This was happening because our `www-authenticate` header parsing logic was flawed and it was omitting `push` scope from `pull,push` scope. We were directly splitting whole string based on commas.


Port OkHttp's [HttpHeaders.parseChallengeHeader](https://github.com/square/okhttp/blob/parent-3.14.9/okhttp/src/main/java/okhttp3/internal/http/HttpHeaders.java#L180) method into our codebase for achieving this. We have runtime dependency on OkHttp, a transitive dependency coming from Fabric8 Kubernetes Client. We needed only `parseChallengeHeader` method for parsing WWW-Authenticate header for fetching authentication challenges. It seemed a better option to port the required method instead of adding okhttp dependency to the project.




## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
