### PR TITLE
 Add check for image name length to not exceed 255

### DIFF
--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -55,6 +55,8 @@ public class ImageName {
     // Digest
     private String digest;
 
+    private static final int REPO_NAME_MAX_LENGTH = 255;
+
     /**
      * Create an image name
      *
@@ -279,6 +281,11 @@ public class ImageName {
                 "tag", TAG_REGEXP, tag,
                 "digest", DIGEST_REGEXP, digest
         };
+
+        if (repository.length() > REPO_NAME_MAX_LENGTH) {
+            errors.add(String.format("Repository name must not be more than %d characters", REPO_NAME_MAX_LENGTH));
+        }
+
         for (int i = 0; i < checks.length; i +=3) {
             String value = (String) checks[i + 2];
             Pattern checkPattern = (Pattern) checks[i + 1];

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameDistributionReferenceTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameDistributionReferenceTest.java
@@ -94,7 +94,7 @@ class ImageNameDistributionReferenceTest {
       "",
       ":justtag",
       "@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      //"a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a:tag", // https://github.com/eclipse/jkube/issues/2542
+      "a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a:tag",
       //"repo@sha256:ffffffffffffffffffffffffffffffffff", // https://github.com/eclipse/jkube/issues/2543
       "validname@invaliddigest:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
       "Uppercase:tag",

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
@@ -12,7 +12,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 package org.eclipse.jkube.kit.config.image;
-
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -125,6 +125,17 @@ class ImageNameTest {
         assertThrows(IllegalArgumentException.class, () -> new ImageName(""));
     }
 
+    
+    @Test
+    @DisplayName("too long repository name, should throw exception")
+    void shouldThrowExceptionOnTooLongImageName() {
+        String tooLongName = StringUtils.repeat("a", 256);
+        assertThatIllegalArgumentException()
+            .as("Too long image name should fail")
+            .isThrownBy(() -> new ImageName(tooLongName))
+            .withMessageContaining("Repository name must not be more than 255 characters");
+    }
+    
     @Test
     void namesUsedByDockerTests() {
         StringBuilder longTag = new StringBuilder();


### PR DESCRIPTION
ImageName throws exception when image repository name length is greater than 255

Fixes #2542 


## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)


## Checklist
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes



