### PR TITLE
ImageName should throw exception when digest length is too small

### DIFF
--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -57,6 +57,8 @@ public class ImageName {
 
     private static final int REPO_NAME_MAX_LENGTH = 255;
 
+    private static final int MIN_DIGEST_LENGTH = 64;
+
     /**
      * Create an image name
      *
@@ -107,6 +109,11 @@ public class ImageName {
          */
         if (tag == null && digest == null) {
             tag = "latest";
+        }
+
+        // Validate the length of the digest
+        if (digest != null && digest.length() < MIN_DIGEST_LENGTH) {
+            throw new IllegalArgumentException("Length of the encoded digest does not match the expected value");
         }
 
         doValidate();

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -377,8 +377,6 @@ public class ImageName {
     private static final Pattern TAG_REGEXP = Pattern.compile("^[\\w][\\w.-]{0,127}$");
 
     private static final Pattern DIGEST_256_REGEXP = Pattern.compile("sha256:([0-9a-f]{64})");
-
     private static final Pattern DIGEST_512_REGEXP = Pattern.compile("sha512:([0-9a-f]{128})");
-
     private static final Pattern DIGEST_REGEXP = Pattern.compile("^(?:" + DIGEST_256_REGEXP + "|" + DIGEST_512_REGEXP + ")");
 }

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -115,10 +115,14 @@ public class ImageName {
 
         // Validate the length of the digest based on the algorithm used
         if (digest != null) {
-            if (digest.startsWith("sha256:") && digest.length() < MIN_SHA256_DIGEST_LENGTH) {
-                throw new IllegalArgumentException("Length of the encoded SHA256 digest does not match the expected value");
-            } else if (digest.startsWith("sha512:") && digest.length() < MIN_SHA512_DIGEST_LENGTH) {
-                throw new IllegalArgumentException("Length of the encoded SHA512 digest does not match the expected value");
+            String encodedDigest = null;
+            if (digest.startsWith("sha256:")) {
+                encodedDigest = digest.substring("sha256:".length());
+            } else if (digest.startsWith("sha512:")) {
+                encodedDigest = digest.substring("sha512:".length());
+            }
+            if (encodedDigest == null || encodedDigest.length() < MIN_SHA256_DIGEST_LENGTH) {
+                throw new IllegalArgumentException("Length of the encoded digest does not match the expected value");
             }
         }
 
@@ -383,6 +387,8 @@ public class ImageName {
     private static final Pattern TAG_REGEXP = Pattern.compile("^[\\w][\\w.-]{0,127}$");
 
     private static final Pattern DIGEST_256_REGEXP = Pattern.compile("sha256:([0-9a-f]{64})");
+
     private static final Pattern DIGEST_512_REGEXP = Pattern.compile("sha512:([0-9a-f]{128})");
+
     private static final Pattern DIGEST_REGEXP = Pattern.compile("^(?:" + DIGEST_256_REGEXP + "|" + DIGEST_512_REGEXP + ")");
 }

--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/ImageName.java
@@ -57,7 +57,9 @@ public class ImageName {
 
     private static final int REPO_NAME_MAX_LENGTH = 255;
 
-    private static final int MIN_DIGEST_LENGTH = 64;
+    private static final int MIN_SHA256_DIGEST_LENGTH = 64;
+
+    private static final int MIN_SHA512_DIGEST_LENGTH = 128;
 
     /**
      * Create an image name
@@ -111,9 +113,13 @@ public class ImageName {
             tag = "latest";
         }
 
-        // Validate the length of the digest
-        if (digest != null && digest.length() < MIN_DIGEST_LENGTH) {
-            throw new IllegalArgumentException("Length of the encoded digest does not match the expected value");
+        // Validate the length of the digest based on the algorithm used
+        if (digest != null) {
+            if (digest.startsWith("sha256:") && digest.length() < MIN_SHA256_DIGEST_LENGTH) {
+                throw new IllegalArgumentException("Length of the encoded SHA256 digest does not match the expected value");
+            } else if (digest.startsWith("sha512:") && digest.length() < MIN_SHA512_DIGEST_LENGTH) {
+                throw new IllegalArgumentException("Length of the encoded SHA512 digest does not match the expected value");
+            }
         }
 
         doValidate();


### PR DESCRIPTION
1.added check to validate digest length
2.updated digest regexp

Fixes #2543 


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X ] Bug fix (non-breaking change which fixes an issue)


## Checklist
 - [ X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X ] My code follows the style guidelines of this project
 - [X ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [ X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ X] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [X ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift


