### PR TITLE
ImageName should throw exception when digest length is too small

### DIFF
--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -357,5 +357,5 @@ public class ImageName {
     // https://github.com/docker/docker/blob/04da4041757370fb6f85510c8977c5a18ddae380/vendor/github.com/docker/distribution/reference/regexp.go#L37
     private static final Pattern TAG_REGEXP = Pattern.compile("^[\\w][\\w.-]{0,127}$");
 
-    private static final Pattern DIGEST_REGEXP = Pattern.compile("^sha256:[a-z0-9]{32,}$");
+    private static final Pattern DIGEST_REGEXP = Pattern.compile("^[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}$");
 }

--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameDistributionReferenceTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameDistributionReferenceTest.java
@@ -95,7 +95,7 @@ class ImageNameDistributionReferenceTest {
       ":justtag",
       "@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
       "a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a:tag",
-      //"repo@sha256:ffffffffffffffffffffffffffffffffff", // https://github.com/eclipse/jkube/issues/2543
+      "repo@sha256:ffffffffffffffffffffffffffffffffff",
       "validname@invaliddigest:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
       "Uppercase:tag",
       "test:5000/Uppercase/lowercase:tag",


### PR DESCRIPTION

Fixes #2543 


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ x] Bug fix (non-breaking change which fixes an issue)


