### PR TITLE
fix (jkube-kit/enricher) : Change default initContainer image from `busybox` to `quay.io/quay/busybox`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Usage:
 * Fix #2389: Helm `values.yaml` sorted alphabetically
 * Fix #2390: support for all missing Chart.yaml fields
 * Fix #2391: Automatically add `values.schema.json` file if detected
+* Fix #2423: Change default VolumePermissionEnricher's initContainer image from `busybox` to `quay.io/quay/busybox`
 * Fix #2444: Add support for Spring Boot application properties placeholders
 * Fix #2456: Add utility class to decompress archive files
 * Fix #2472: Support for Helm Chart.yaml appVersion field defaulting to project version

--- a/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass-annotation/kubernetes.yml
+++ b/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass-annotation/kubernetes.yml
@@ -104,7 +104,7 @@ items:
                 - chmod
                 - "777"
                 - /var/lib/registry
-              image: busybox
+              image: quay.io/quay/busybox
               imagePullPolicy: IfNotPresent
               name: jkube-volume-permission
               volumeMounts:

--- a/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass-annotation/openshift.yml
+++ b/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass-annotation/openshift.yml
@@ -107,7 +107,7 @@ items:
                 - chmod
                 - "777"
                 - /var/lib/registry
-              image: busybox
+              image: quay.io/quay/busybox
               imagePullPolicy: IfNotPresent
               name: jkube-volume-permission
               volumeMounts:

--- a/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass/kubernetes.yml
+++ b/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass/kubernetes.yml
@@ -103,7 +103,7 @@ items:
           - chmod
           - "777"
           - /var/lib/registry
-          image: busybox
+          image: quay.io/quay/busybox
           imagePullPolicy: IfNotPresent
           name: jkube-volume-permission
           resources:

--- a/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass/openshift.yml
+++ b/gradle-plugin/it/src/it/volume-permission/expected/custom-storageclass/openshift.yml
@@ -106,7 +106,7 @@ items:
           - chmod
           - "777"
           - /var/lib/registry
-          image: busybox
+          image: quay.io/quay/busybox
           imagePullPolicy: IfNotPresent
           name: jkube-volume-permission
           resources:

--- a/gradle-plugin/it/src/it/volume-permission/expected/default/kubernetes.yml
+++ b/gradle-plugin/it/src/it/volume-permission/expected/default/kubernetes.yml
@@ -102,7 +102,7 @@ items:
           - chmod
           - "777"
           - /var/lib/registry
-          image: busybox
+          image: quay.io/quay/busybox
           imagePullPolicy: IfNotPresent
           name: jkube-volume-permission
           resources:

--- a/gradle-plugin/it/src/it/volume-permission/expected/default/openshift.yml
+++ b/gradle-plugin/it/src/it/volume-permission/expected/default/openshift.yml
@@ -105,7 +105,7 @@ items:
           - chmod
           - "777"
           - /var/lib/registry
-          image: busybox
+          image: quay.io/quay/busybox
           imagePullPolicy: IfNotPresent
           name: jkube-volume-permission
           resources:

--- a/jkube-kit/doc/src/main/asciidoc/inc/enricher/volume-permission/_jkube_volume_permission.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/enricher/volume-permission/_jkube_volume_permission.adoc
@@ -12,7 +12,7 @@ Enricher which fixes the permission of persistent volume mount with the help of 
 | *imageName*
 | Image name for PersistentVolume init container
 
-  Defaults to `busybox`.
+  Defaults to `quay.io/quay/busybox`.
 
 | `jkube.enricher.jkube-volume-permission.imageName`
 

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricher.java
@@ -53,7 +53,7 @@ public class VolumePermissionEnricher extends BaseEnricher {
 
     @AllArgsConstructor
     enum Config implements Configs.Config {
-        IMAGE_NAME("imageName", "busybox"),
+        IMAGE_NAME("imageName", "quay.io/quay/busybox"),
         PERMISSION("permission", "777"),
         /**
          * @deprecated Use configuration field in PersistentVolumeClaimStorageClassEnricher

--- a/kubernetes-maven-plugin/it/src/it/deployment-strategy-type-919/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/deployment-strategy-type-919/expected/kubernetes.yml
@@ -71,7 +71,7 @@ items:
           - chmod
           - "777"
           - /var/lib/registry
-          image: busybox
+          image: quay.io/quay/busybox
           imagePullPolicy: IfNotPresent
           name: jkube-volume-permission
           volumeMounts:

--- a/kubernetes-maven-plugin/it/src/it/volume-enricher-custom-storage-class/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/volume-enricher-custom-storage-class/expected/kubernetes.yml
@@ -103,7 +103,7 @@ items:
           - chmod
           - "777"
           - /var/lib/registry
-          image: busybox
+          image: quay.io/quay/busybox
           imagePullPolicy: IfNotPresent
           name: jkube-volume-permission
           resources:

--- a/kubernetes-maven-plugin/it/src/it/volume-enricher-default-storage-class/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/volume-enricher-default-storage-class/expected/kubernetes.yml
@@ -102,7 +102,7 @@ items:
           - chmod
           - "777"
           - /var/lib/registry
-          image: busybox
+          image: quay.io/quay/busybox
           imagePullPolicy: IfNotPresent
           name: jkube-volume-permission
           resources:


### PR DESCRIPTION
## Description
Related to #2423

Update VolumePermissionEnricher imageName config's default value to`quay.io/quay/busybox` to avoid Docker Hub rate limiting issues.

+ Update VolumePermissionEnricher `imageName` field's default value to `quay.io/quay/busybox`
+ Add tests in VolumePermissionTest for overriding `imageName` and when volume mounts in container do not match the PersistentVolumeClaim
+ Remove redundant test case in VolumePermissionTest.adapt it was doing the same thing as parameterized test case above it.


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
