### PR TITLE
fix (jkube-kit-spring-boot) : fix create dir check in SpringBootDevtoolsUtils

### DIFF
--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/SpringBootDevtoolsUtils.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/SpringBootDevtoolsUtils.java
@@ -17,6 +17,7 @@ import com.google.common.base.Strings;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jkube.generator.javaexec.FatJarDetector;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
 import org.eclipse.jkube.kit.common.util.SpringBootUtil;
 
@@ -66,10 +67,15 @@ public class SpringBootDevtoolsUtils {
 
   private static void appendSecretTokenToFile(JavaProject project, String path, String token) {
     File file = new File(project.getBaseDirectory(), path);
-    boolean dirCreated = file.getParentFile().mkdirs();
-    if (!dirCreated) {
+    try {
+      FileUtil.createDirectory(file.getParentFile());
+    } catch (IOException ioException) {
       throw new IllegalStateException("Failure in creating directory " + file.getParentFile().getAbsolutePath());
     }
+    writeRemoteSecretToFile(file, token);
+  }
+
+  private static void writeRemoteSecretToFile(File file, String token) {
     String text = String.format("%s" +
             "# Remote secret added by jkube-kit-plugin\n" +
             "%s=%s\n",

--- a/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/SpringBootDevtoolsUtilsTest.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/SpringBootDevtoolsUtilsTest.java
@@ -53,7 +53,7 @@ class SpringBootDevtoolsUtilsTest {
   }
 
   @Test
-  void ensureSpringDevToolSecretToken_whenNoTokenFound_thenAppendTokenAndThrowException() throws IOException {
+  void ensureSpringDevToolSecretToken_whenNoTokenFound_thenAppendToken() throws IOException {
     // Given
     JavaProject javaProject = createSpringBootJavaProject();
 
@@ -61,17 +61,21 @@ class SpringBootDevtoolsUtilsTest {
     boolean result = SpringBootDevtoolsUtils.ensureSpringDevToolSecretToken(javaProject);
 
     // Then
-    assertThat(result).isFalse();
-    Path srcApplicationProperties = temporaryFolder.toPath()
-        .resolve("src").resolve("main").resolve("resources").resolve("application.properties");
-    Path targetApplicationProperties = temporaryFolder.toPath()
-        .resolve("target").resolve("classes").resolve("application.properties");
-    assertThat(new String(Files.readAllBytes(srcApplicationProperties)))
-        .contains("# Remote secret added by jkube-kit-plugin")
-        .contains("spring.devtools.remote.secret=");
-    assertThat(new String(Files.readAllBytes(targetApplicationProperties)))
-        .contains("# Remote secret added by jkube-kit-plugin")
-        .contains("spring.devtools.remote.secret=");
+    thenSpringBootDevtoolsTokenAddedToProject(result);
+  }
+
+  @Test
+  void ensureSpringDevToolSecretToken_whenNoTokenFoundButTargetDirAlreadyExists_thenAppendToken() throws IOException {
+    // Given
+    JavaProject javaProject = createSpringBootJavaProject();
+    Files.createDirectory(temporaryFolder.toPath().resolve("target"));
+    Files.createDirectory(temporaryFolder.toPath().resolve("target").resolve("classes"));
+
+    // When
+    boolean result = SpringBootDevtoolsUtils.ensureSpringDevToolSecretToken(javaProject);
+
+    // Then
+    thenSpringBootDevtoolsTokenAddedToProject(result);
   }
 
   @Test
@@ -198,5 +202,19 @@ class SpringBootDevtoolsUtilsTest {
     manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, "org.example.Foo");
     JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(jarFile.toPath()), manifest);
     jarOutputStream.closeEntry();
+  }
+
+  private void thenSpringBootDevtoolsTokenAddedToProject(boolean result) throws IOException {
+    assertThat(result).isFalse();
+    Path srcApplicationProperties = temporaryFolder.toPath()
+        .resolve("src").resolve("main").resolve("resources").resolve("application.properties");
+    Path targetApplicationProperties = temporaryFolder.toPath()
+        .resolve("target").resolve("classes").resolve("application.properties");
+    assertThat(new String(Files.readAllBytes(srcApplicationProperties)))
+        .contains("# Remote secret added by jkube-kit-plugin")
+        .contains("spring.devtools.remote.secret=");
+    assertThat(new String(Files.readAllBytes(targetApplicationProperties)))
+        .contains("# Remote secret added by jkube-kit-plugin")
+        .contains("spring.devtools.remote.secret=");
   }
 }


### PR DESCRIPTION
## Description
I noticed this while testing buildpacks PR with `k8s:watch`

JKube seems to be throwing an exception while running `k8s:watch` when a Spring Boot project doesn't contain the `spring.devtools.remote.secret` in project.

```
[ERROR] Failed to execute goal org.eclipse.jkube:kubernetes-maven-plugin:1.16-SNAPSHOT:watch (default-cli) on project spring-boot3-demo-jkube: Execution default-cli of goal org.eclipse.jkube:kubernetes-maven-plugin:1.16-SNAPSHOT:watch failed: Failure in creating directory /home/rokumar/work/repos/jkube-buildpacks-poc-testing/maven-it/target/classes 
```

Problem seems to lie in the SpringBootDevtoolsUtils directory creation check:

https://github.com/eclipse/jkube/blob/d4d41587236da6f8c1dccc3754e8ebac539a22ba/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/SpringBootDevtoolsUtils.java#L69-L72

mkdirs() returns false when directory is already present, only throw exception when directory doesn't exist and mkdir returned false.




## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
