### PR TITLE
chore (gradle-plugin): KubernetesRemoteDevTaskTest.setUp removed "throws Exception"

### DIFF
--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesRemoteDevTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesRemoteDevTaskTest.java
@@ -44,7 +44,7 @@ class KubernetesRemoteDevTaskTest {
   private Runnable onStart;
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(new TestKubernetesExtension());
     task = new KubernetesRemoteDevTask(KubernetesExtension.class);
     task.jKubeServiceHub = mock(JKubeServiceHub.class, RETURNS_DEEP_STUBS);


### PR DESCRIPTION
## Description

Removes a redundant 'throws Exception" in a test from the gradle plugin 

Fixes #2716 



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
