### PR TITLE
fix (jkube-kit/enricher) : WellKnownLabelEnricher also considers labels added via resource configuration

### DIFF
--- a/gradle-plugin/it/src/it/well-known-labels/build.gradle
+++ b/gradle-plugin/it/src/it/well-known-labels/build.gradle
@@ -25,6 +25,32 @@ repositories {
     mavenCentral()
 }
 
+def allProperties = new Properties();
+allProperties.put("team","via-resource-groovy-dsl-labels-all")
+allProperties.put("language", "via-resource-groovy-dsl-labels-all")
+allProperties.put("provider", "via-resource-groovy-dsl-labels-all")
+allProperties.put("app", "via-resource-groovy-dsl-labels-all")
+allProperties.put("version", "via-resource-groovy-dsl-labels-all")
+allProperties.put("group", "via-resource-groovy-dsl-labels-all")
+allProperties.put("app.kubernetes.io/name", "via-resource-groovy-dsl-labels-all")
+allProperties.put("app.kubernetes.io/version", "via-resource-groovy-dsl-labels-all")
+allProperties.put("app.kubernetes.io/component", "via-resource-groovy-dsl-labels-all")
+allProperties.put("app.kubernetes.io/managed-by", "via-resource-groovy-dsl-labels-all")
+allProperties.put("app.kubernetes.io/part-of", "via-resource-groovy-dsl-labels-all")
+
+def serviceProperties = new Properties();
+serviceProperties.put("team", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("language", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("provider", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("app", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("version", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("group", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("app.kubernetes.io/name", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("app.kubernetes.io/version", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("app.kubernetes.io/component", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("app.kubernetes.io/managed-by", "via-resource-groovy-dsl-labels-service")
+serviceProperties.put("app.kubernetes.io/part-of", "via-resource-groovy-dsl-labels-service")
+
 def extensionConfig = {
     offline = true
     images {
@@ -36,6 +62,14 @@ def extensionConfig = {
             }
         }
     }
+if (project.hasProperty('labelsViaResourceConfig')) {
+    resources {
+        labels {
+            all = allProperties
+            service = serviceProperties
+        }
+    }
+}
 }
 
 kubernetes(extensionConfig)

--- a/gradle-plugin/it/src/it/well-known-labels/expected/labelsViaResourceConfig/kubernetes.yml
+++ b/gradle-plugin/it/src/it/well-known-labels/expected/labelsViaResourceConfig/kubernetes.yml
@@ -1,0 +1,103 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      jkube.eclipse.org/git-branch: "@ignore@"
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+    labels:
+      app: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/component: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/name: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/version: via-resource-groovy-dsl-labels-service
+      group: via-resource-groovy-dsl-labels-service
+      provider: via-resource-groovy-dsl-labels-service
+      version: via-resource-groovy-dsl-labels-service
+    name: well-known-labels
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/component: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/name: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-service
+      group: via-resource-groovy-dsl-labels-service
+      provider: via-resource-groovy-dsl-labels-service
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      jkube.eclipse.org/git-branch: "@ignore@"
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+    labels:
+      app: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/component: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/name: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/version: via-resource-groovy-dsl-labels-all
+      group: via-resource-groovy-dsl-labels-all
+      provider: via-resource-groovy-dsl-labels-all
+      version: via-resource-groovy-dsl-labels-all
+    name: well-known-labels
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      matchLabels:
+        app: via-resource-groovy-dsl-labels-all
+        app.kubernetes.io/component: via-resource-groovy-dsl-labels-all
+        app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-all
+        app.kubernetes.io/name: via-resource-groovy-dsl-labels-all
+        app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-all
+        group: via-resource-groovy-dsl-labels-all
+        provider: via-resource-groovy-dsl-labels-all
+    template:
+      metadata:
+        annotations:
+          jkube.eclipse.org/git-branch: "@ignore@"
+          jkube.eclipse.org/git-commit: "@ignore@"
+          jkube.eclipse.org/git-url: "@ignore@"
+        labels:
+          app: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/component: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/name: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/version: via-resource-groovy-dsl-labels-all
+          group: via-resource-groovy-dsl-labels-all
+          provider: via-resource-groovy-dsl-labels-all
+          version: via-resource-groovy-dsl-labels-all
+        name: well-known-labels
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          image: repository/well-known-labels:latest
+          imagePullPolicy: IfNotPresent
+          name: repository-well-known-labels
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          securityContext:
+            privileged: false

--- a/gradle-plugin/it/src/it/well-known-labels/expected/labelsViaResourceConfig/openshift.yml
+++ b/gradle-plugin/it/src/it/well-known-labels/expected/labelsViaResourceConfig/openshift.yml
@@ -1,0 +1,144 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.eclipse.org/git-branch: "@ignore@"
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+    labels:
+      app: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/component: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/name: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/version: via-resource-groovy-dsl-labels-service
+      group: via-resource-groovy-dsl-labels-service
+      provider: via-resource-groovy-dsl-labels-service
+      version: via-resource-groovy-dsl-labels-service
+    name: well-known-labels
+  spec:
+    ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/component: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/name: via-resource-groovy-dsl-labels-service
+      app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-service
+      group: via-resource-groovy-dsl-labels-service
+      provider: via-resource-groovy-dsl-labels-service
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.eclipse.org/git-branch: "@ignore@"
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+    labels:
+      app: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/component: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/name: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/version: via-resource-groovy-dsl-labels-all
+      group: via-resource-groovy-dsl-labels-all
+      provider: via-resource-groovy-dsl-labels-all
+      version: via-resource-groovy-dsl-labels-all
+    name: well-known-labels
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/component: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/name: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-all
+      group: via-resource-groovy-dsl-labels-all
+      provider: via-resource-groovy-dsl-labels-all
+    strategy:
+      rollingParams:
+        timeoutSeconds: 3600
+      type: Rolling
+    template:
+      metadata:
+        annotations:
+          app.openshift.io/vcs-ref: "@ignore@"
+          app.openshift.io/vcs-uri: "@ignore@"
+          jkube.eclipse.org/git-branch: "@ignore@"
+          jkube.eclipse.org/git-commit: "@ignore@"
+          jkube.eclipse.org/git-url: "@ignore@"
+        labels:
+          app: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/component: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/name: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-all
+          app.kubernetes.io/version: via-resource-groovy-dsl-labels-all
+          group: via-resource-groovy-dsl-labels-all
+          provider: via-resource-groovy-dsl-labels-all
+          version: via-resource-groovy-dsl-labels-all
+        name: well-known-labels
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: repository/well-known-labels:latest
+          imagePullPolicy: IfNotPresent
+          name: repository-well-known-labels
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          securityContext:
+            privileged: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - repository-well-known-labels
+        from:
+          kind: ImageStreamTag
+          name: well-known-labels:latest
+      type: ImageChange
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      app.openshift.io/vcs-ref: "@ignore@"
+      app.openshift.io/vcs-uri: "@ignore@"
+      jkube.eclipse.org/git-branch: "@ignore@"
+      jkube.eclipse.org/git-commit: "@ignore@"
+      jkube.eclipse.org/git-url: "@ignore@"
+    labels:
+      app: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/component: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/managed-by: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/name: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/part-of: via-resource-groovy-dsl-labels-all
+      app.kubernetes.io/version: via-resource-groovy-dsl-labels-all
+      group: via-resource-groovy-dsl-labels-all
+      provider: via-resource-groovy-dsl-labels-all
+      version: via-resource-groovy-dsl-labels-all
+    name: well-known-labels
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: well-known-labels

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/WellKnownLabelsIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/WellKnownLabelsIT.java
@@ -43,7 +43,8 @@ class WellKnownLabelsIT {
             "-Pjkube.enricher.jkube-well-known-labels.component=custom-component",
             "-Pjkube.enricher.jkube-well-known-labels.partOf=custom-part-of",
             "-Pjkube.enricher.jkube-well-known-labels.managedBy=custom-managed-by",
-        })
+        }),
+        arguments("labelsViaResourceConfig", new String[] {"-PlabelsViaResourceConfig=true"})
     );
   }
 

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/MapUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/MapUtil.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.BiFunction;
 
 public class MapUtil {
@@ -54,7 +55,8 @@ public class MapUtil {
      * @param <V> second type
      * @return merged hash map
      */
-    public static <K,V> Map<K,V> mergeMaps(Map<K, V> ...maps) {
+    @SafeVarargs
+    public static <K,V> Map<K,V> mergeMaps(Map<K, V>... maps) {
         Map<K, V> answer = new HashMap<>();
         for (int i = maps.length-1; i >= 0; i--) {
             if (maps[i] != null) {
@@ -63,6 +65,25 @@ public class MapUtil {
         }
         return answer;
 
+    }
+
+    /**
+     * Returns a new map with all the entries the provided properties merged.
+     *
+     * The first arguments take precedence over the later ones.
+     * i.e. properties defined in the last argument will not override properties defined in the first argument.
+     *
+     * @param properties var arg for properties
+     * @return merged hash map
+     */
+    public static Map<String, String> mergeMaps(Properties... properties) {
+        Map<String, String> answer = new HashMap<>();
+        for (int i = properties.length-1; i >= 0; i--) {
+            if (properties[i] != null) {
+                answer.putAll(PropertiesUtil.toMap(properties[i]));
+            }
+        }
+        return answer;
     }
 
     /**

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/MapUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/MapUtil.java
@@ -42,23 +42,24 @@ public class MapUtil {
     }
 
     /**
-     * Returns a new map with all the entries of map1 and any from map2 which don't override map1.
+     * Returns a new map with all the entries of first map with rest map entries which don't override map1.
      *
-     * Can handle either maps being null. Always returns a new mutable map
+     * Can handle either maps being null. Always returns a new mutable map.
      *
-     * @param map1 first hash map
-     * @param map2 second hash map
+     * <b>Note:</b> Be careful about the ordering of maps passed here. First map passed in the var args
+     * would always be given precedence over other maps in case there are colliding entries with same key values.
+     *
+     * @param maps var arg for maps
      * @param <K> first type
      * @param <V> second type
      * @return merged hash map
      */
-    public static <K,V> Map<K,V> mergeMaps(Map<K, V> map1, Map<K, V> map2) {
+    public static <K,V> Map<K,V> mergeMaps(Map<K, V> ...maps) {
         Map<K, V> answer = new HashMap<>();
-        if (map2 != null) {
-            answer.putAll(map2);
-        }
-        if (map1 != null) {
-            answer.putAll(map1);
+        for (int i = maps.length-1; i >= 0; i--) {
+            if (maps[i] != null) {
+                answer.putAll(maps[i]);
+            }
         }
         return answer;
 

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/AbstractLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/AbstractLabelEnricher.java
@@ -16,20 +16,23 @@ package org.eclipse.jkube.enricher.generic;
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerBuilder;
 import io.fabric8.kubernetes.api.model.ReplicationControllerSpec;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.api.model.apps.DaemonSetBuilder;
+import io.fabric8.kubernetes.api.model.apps.DaemonSetSpec;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSetSpec;
 import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetSpec;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import org.eclipse.jkube.kit.common.util.MapUtil;
-import org.eclipse.jkube.kit.common.util.PropertiesUtil;
 import org.eclipse.jkube.kit.config.resource.MetaDataConfig;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
@@ -37,37 +40,29 @@ import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
 import org.eclipse.jkube.kit.enricher.api.model.Configuration;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-
-import static org.eclipse.jkube.kit.common.util.PropertiesUtil.toMap;
 
 public abstract class AbstractLabelEnricher extends BaseEnricher {
   protected AbstractLabelEnricher(EnricherContext enricherContext, String name) {
     super(enricherContext, name);
   }
 
-  abstract Map<String, String> createLabels(boolean withoutVersion, Map<String, String> labelsViaResourceConfig);
+  abstract Map<String, String> createLabels(boolean includeVersion, Map<String, String> labelsViaResourceConfig);
 
   @Override
-  @SuppressWarnings("unchecked")
   public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
     builder.accept(new TypedVisitor<ServiceBuilder>() {
       @Override
       public void visit(ServiceBuilder serviceBuilder) {
-        Map<String, String> selectors = new HashMap<>();
-        Map<String, String> labelsConfiguredViaResourceConfig = MapUtil.mergeMaps(
-            toMap(getResourceConfigLabels().getService()),
-            toMap(getResourceConfigLabels().getAll()));
-        if(serviceBuilder.buildSpec() != null && serviceBuilder.buildSpec().getSelector() != null) {
-          selectors.putAll(serviceBuilder.buildSpec().getSelector());
-        }
-        MapUtil.mergeIfAbsent(selectors, createLabels(true, labelsConfiguredViaResourceConfig));
+        final Map<String, String> selectors = processSelectors(
+          Optional.ofNullable(serviceBuilder.buildSpec())
+            .map(ServiceSpec::getSelector)
+            .orElse(new HashMap<>()),
+          false,
+          getResourceConfigLabels().getService(),getResourceConfigLabels().getAll());
         serviceBuilder.editOrNewSpec().addToSelector(selectors).endSpec();
       }
     });
@@ -75,13 +70,15 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
     builder.accept(new TypedVisitor<DeploymentBuilder>() {
       @Override
       public void visit(DeploymentBuilder builder) {
-        final Map<String, String> selectors = mergedSelectors(Optional.ofNullable(builder.buildSpec())
+        final Map<String, String> selectors = processSelectors(
+          Optional.ofNullable(builder.buildSpec())
             .map(DeploymentSpec::getSelector)
             .map(LabelSelector::getMatchLabels)
-            .orElse(new HashMap<>()), Arrays.asList(
-                getResourceConfigLabels().getDeployment(),
-                getResourceConfigLabels().getPod(),
-                getResourceConfigLabels().getAll()));
+            .orElse(new HashMap<>()),
+          false,
+          getResourceConfigLabels().getDeployment(),
+          getResourceConfigLabels().getPod(),
+          getResourceConfigLabels().getAll());
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }
     });
@@ -89,11 +86,12 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
     builder.accept(new TypedVisitor<DeploymentConfigBuilder>() {
       @Override
       public void visit(DeploymentConfigBuilder builder) {
-        final Map<String, String> selectors = mergedSelectors(Optional.ofNullable(builder.buildSpec())
+        final Map<String, String> selectors = processSelectors(
+          Optional.ofNullable(builder.buildSpec())
             .map(DeploymentConfigSpec::getSelector)
-            .orElse(new HashMap<>()), Arrays.asList(
-                getResourceConfigLabels().getPod(),
-                getResourceConfigLabels().getAll()));
+            .orElse(new HashMap<>()),
+          false,
+          getResourceConfigLabels().getPod(), getResourceConfigLabels().getAll());
         builder.editOrNewSpec().addToSelector(selectors).endSpec();
       }
     });
@@ -101,14 +99,12 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
     builder.accept(new TypedVisitor<DaemonSetBuilder>() {
       @Override
       public void visit(DaemonSetBuilder builder) {
-        Map<String, String> selectors = new HashMap<>();
-        Map<String, String> labelsFromResourceConfig = MapUtil.mergeMaps(
-            toMap(getResourceConfigLabels().getPod()),
-            toMap(getResourceConfigLabels().getAll()));
-        if(builder.buildSpec() != null && builder.buildSpec().getSelector() != null && builder.buildSpec().getSelector().getMatchLabels() != null) {
-          selectors.putAll(builder.buildSpec().getSelector().getMatchLabels());
-        }
-        MapUtil.mergeIfAbsent(selectors, createLabels(false, labelsFromResourceConfig));
+        final Map<String, String> selectors = processSelectors(
+          Optional.ofNullable(builder.buildSpec())
+            .map(DaemonSetSpec::getSelector)
+            .map(LabelSelector::getMatchLabels)
+            .orElse(new HashMap<>()),
+          true, getResourceConfigLabels().getAll());
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }
     });
@@ -116,11 +112,12 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
     builder.accept(new TypedVisitor<ReplicationControllerBuilder>() {
       @Override
       public void visit(ReplicationControllerBuilder builder) {
-        final Map<String, String> selectors = mergedSelectors(Optional.ofNullable(builder.buildSpec())
+        final Map<String, String> selectors = processSelectors(
+          Optional.ofNullable(builder.buildSpec())
             .map(ReplicationControllerSpec::getSelector)
-            .orElse(new HashMap<>()), Arrays.asList(
-                getResourceConfigLabels().getPod(),
-                getResourceConfigLabels().getAll()));
+            .orElse(new HashMap<>()),
+          false,
+          getResourceConfigLabels().getPod(), getResourceConfigLabels().getAll());
         builder.editOrNewSpec().addToSelector(selectors).endSpec();
       }
     });
@@ -128,13 +125,15 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
     builder.accept(new TypedVisitor<ReplicaSetBuilder>() {
       @Override
       public void visit(ReplicaSetBuilder builder) {
-        final Map<String, String> selectors = mergedSelectors(Optional.ofNullable(builder.buildSpec())
+        final Map<String, String> selectors = processSelectors(
+          Optional.ofNullable(builder.buildSpec())
             .map(ReplicaSetSpec::getSelector)
             .map(LabelSelector::getMatchLabels)
-            .orElse(new HashMap<>()), Arrays.asList(
-                getResourceConfigLabels().getReplicaSet(),
-                getResourceConfigLabels().getPod(),
-                getResourceConfigLabels().getAll()));
+            .orElse(new HashMap<>()),
+          false,
+          getResourceConfigLabels().getReplicaSet(),
+          getResourceConfigLabels().getPod(),
+          getResourceConfigLabels().getAll());
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }
     });
@@ -142,14 +141,13 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
     builder.accept(new TypedVisitor<StatefulSetBuilder>() {
       @Override
       public void visit(StatefulSetBuilder builder) {
-        Map<String, String> selectors = new HashMap<>();
-        Map<String, String> labelsFromResourceConfig = MapUtil.mergeMaps(
-            toMap(getResourceConfigLabels().getPod()),
-            toMap(getResourceConfigLabels().getAll()));
-        if(builder.buildSpec() != null && builder.buildSpec().getSelector() != null && builder.buildSpec().getSelector().getMatchLabels() != null) {
-          selectors.putAll(builder.buildSpec().getSelector().getMatchLabels());
-        }
-        MapUtil.mergeIfAbsent(selectors, createLabels(false, labelsFromResourceConfig));
+        final Map<String, String> selectors = processSelectors(
+          Optional.ofNullable(builder.buildSpec())
+            .map(StatefulSetSpec::getSelector)
+            .map(LabelSelector::getMatchLabels)
+            .orElse(new HashMap<>()),
+          true,
+          getResourceConfigLabels().getPod(), getResourceConfigLabels().getAll());
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }
     });
@@ -162,20 +160,19 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
     builder.accept(new TypedVisitor<ObjectMetaBuilder>() {
       @Override
       public void visit(ObjectMetaBuilder element) {
-        Map<String, String> labels = Optional.ofNullable(element.getLabels()).orElse(new HashMap<>());
-        MapUtil.mergeIfAbsent(labels, createLabels(false, Collections.emptyMap()));
+        final Map<String, String> labels = processSelectors(
+          Optional.ofNullable(element.build())
+            .map(ObjectMeta::getLabels)
+            .orElse(new HashMap<>()),
+          true);
         element.withLabels(labels);
       }
     });
   }
 
-  @SuppressWarnings("unchecked")
-  private Map<String, String> mergedSelectors(Map<String, String> originalSelectors, List<Properties> labelPropertyList) {
-    Map<String, String> labelsFromResourceConfig = MapUtil.mergeMaps(labelPropertyList.stream()
-        .map(PropertiesUtil::toMap)
-        .toArray(Map[]::new));
-    MapUtil.mergeIfAbsent(originalSelectors, createLabels(true, labelsFromResourceConfig));
-    return originalSelectors;
+  private Map<String, String> processSelectors(Map<String, String> selectors, boolean includeVersion, Properties... labelPropertyList) {
+    MapUtil.mergeIfAbsent(selectors, createLabels(includeVersion, MapUtil.mergeMaps(labelPropertyList)));
+    return selectors;
   }
 
   protected MetaDataConfig getResourceConfigLabels() {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/AbstractLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/AbstractLabelEnricher.java
@@ -29,31 +29,45 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import org.eclipse.jkube.kit.common.util.MapUtil;
+import org.eclipse.jkube.kit.common.util.PropertiesUtil;
+import org.eclipse.jkube.kit.config.resource.MetaDataConfig;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
+import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
+import org.eclipse.jkube.kit.enricher.api.model.Configuration;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
+
+import static org.eclipse.jkube.kit.common.util.PropertiesUtil.toMap;
 
 public abstract class AbstractLabelEnricher extends BaseEnricher {
   protected AbstractLabelEnricher(EnricherContext enricherContext, String name) {
     super(enricherContext, name);
   }
 
-  abstract Map<String, String> createLabels(boolean withoutVersion);
+  abstract Map<String, String> createLabels(boolean withoutVersion, Map<String, String> labelsViaResourceConfig);
 
   @Override
+  @SuppressWarnings("unchecked")
   public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
     builder.accept(new TypedVisitor<ServiceBuilder>() {
       @Override
       public void visit(ServiceBuilder serviceBuilder) {
         Map<String, String> selectors = new HashMap<>();
+        Map<String, String> labelsConfiguredViaResourceConfig = MapUtil.mergeMaps(
+            toMap(getResourceConfigLabels().getService()),
+            toMap(getResourceConfigLabels().getAll()));
         if(serviceBuilder.buildSpec() != null && serviceBuilder.buildSpec().getSelector() != null) {
           selectors.putAll(serviceBuilder.buildSpec().getSelector());
         }
-        MapUtil.mergeIfAbsent(selectors, createLabels(true));
+        MapUtil.mergeIfAbsent(selectors, createLabels(true, labelsConfiguredViaResourceConfig));
         serviceBuilder.editOrNewSpec().addToSelector(selectors).endSpec();
       }
     });
@@ -64,7 +78,10 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
         final Map<String, String> selectors = mergedSelectors(Optional.ofNullable(builder.buildSpec())
             .map(DeploymentSpec::getSelector)
             .map(LabelSelector::getMatchLabels)
-            .orElse(new HashMap<>()));
+            .orElse(new HashMap<>()), Arrays.asList(
+                getResourceConfigLabels().getDeployment(),
+                getResourceConfigLabels().getPod(),
+                getResourceConfigLabels().getAll()));
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }
     });
@@ -74,7 +91,9 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
       public void visit(DeploymentConfigBuilder builder) {
         final Map<String, String> selectors = mergedSelectors(Optional.ofNullable(builder.buildSpec())
             .map(DeploymentConfigSpec::getSelector)
-            .orElse(new HashMap<>()));
+            .orElse(new HashMap<>()), Arrays.asList(
+                getResourceConfigLabels().getPod(),
+                getResourceConfigLabels().getAll()));
         builder.editOrNewSpec().addToSelector(selectors).endSpec();
       }
     });
@@ -83,10 +102,13 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
       @Override
       public void visit(DaemonSetBuilder builder) {
         Map<String, String> selectors = new HashMap<>();
+        Map<String, String> labelsFromResourceConfig = MapUtil.mergeMaps(
+            toMap(getResourceConfigLabels().getPod()),
+            toMap(getResourceConfigLabels().getAll()));
         if(builder.buildSpec() != null && builder.buildSpec().getSelector() != null && builder.buildSpec().getSelector().getMatchLabels() != null) {
           selectors.putAll(builder.buildSpec().getSelector().getMatchLabels());
         }
-        MapUtil.mergeIfAbsent(selectors, createLabels(false));
+        MapUtil.mergeIfAbsent(selectors, createLabels(false, labelsFromResourceConfig));
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }
     });
@@ -96,7 +118,9 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
       public void visit(ReplicationControllerBuilder builder) {
         final Map<String, String> selectors = mergedSelectors(Optional.ofNullable(builder.buildSpec())
             .map(ReplicationControllerSpec::getSelector)
-            .orElse(new HashMap<>()));
+            .orElse(new HashMap<>()), Arrays.asList(
+                getResourceConfigLabels().getPod(),
+                getResourceConfigLabels().getAll()));
         builder.editOrNewSpec().addToSelector(selectors).endSpec();
       }
     });
@@ -107,7 +131,10 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
         final Map<String, String> selectors = mergedSelectors(Optional.ofNullable(builder.buildSpec())
             .map(ReplicaSetSpec::getSelector)
             .map(LabelSelector::getMatchLabels)
-            .orElse(new HashMap<>()));
+            .orElse(new HashMap<>()), Arrays.asList(
+                getResourceConfigLabels().getReplicaSet(),
+                getResourceConfigLabels().getPod(),
+                getResourceConfigLabels().getAll()));
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }
     });
@@ -116,10 +143,13 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
       @Override
       public void visit(StatefulSetBuilder builder) {
         Map<String, String> selectors = new HashMap<>();
+        Map<String, String> labelsFromResourceConfig = MapUtil.mergeMaps(
+            toMap(getResourceConfigLabels().getPod()),
+            toMap(getResourceConfigLabels().getAll()));
         if(builder.buildSpec() != null && builder.buildSpec().getSelector() != null && builder.buildSpec().getSelector().getMatchLabels() != null) {
           selectors.putAll(builder.buildSpec().getSelector().getMatchLabels());
         }
-        MapUtil.mergeIfAbsent(selectors, createLabels(false));
+        MapUtil.mergeIfAbsent(selectors, createLabels(false, labelsFromResourceConfig));
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }
     });
@@ -133,14 +163,25 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
       @Override
       public void visit(ObjectMetaBuilder element) {
         Map<String, String> labels = Optional.ofNullable(element.getLabels()).orElse(new HashMap<>());
-        MapUtil.mergeIfAbsent(labels, createLabels(false));
+        MapUtil.mergeIfAbsent(labels, createLabels(false, Collections.emptyMap()));
         element.withLabels(labels);
       }
     });
   }
 
-  private Map<String, String> mergedSelectors(Map<String, String> originalSelectors) {
-    MapUtil.mergeIfAbsent(originalSelectors, createLabels(true));
+  @SuppressWarnings("unchecked")
+  private Map<String, String> mergedSelectors(Map<String, String> originalSelectors, List<Properties> labelPropertyList) {
+    Map<String, String> labelsFromResourceConfig = MapUtil.mergeMaps(labelPropertyList.stream()
+        .map(PropertiesUtil::toMap)
+        .toArray(Map[]::new));
+    MapUtil.mergeIfAbsent(originalSelectors, createLabels(true, labelsFromResourceConfig));
     return originalSelectors;
+  }
+
+  protected MetaDataConfig getResourceConfigLabels() {
+    return Optional.ofNullable(getConfiguration())
+        .map(Configuration::getResource)
+        .map(ResourceConfig::getLabels)
+        .orElse(MetaDataConfig.builder().build());
   }
 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -65,7 +64,7 @@ public class ProjectLabelEnricher extends AbstractLabelEnricher {
     }
 
     @Override
-    public Map<String, String> createLabels(boolean withoutVersion, Map<String, String> labelsViaResourceConfig) {
+    public Map<String, String> createLabels(boolean includeVersion, Map<String, String> labelsViaResourceConfig) {
         Map<String, String> ret = new HashMap<>();
 
         boolean enableProjectLabel = Configs.asBoolean(getConfig(Config.USE_PROJECT_LABEL));
@@ -78,7 +77,7 @@ public class ProjectLabelEnricher extends AbstractLabelEnricher {
 
         ret.putAll(addProjectLabelFromApplicableSource(Config.GROUP, "group", groupArtifactVersion.getGroupId(), labelsViaResourceConfig));
         ret.putAll(addProjectLabelFromApplicableSource(Config.PROVIDER, LABEL_PROVIDER, null, labelsViaResourceConfig));
-        if (!withoutVersion) {
+        if (includeVersion) {
             ret.putAll(addProjectLabelFromApplicableSource(Config.VERSION, "version", groupArtifactVersion.getVersion(), labelsViaResourceConfig));
         }
         return ret;

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
@@ -15,7 +15,9 @@ package org.eclipse.jkube.enricher.generic;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -50,7 +52,7 @@ public class ProjectLabelEnricher extends AbstractLabelEnricher {
         APP("app", null),
         GROUP("group", null),
         VERSION("version", null),
-        PROVIDER("provider", "jkube");
+        PROVIDER(LABEL_PROVIDER, "jkube");
 
         @Getter
         protected String key;
@@ -63,22 +65,31 @@ public class ProjectLabelEnricher extends AbstractLabelEnricher {
     }
 
     @Override
-    public Map<String, String> createLabels(boolean withoutVersion) {
+    public Map<String, String> createLabels(boolean withoutVersion, Map<String, String> labelsViaResourceConfig) {
         Map<String, String> ret = new HashMap<>();
 
         boolean enableProjectLabel = Configs.asBoolean(getConfig(Config.USE_PROJECT_LABEL));
         final GroupArtifactVersion groupArtifactVersion = getContext().getGav();
         if (enableProjectLabel) {
-            ret.put("project", groupArtifactVersion.getArtifactId());
+            ret.putAll(addProjectLabelFromApplicableSource(null, "project", groupArtifactVersion.getArtifactId(), labelsViaResourceConfig));
         } else {
-            ret.put("app", getConfig(Config.APP, groupArtifactVersion.getArtifactId()));
+            ret.putAll(addProjectLabelFromApplicableSource(Config.APP, "app", groupArtifactVersion.getArtifactId(), labelsViaResourceConfig));
         }
 
-        ret.put("group", getConfig(Config.GROUP, groupArtifactVersion.getGroupId()));
-        ret.put(LABEL_PROVIDER, getConfig(Config.PROVIDER));
+        ret.putAll(addProjectLabelFromApplicableSource(Config.GROUP, "group", groupArtifactVersion.getGroupId(), labelsViaResourceConfig));
+        ret.putAll(addProjectLabelFromApplicableSource(Config.PROVIDER, LABEL_PROVIDER, null, labelsViaResourceConfig));
         if (!withoutVersion) {
-            ret.put("version", getConfig(Config.VERSION, groupArtifactVersion.getVersion()));
+            ret.putAll(addProjectLabelFromApplicableSource(Config.VERSION, "version", groupArtifactVersion.getVersion(), labelsViaResourceConfig));
         }
         return ret;
+    }
+
+    private Map<String, String> addProjectLabelFromApplicableSource(Configs.Config key, String labelKey, String defaultValue, Map<String, String> labelsViaResourceConfig) {
+        Map<String, String> entryMap = new HashMap<>();
+        String appLabelValueFromConfig = Optional.ofNullable(key)
+            .map(k -> getConfig(k, defaultValue))
+            .orElse(defaultValue);
+        entryMap.put(labelKey, labelsViaResourceConfig.getOrDefault(labelKey, appLabelValueFromConfig));
+        return entryMap;
     }
 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/WellKnownLabelsEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/WellKnownLabelsEnricher.java
@@ -52,7 +52,7 @@ public class WellKnownLabelsEnricher extends AbstractLabelEnricher {
   }
 
   @Override
-  public Map<String, String> createLabels(boolean withoutVersion, Map<String, String> labelsViaResourceConfig) {
+  public Map<String, String> createLabels(boolean includeVersion, Map<String, String> labelsViaResourceConfig) {
     Map<String, String> ret = new HashMap<>();
     if (!shouldAddWellKnownLabels()) {
       return ret;
@@ -60,7 +60,7 @@ public class WellKnownLabelsEnricher extends AbstractLabelEnricher {
 
     final GroupArtifactVersion groupArtifactVersion = getContext().getGav();
     ret.putAll(addWellKnownLabelFromApplicableSource(Config.APP_NAME, "name", groupArtifactVersion.getArtifactId(), labelsViaResourceConfig));
-    if (!withoutVersion) {
+    if (includeVersion) {
       ret.putAll(addWellKnownLabelFromApplicableSource(Config.APP_VERSION, "version", groupArtifactVersion.getVersion(), labelsViaResourceConfig));
     }
     ret.putAll(addWellKnownLabelFromApplicableSource(Config.APP_PART_OF, "part-of", groupArtifactVersion.getGroupId(), labelsViaResourceConfig));

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/WellKnownLabelsEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/WellKnownLabelsEnricher.java
@@ -52,28 +52,31 @@ public class WellKnownLabelsEnricher extends AbstractLabelEnricher {
   }
 
   @Override
-  public Map<String, String> createLabels(boolean withoutVersion) {
+  public Map<String, String> createLabels(boolean withoutVersion, Map<String, String> labelsViaResourceConfig) {
     Map<String, String> ret = new HashMap<>();
     if (!shouldAddWellKnownLabels()) {
       return ret;
     }
 
     final GroupArtifactVersion groupArtifactVersion = getContext().getGav();
-    ret.putAll(addWellKnownLabelFromConfig(Config.APP_NAME, "name", groupArtifactVersion.getArtifactId()));
+    ret.putAll(addWellKnownLabelFromApplicableSource(Config.APP_NAME, "name", groupArtifactVersion.getArtifactId(), labelsViaResourceConfig));
     if (!withoutVersion) {
-      ret.putAll(addWellKnownLabelFromConfig(Config.APP_VERSION, "version", groupArtifactVersion.getVersion()));
+      ret.putAll(addWellKnownLabelFromApplicableSource(Config.APP_VERSION, "version", groupArtifactVersion.getVersion(), labelsViaResourceConfig));
     }
-    ret.putAll(addWellKnownLabelFromConfig(Config.APP_PART_OF, "part-of", groupArtifactVersion.getGroupId()));
-    ret.putAll(addWellKnownLabelFromConfig(Config.APP_MANAGED_BY, "managed-by", "jkube"));
-    ret.putAll(addWellKnownLabelFromConfig(Config.APP_COMPONENT, "component", null));
+    ret.putAll(addWellKnownLabelFromApplicableSource(Config.APP_PART_OF, "part-of", groupArtifactVersion.getGroupId(), labelsViaResourceConfig));
+    ret.putAll(addWellKnownLabelFromApplicableSource(Config.APP_MANAGED_BY, "managed-by", "jkube", labelsViaResourceConfig));
+    ret.putAll(addWellKnownLabelFromApplicableSource(Config.APP_COMPONENT, "component", null, labelsViaResourceConfig));
     return ret;
   }
 
-  private Map<String, String> addWellKnownLabelFromConfig(Configs.Config key, String labelKey, String defaultValue) {
+  private Map<String, String> addWellKnownLabelFromApplicableSource(Configs.Config key, String labelKey, String defaultValue, Map<String, String> labelsViaResourceConfig) {
     Map<String, String> entryMap = new HashMap<>();
-    String value = getConfig(key, defaultValue);
-    if (StringUtils.isNotBlank(value)) {
-      entryMap.put(KUBERNETES_APP_LABEL + labelKey, value);
+    String appLabel = KUBERNETES_APP_LABEL + labelKey;
+    String appLabelValueFromConfig = getConfig(key, defaultValue);
+    if (labelsViaResourceConfig.containsKey(appLabel)) {
+      entryMap.put(appLabel, labelsViaResourceConfig.get(appLabel));
+    } else if (StringUtils.isNotBlank(appLabelValueFromConfig)) {
+      entryMap.put(appLabel, appLabelValueFromConfig);
     }
     return entryMap;
   }


### PR DESCRIPTION
## Description

Fix #1700 
While adding labels and selectors to a resource, WellKnownLabelEnricher and ProjectLabelEnricher would give precedence to label configured via resource label XML/Groovy DSL configuration.

This precedence would depend on the type of resource label configuration used. If `all` has been provided in configuration, this means precedence would be given for all resources. However, if some specific resource label configuration is used; precedence would only be given for that specific resource

+ Added another argument `Map<String, String> labelsViaResourceConfig` in AbstractLabelEnricher.createLabels to accommodate labels configured via resource configuration. `labelsViaResourceConfig` would override default opinionated or enricher configuration settings.
+ While invoking `createLabels`, various resource visitors would also pass their specific resource label configuration option so that that can be checked while creating opinonated labels




## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [ ] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [X] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
