### PR TITLE
chore(deps): Bump plexus-utils from 3.5.0 to 3.6.0

### DIFF
--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -56,7 +56,7 @@
     <version.openshift-client>${version.kubernetes-client}</version.openshift-client>
     <version.plexus-classworlds>2.9.0</version.plexus-classworlds>
     <version.plexus-build-api>0.0.7</version.plexus-build-api>
-    <version.plexus-utils>3.5.0</version.plexus-utils>
+    <version.plexus-utils>3.6.0</version.plexus-utils>
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.validation-api>2.0.1.Final</version.validation-api>
     <version.ow2.asm>9.8</version.ow2.asm>


### PR DESCRIPTION
Bump `org.codehaus.plexus:plexus-utils` from 3.5.0 to 3.6.0.

Bumping to 4.x is not feasible since XML classes (`Xpp3Dom`, `Xpp3DomBuilder`)
were extracted to a separate `plexus-xml` artifact and the project uses them
in `common-maven`. Supersedes #3852.