### PR TITLE
chore(deps): bump helm-java to 0.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.19-SNAPSHOT
+* Fix #3840: Bump helm-java to 0.0.19
 * Fix #3833: BuildConfig resource fragment loading should use local file instead of fetching from server
 * Fix #3820: Skip flag does not work for helm tasks
 * Fix #3823: Update native binary S2I base image from UBI 8 to UBI 9

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <version.gradle>7.6.4</version.gradle>
     <version.gradle-api-maven-plugin>0.0.7</version.gradle-api-maven-plugin>
     <version.groovy>3.0.23</version.groovy>
-    <version.helm-java>0.0.16</version.helm-java>
+    <version.helm-java>0.0.19</version.helm-java>
     <version.guava>33.4.0-jre</version.guava>
     <version.error_prone_annotations>2.36.0</version.error_prone_annotations>
     <version.jackson>2.20.1</version.jackson>


### PR DESCRIPTION
## Summary
- Bump helm-java from 0.0.16 to 0.0.19

