### PR TITLE
doc : When using a Maven master password you should configure `helm` → `security`

### DIFF
--- a/jkube-kit/doc/src/main/asciidoc/inc/helm/_jkube_helm.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/helm/_jkube_helm.adoc
@@ -166,6 +166,12 @@ Defaults to empty string.
 | The Helm chart file extension (`tgz`, `tar.bz`, `tar.bzip2`, `tar.bz2`), default value is `tar.gz` if not provided.
 | `jkube.helm.chartExtension`
 
+ifeval::["{plugin-type}" == "maven"]
+| *security*
+| The Maven security dispatcher configuration file. If you use the default security dispatcher, you need to point this to the file containing your master password. If you followed the http://maven.apache.org/guides/mini/guide-encryption.html[Maven Password Encryption guide], this is `${user.home}/.m2/settings-security.xml`.
+|
+endif::[]
+
 | *<<helm-dependencies, dependencies>>*
 | The list of dependencies for this chart.
 |

--- a/jkube-kit/doc/src/main/asciidoc/inc/helm/_jkube_helm_push.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/helm/_jkube_helm_push.adoc
@@ -31,6 +31,7 @@ ifeval::["{plugin-type}" == "maven"]
 You can provide helm repository authentication credentials either via properties or using environment variables. It's also possible to specify credentials in maven settings as well. You just
 need to add a server entry for your repo like this:
 
+[#helm-repository-authentication-credentials-in-settings-xml]
 .Helm Repository Authentication credentials in settings.xml
 [source,xml,indent=0,subs="verbatim,quotes,attributes"]
 ----
@@ -47,6 +48,19 @@ need to add a server entry for your repo like this:
   </servers>
 
 </settings>
+----
+
+If you have encrypted your password with a master password (as outlined in the http://maven.apache.org/guides/mini/guide-encryption.html[Maven Password Encryption guide]), make sure to configure the `security` setting:
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+----
+<plugin>
+  <configuration>
+    <helm>
+      <security>~/.m2/security-settings.xml</security>
+      ...
+    </helm>
+  </configuration>
+</plugin>
 ----
 endif::[]
 

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_authentication.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_authentication.adoc
@@ -166,7 +166,7 @@ Password:
 ----
 
 This password then can be used in `authConfig`, `docker.password`
-and/or the `<server>` setting configuration. However, putting an
+and/or the <<helm-repository-authentication-credentials-in-settings-xml,`<server>` setting configuration>>. However, putting an
 encrypted password into `authConfig` in the `pom.xml` doesn't make
 much sense, since this password is encrypted with an individual master
 password.


### PR DESCRIPTION
## Description
When you use a Maven master password and want to use `helm-push`, this will fail if you do not configure `helm` → `security` to point to your master password file (which normally is something like
~/.m2/settings-security.xml or ~/.settings-security.xml). Documentation did not mention that, so that is added.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift
