### PR TITLE
ContainerHandler : Return empty collection instead of null

### DIFF
--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandler.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandler.java
@@ -42,6 +42,7 @@ import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -181,7 +182,7 @@ public class ContainerHandler {
             }
             return ret;
         } else {
-            return null;
+            return Collections.emptyList();
         }
     }
 

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
@@ -515,14 +515,14 @@ class ContainerHandlerTest {
     }
 
     @Test
-    void getPorts_withEmptyPorts_shouldBeNull() {
+    void getPorts_withEmptyPorts_shouldBeEmptyList() {
         ContainerHandler handler = createContainerHandler(project);
 
         images.add(imageConfiguration);
 
         //Empty Ports
         List<ContainerPort> containerPorts = handler.getContainers(config, images).get(0).getPorts();
-        assertThat(containerPorts).isNull();
+        assertThat(containerPorts).isEmpty();
     }
 
     @Test

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
@@ -526,7 +526,7 @@ class ContainerHandlerTest {
     }
 
     @Test
-    void getPorts_withoutPort_shouldBeNull() {
+    void getPorts_withoutPort_shouldBeEmptyList() {
         ContainerHandler handler = createContainerHandler(project);
 
         //without Ports

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/ContainerHandlerTest.java
@@ -538,7 +538,7 @@ class ContainerHandlerTest {
         images.add(imageConfiguration);
 
         List<ContainerPort> containerPorts = handler.getContainers(config, images).get(0).getPorts();
-        assertThat(containerPorts).isNull();
+        assertThat(containerPorts).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Fixes #2812 

## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

Acceptance Criteria (From Bug description)

 - [x] ContainerHandler.getContainerPorts is updated to return a non null value
 - [x] Project compiles successfully after running mvn clean install