### PR TITLE
fix(openshift): use local file loading for BuildConfig resource fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.19-SNAPSHOT
+* Fix #3833: BuildConfig resource fragment loading should use local file instead of fetching from server
 * Fix #3591: Fix windows line endings for yaml literal blocks, json serialization config updated
 * Fix #3781: Native Generator does not work in Windows system, always finds multiple native executable
 * Fix #2286: Remove Guava dependency where ever possible

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
@@ -271,7 +271,7 @@ public class OpenshiftBuildService extends AbstractImageBuildService {
         // Check for BuildConfig resource fragment
         File buildConfigResourceFragment = KubernetesHelper.getResourceFragmentFromSource(buildServiceConfig.getResourceDir(), buildServiceConfig.getResourceConfig() != null ? buildServiceConfig.getResourceConfig().getRemotes() : null, "buildconfig.yml", log);
         if (buildConfigResourceFragment != null) {
-            BuildConfig buildConfigFragment = client.buildConfigs().load(buildConfigResourceFragment).get();
+            BuildConfig buildConfigFragment = client.buildConfigs().load(buildConfigResourceFragment).item();
             specBuilder = new BuildConfigSpecBuilder(buildConfigFragment.getSpec());
         } else {
             specBuilder = new BuildConfigSpecBuilder();


### PR DESCRIPTION
## Description

The BuildConfig resource fragment loading was using `.get()` after `.load()` which caused the Kubernetes client to make an unnecessary server fetch. This would fail if the fragment didn't exist on the server, even though it was only meant to be a local file template.

Changed to use `.item()` instead of `.get()` to load the fragment content locally without a server round-trip.

Also adds integration test for BuildConfig fragment merging that verifies triggers and runPolicy from fragments are properly merged into the generated BuildConfig.



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] My code follows the style guidelines of this project
 - [ ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [ ] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
