### PR TITLE
Draft: fix/3726

### DIFF
--- a/jkube-kit/build/service/jib/src/main/java/org/eclipse/jkube/kit/service/jib/JibService.java
+++ b/jkube-kit/build/service/jib/src/main/java/org/eclipse/jkube/kit/service/jib/JibService.java
@@ -39,10 +39,13 @@ import org.eclipse.jkube.kit.config.image.ImageName;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -161,7 +164,11 @@ public class JibService implements AutoCloseable {
     if (imageConfiguration.getBuildConfiguration().getTags() != null) {
       imageConfiguration.getBuildConfiguration().getTags().forEach(to::withAdditionalTag);
     }
-    from.setCreationTime(Instant.now());
+    Instant creationTime = Optional.ofNullable(configuration.getProject().getBuildDate())
+            .orElse(LocalDate.now())
+            .atStartOfDay(ZoneId.of("UTC"))
+            .toInstant();
+    from.setCreationTime(creationTime);
     try {
       from.containerize(to);
       jibLogger.updateFinished();

--- a/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceTest.java
+++ b/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceTest.java
@@ -44,6 +44,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -77,6 +78,7 @@ class JibServiceTest {
         .build())
       .project(JavaProject.builder()
         .baseDirectory(tempDir.toFile())
+        .buildDate(LocalDate.now())
         .build())
       .build();
     imageConfiguration = ImageConfiguration.builder()


### PR DESCRIPTION
Use build date for container creation time attribute.

## Description
<!--
Thank you for your pull request (PR)!



-->


Fixes #3726

JIB builder uses a random new Date() for configuration, I'd rather use the build's timestamp instead (if present)

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
