### PR TITLE
Updated afterEach method signature

### DIFF
--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ITGradleRunnerExtension.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ITGradleRunnerExtension.java
@@ -38,7 +38,7 @@ public class ITGradleRunnerExtension implements BeforeEachCallback, AfterEachCal
   }
 
   @Override
-  public void afterEach(ExtensionContext context) throws Exception {
+  public void afterEach(ExtensionContext context) {
     gradleRunner = null;
   }
 


### PR DESCRIPTION
This PR addresses a minor code cleanliness issue in the ITGradleRunnerExtension.afterEach method within the JKube Gradle Plugin Integration Tests. Previously, the method signature unnecessarily declared throwing an Exception, despite no such exceptions being thrown within the method body or by its operations. This change simplifies the method signature by removing the throws Exception declaration, aligning it with best practices and enhancing code readability.

Fixes #2630

Type of Change
Bug fix (non-breaking change which fixes an issue)

Checklist
I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
My code follows the style guidelines of this project
I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
I have performed a self-review of my code
New and existing unit tests pass locally with my changes