### PR TITLE
Fix unit test so it works on all platforms

### DIFF
--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/FileUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/FileUtilTest.java
@@ -161,6 +161,7 @@ class FileUtilTest {
     Files.write(sourceFile.toPath(), "testdata".getBytes(StandardCharsets.UTF_8));
     long originalTimestamp = new Date().getTime() - 10;
     assertThat(sourceFile.setLastModified(originalTimestamp)).isTrue();
+    originalTimestamp = sourceFile.lastModified(); // Update last modified, because different platforms have different precision.
     Path targetFilePath = folder.toPath().resolve("target");
 
     // When


### PR DESCRIPTION
## Description
On my platform (Ubuntu Linux 6.5.0-17-generic on ext4) the last modified timestamps are rounded to the nearest second.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
