### PR TITLE
Check if the fragment doesnot already have a name

### DIFF
--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NameEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NameEnricher.java
@@ -54,10 +54,12 @@ public class NameEnricher extends BaseEnricher {
     builder.accept(new TypedVisitor<ObjectMetaBuilder>() {
       @Override
       public void visit(ObjectMetaBuilder resource) {
-        if (StringUtils.isNotBlank(configuredName)) {
-          resource.withName(configuredName);
-        } else if (StringUtils.isBlank(resource.getName())) {
-          resource.withName(defaultName);
+        if(StringUtils.isBlank(resource.getName())) {
+          if (StringUtils.isNotBlank(configuredName)) {
+            resource.withName(configuredName);
+          } else {
+            resource.withName(defaultName);
+          }
         }
       }
     });


### PR DESCRIPTION
## Description
In the `NamingEnricher`, instead of overriding all the object names by the `${jkube.enricher.jkube-name.name}`, only overrides name to every object which misses a name.
Fixes #2823 


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
