### PR TITLE
issue #2779 : jkube/kubernetes-maven-plugin/plugin/src/main/java/org/…

### DIFF
--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/RemoteDevMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/RemoteDevMojo.java
@@ -34,7 +34,7 @@ public class RemoteDevMojo extends AbstractJKubeMojo {
   protected RemoteDevelopmentConfig remoteDevelopment;
 
   @Override
-  public void executeInternal() throws MojoExecutionException, MojoFailureException {
+  public void executeInternal() {
     final RemoteDevelopmentService remoteDevelopmentService =
       new RemoteDevelopmentService(jkubeServiceHub.getLog(), jkubeServiceHub.getClient(), remoteDevelopment);
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {


### PR DESCRIPTION
…eclipse/jkube/maven/plugin/mojo/develop/RemoteDevMojo.java declared exception is never thrown so, it is removed

## Description
issue : [2779](https://github.com/eclipse/jkube/issues/2779)

the function RemoteDevMojo.executeInternal is throwing exception which is never used.
so, the thrown exception is removed from the function