### PR TITLE
Replaced the creation of the temporary directory using the @TempDir JUnit annotation

### DIFF
--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
@@ -51,6 +51,9 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  */
 class DockerFileUtilTest {
 
+    @TempDir
+    private File tempDir;
+
     @Test
     void simple() throws Exception {
         File toTest = copyToTempDir("Dockerfile_from_simple");
@@ -81,9 +84,8 @@ class DockerFileUtilTest {
     }
 
     private File copyToTempDir(String resource) throws IOException {
-        File dir = Files.createTempDirectory("d-m-p").toFile();
-        File ret = new File(dir, "Dockerfile");
-        try (OutputStream os = new FileOutputStream(ret)) {
+      File ret = new File(tempDir, "Dockerfile");
+        try (OutputStream os = Files.newOutputStream(ret.toPath())) {
             FileUtils.copyFile(new File(getClass().getResource(resource).getPath()), os);
         }
         return ret;

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
@@ -84,7 +84,7 @@ class DockerFileUtilTest {
     }
 
     private File copyToTempDir(String resource) throws IOException {
-      File ret = new File(tempDir, "Dockerfile");
+        File ret = new File(tempDir, "Dockerfile");
         try (OutputStream os = Files.newOutputStream(ret.toPath())) {
             FileUtils.copyFile(new File(getClass().getResource(resource).getPath()), os);
         }

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/helper/DockerFileUtilTest.java
@@ -275,10 +275,11 @@ class DockerFileUtilTest {
     }
 
     @Test
-    void readDockerConfig_fromUserDir(@TempDir Path home) throws IOException {
+    void readDockerConfig_fromUserDir() throws IOException {
         final String original = System.getProperty("user.home");
         try {
             // Given
+            Path home = tempDir.toPath();
             System.setProperty("user.home", home.toFile().getAbsolutePath());
             Files.createDirectories(home.resolve(".docker"));
             Files.write(home.resolve(".docker").resolve("config.json"),
@@ -294,10 +295,11 @@ class DockerFileUtilTest {
     }
 
     @Test
-    void readDockerConfig_fromEnvVariable(@TempDir Path dockerConfig) throws IOException {
+    void readDockerConfig_fromEnvVariable() throws IOException {
         final String original = System.getProperty("user.home");
         try {
             // Given
+            Path dockerConfig = tempDir.toPath();
             final Map<String, String> env = Collections.singletonMap("DOCKER_CONFIG", dockerConfig.toFile().getAbsolutePath());
             EnvUtil.overrideEnvGetter(env::get);
             System.clearProperty("user.home");
@@ -313,11 +315,11 @@ class DockerFileUtilTest {
         }
     }
     @Test
-    void readDockerConfig_fromMissing(@TempDir Path home) {
+    void readDockerConfig_fromMissing() {
         final String original = System.getProperty("user.home");
         try {
             // Given
-            System.setProperty("user.home", home.toFile().getAbsolutePath());
+            System.setProperty("user.home", tempDir.toPath().toFile().getAbsolutePath());
             // When
             final Map<String, Object> config = DockerFileUtil.readDockerConfig();
             // Then


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #2775

Replaced the creation of the temporary directory with the `@TempDir` JUnit annotation

 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] New and existing unit tests pass locally with my changes
 - [x]  Files.createTempDirectory is replaced with @TempDir annotation field
 - [x] Instead of new FileOutputStream(ret) use Files.newOutputStream(ret.toPath())

