### PR TITLE
chore: replace double assertion assertThrows and assertThat with single assertj's assertThatIOException in RegistryServiceTest

### DIFF
--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/RegistryServiceTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/RegistryServiceTest.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,11 +64,10 @@ class RegistryServiceTest {
 
   @Test
   void pullImageWithPolicy_pullPolicyNeverAndNoImage_shouldThrowException() {
-    // When
-    final IOException result = assertThrows(IOException.class, () -> registryService.pullImageWithPolicy("image",
-        ImagePullManager.createImagePullManager("Never", "", new Properties()), null, null));
-    // Then
-    assertThat(result).hasMessageStartingWith("No image 'image' found and pull policy 'Never' is set");
+    assertThatIOException()
+            .isThrownBy(() -> registryService.pullImageWithPolicy("image",
+                    ImagePullManager.createImagePullManager("Never", "", new Properties()), null, null))
+            .withMessageStartingWith("No image 'image' found and pull policy 'Never' is set");
   }
 
   @Test


### PR DESCRIPTION
## Description
- Replace double assertion `assertThrows` + `assertThat` with the single equivalent and more readable assertj `assertThatIOException` in test `RegistryServiceTest.pullImageWithPolicy_pullPolicyNeverAndNoImage_shouldThrowException`
- Replace related import

Fixes #2713

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
