### PR TITLE
chore(deps): Bump plexus-utils from 3.6.0 to 4.0.3

### DIFF
--- a/jkube-kit/common-maven/pom.xml
+++ b/jkube-kit/common-maven/pom.xml
@@ -65,6 +65,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-build-api</artifactId>
     </dependency>

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -56,7 +56,8 @@
     <version.openshift-client>${version.kubernetes-client}</version.openshift-client>
     <version.plexus-classworlds>2.9.0</version.plexus-classworlds>
     <version.plexus-build-api>0.0.7</version.plexus-build-api>
-    <version.plexus-utils>3.6.0</version.plexus-utils>
+    <version.plexus-utils>4.0.3</version.plexus-utils>
+    <version.plexus-xml>3.0.2</version.plexus-xml>
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.validation-api>2.0.1.Final</version.validation-api>
     <version.ow2.asm>9.8</version.ow2.asm>
@@ -701,6 +702,12 @@
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
         <version>${version.plexus-utils}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-xml</artifactId>
+        <version>${version.plexus-xml}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Bump `org.codehaus.plexus:plexus-utils` from 3.6.0 to 4.0.3.

In plexus-utils 4.x, XML classes (`Xpp3Dom`, `Xpp3DomBuilder`, `XmlPullParserException`)
were extracted to a separate `plexus-xml` artifact. This PR adds `plexus-xml:3.0.2` as a
dependency in `common-maven` to provide those classes.

Supersedes Closes #3852