### PR TITLE
Do not order all Yaml maps by keys, only the Helm values file

### DIFF
--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/AuthConfigTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/AuthConfigTest.java
@@ -36,7 +36,7 @@ class AuthConfigTest {
     // Since Base64.decodeBase64 handles URL-safe encoding, must explicitly check
     // the correct characters are used
     assertThat(config.toHeaderValue(new KitLogger.SilentLogger()))
-      .isEqualTo("eyJlbWFpbCI6InJvbGFuZEBqb2xva2lhLm9yZyIsInBhc3N3b3JkIjoiIz5zZWNyZXRzPz8iLCJ1c2VybmFtZSI6InJvbGFuZCJ9");
+      .isEqualTo("eyJ1c2VybmFtZSI6InJvbGFuZCIsInBhc3N3b3JkIjoiIz5zZWNyZXRzPz8iLCJlbWFpbCI6InJvbGFuZEBqb2xva2lhLm9yZyJ9");
 
     String header = new String(Base64.getDecoder().decode(config.toHeaderValue(new KitLogger.SilentLogger())));
 

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/RegistryAuthTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/auth/RegistryAuthTest.java
@@ -50,7 +50,7 @@ class RegistryAuthTest {
         // Since Base64.decodeBase64 handles URL-safe encoding, must explicitly check
         // the correct characters are used
         assertThat(config.toHeaderValue())
-            .isEqualTo("eyJlbWFpbCI6InJvbGFuZEBqb2xva2lhLm9yZyIsInBhc3N3b3JkIjoiIz5zZWNyZXRzPz8iLCJ1c2VybmFtZSI6InJvbGFuZCJ9");
+            .isEqualTo("eyJ1c2VybmFtZSI6InJvbGFuZCIsInBhc3N3b3JkIjoiIz5zZWNyZXRzPz8iLCJlbWFpbCI6InJvbGFuZEBqb2xva2lhLm9yZyJ9");
 
         String header = new String(Base64.getDecoder().decode(config.toHeaderValue()));
 

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/Serialization.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/Serialization.java
@@ -42,7 +42,6 @@ public class Serialization {
   static {
     for (ObjectMapper mapper : new ObjectMapper[]{JSON_MAPPER, YAML_MAPPER}) {
       mapper.enable(SerializationFeature.INDENT_OUTPUT)
-        .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
         .disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS)
         .disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
     }


### PR DESCRIPTION
## Description
This pull request keeps the ordering of lines in Yaml fragments as-is. The only exception is the Helm `values.yaml` file, which is still sorted alphabetically.

This change is needed when we eventually want to allow plain Helm directives in Yaml fragments.

This pull request is an exerpt of https://github.com/eclipse/jkube/pull/2689.

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
