### PR TITLE
refactor: temporary usage of local CompletableFuture

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/AsyncUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/AsyncUtil.java
@@ -78,6 +78,17 @@ public class AsyncUtil {
     }
   }
 
+  public static <T> T get(CompletableFuture<T> completableFuture) {
+    try {
+      return completableFuture.get();
+    } catch (ExecutionException e) {
+      throw new IllegalStateException(e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    }
+  }
+
   @FunctionalInterface
   public interface ThrowingFunction<T, R> {
     R apply(T t) throws Exception;


### PR DESCRIPTION
## Description

PodLogService uses an instance variable to keep state derived from a method that can be invoked multiple times and breaking the functionality.

This change (first of a series) moves to use a local variable instead.



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
