### PR TITLE
fix (jkube-kit/common): Don't use IoUtil.getFreeRandomPort for TestHttpStaticServer

### DIFF
--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/TestHttpStaticServer.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/TestHttpStaticServer.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.eclipse.jkube.kit.common.util.AsyncUtil.async;
-import static org.eclipse.jkube.kit.common.util.IoUtil.getFreeRandomPort;
 
 public class TestHttpStaticServer implements Closeable {
 
@@ -53,8 +52,7 @@ public class TestHttpStaticServer implements Closeable {
 
   private static Callable<HttpServer> startServer(File staticDirectory) {
     return () -> {
-      final int port = getFreeRandomPort();
-      final HttpServer ret = HttpServer.create(new InetSocketAddress(port), 0);
+      final HttpServer ret = HttpServer.create(new InetSocketAddress(0), 0);
       ret.createContext("/", exchange -> {
         final String path = exchange.getRequestURI().getPath();
         final File file = new File(staticDirectory, path).getCanonicalFile();


### PR DESCRIPTION
## Description

`IoUtil.getFreeRandomPort` seems to be returning already allocated port values ( see https://github.com/eclipse/jkube/issues/2501)

InetSocketAddress can automatically generate a port on it's own if we pass `0` as port value. See [InetSocketAddress javadocs](https://docs.oracle.com/javase/8/docs/api/java/net/InetSocketAddress.html#InetSocketAddress-int-).


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
