### PR TITLE
Fix #3859: SecDispatcher compatibility with Maven 3.9.13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.20-SNAPSHOT
+* Fix #3859: kubernetes-maven-plugin compatibility with Maven 3.9.13+ SecDispatcher changes
 * Fix #3834: Improve docs for jkube-volume-permission enricher
 * Fix #3848: fix kube-api-test binary download failures due to deprecated kubebuilder-tools storage
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojo.java
@@ -15,7 +15,6 @@ package org.eclipse.jkube.maven.plugin.mojo.build;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -66,15 +65,10 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.shared.utils.logging.MessageUtils;
-import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.codehaus.plexus.context.Context;
-import org.codehaus.plexus.context.ContextException;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import org.eclipse.jkube.maven.plugin.mojo.KitLoggerProvider;
 import org.fusesource.jansi.Ansi;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 
 import static org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory.DockerAccessContext.DEFAULT_MAX_CONNECTIONS;
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestamp;
@@ -83,7 +77,7 @@ import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUt
 import static org.eclipse.jkube.maven.plugin.mojo.build.AbstractJKubeMojo.DEFAULT_LOG_PREFIX;
 
 public abstract class AbstractDockerMojo extends AbstractMojo
-    implements Contextualizable, KitLoggerProvider {
+    implements KitLoggerProvider {
 
     public static final String CONTEXT_KEY_LOG_DISPATCHER = "CONTEXT_KEY_DOCKER_LOG_DISPATCHER";
 
@@ -319,7 +313,8 @@ public abstract class AbstractDockerMojo extends AbstractMojo
     // Mode which is resolved, also when 'auto' is set
     protected RuntimeMode runtimeMode;
 
-    protected PlexusContainer plexusContainer;
+    @Component(role = org.sonatype.plexus.components.sec.dispatcher.SecDispatcher.class, hint = "default")
+    protected SecDispatcher securityDispatcher;
 
     /**
      * Watching mode for rebuilding images
@@ -346,11 +341,6 @@ public abstract class AbstractDockerMojo extends AbstractMojo
     protected boolean offline;
 
     protected JavaProject javaProject;
-
-    @Override
-    public void contextualize(Context context) throws ContextException {
-        plexusContainer = ((PlexusContainer) context.get(PlexusConstants.PLEXUS_KEY));
-    }
 
     @Override
     public KitLogger getKitLogger() {
@@ -443,22 +433,17 @@ public abstract class AbstractDockerMojo extends AbstractMojo
                 .authConfig(authConfig != null ? authConfig.toMap() : null)
                 .skipExtendedAuth(skipExtendedAuth)
                 .registry(specificRegistry != null ? specificRegistry : registry)
-                .passwordDecryptionMethod(password -> {
-                    try {
-                        // Done by reflection since I have classloader issues otherwise
-                        if (plexusContainer != null) {
-                            Object secDispatcher = plexusContainer.lookup(SecDispatcher.ROLE, "maven");
-                            Method method = secDispatcher.getClass().getMethod("decrypt", String.class);
-                            return (String) method.invoke(secDispatcher, password);
-                        } else {
-                            return password;
-                        }
-                    } catch (ComponentLookupException e) {
-                        throw new RuntimeException("Error looking security dispatcher",e);
-                    } catch (ReflectiveOperationException e) {
-                        throw new RuntimeException("Cannot decrypt password: " + e.getCause(),e);
-                    }
-                }).build();
+                .passwordDecryptionMethod(this::decrypt)
+                .build();
+    }
+
+    String decrypt(String password) {
+        try {
+            return securityDispatcher.decrypt(password);
+        } catch (SecDispatcherException e) {
+            getKitLogger().error("Failure in decrypting password");
+        }
+        return password;
     }
 
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/BuildMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/BuildMojo.java
@@ -17,16 +17,13 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
-
-
 /**
  * Builds the docker images configured for this project via a Docker or S2I binary build.
  *
  * @author roland
  */
 @Mojo(name = "build", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.COMPILE)
-public class BuildMojo extends AbstractDockerMojo implements Contextualizable {
+public class BuildMojo extends AbstractDockerMojo {
 
     @Override
     protected boolean shouldSkip() {

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/AbstractDockerMojoTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.maven.plugin.mojo.build;
+
+import java.io.IOException;
+
+import org.apache.maven.settings.Settings;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.RegistryConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+class AbstractDockerMojoTest {
+
+  private TestMojo mojo;
+  private SecDispatcher secDispatcher;
+
+  @BeforeEach
+  void setUp() {
+    secDispatcher = mock(SecDispatcher.class);
+    mojo = new TestMojo();
+    mojo.settings = new Settings();
+    mojo.securityDispatcher = secDispatcher;
+    mojo.log = spy(new KitLogger.SilentLogger());
+  }
+
+  @Test
+  void getRegistryConfig_shouldDecryptPasswordUsingSecDispatcher() throws SecDispatcherException {
+    // Given
+    when(secDispatcher.decrypt("encrypted")).thenReturn("decrypted");
+    // When
+    RegistryConfig config = mojo.getRegistryConfig(null);
+    // Then
+    assertThat(config.getPasswordDecryptionMethod().apply("encrypted")).isEqualTo("decrypted");
+  }
+
+  @Test
+  void getRegistryConfig_whenDecryptionFails_shouldReturnOriginalPassword() throws SecDispatcherException {
+    // Given
+    when(secDispatcher.decrypt("encrypted")).thenThrow(new SecDispatcherException("test"));
+    // When
+    RegistryConfig config = mojo.getRegistryConfig(null);
+    // Then
+    assertThat(config.getPasswordDecryptionMethod().apply("encrypted")).isEqualTo("encrypted");
+  }
+
+  @Test
+  void getRegistryConfig_withSpecificRegistry_shouldSetRegistry() {
+    // When
+    RegistryConfig config = mojo.getRegistryConfig("my-registry.io");
+    // Then
+    assertThat(config.getRegistry()).isEqualTo("my-registry.io");
+  }
+
+  private static class TestMojo extends AbstractDockerMojo {
+    @Override
+    protected void executeInternal() throws IOException {
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes: #3859 

- Replace runtime `plexusContainer.lookup(SecDispatcher.ROLE, "maven")` with `@Component(role = SecDispatcher.class, hint = "default")` field injection in `AbstractDockerMojo`
- Remove `Contextualizable` interface from `AbstractDockerMojo` and `BuildMojo` since `PlexusContainer` is no longer needed
- Add `AbstractDockerMojoTest` with tests for password decryption via `SecDispatcher`

## Description

Maven 3.9.13+ ([apache/maven#11711](https://github.com/apache/maven/pull/11711)) removed the `SecDispatcher` Plexus XML component descriptor with roleHint `"maven"`. This causes `AbstractDockerMojo.getRegistryConfig()` to throw `NoSuchElementException` when it attempts `plexusContainer.lookup(SecDispatcher.ROLE, "maven")` at runtime, breaking `k8s:build`, `k8s:push`, and `k8s:watch` goals whenever registry authentication is needed (i.e., the base image is not cached locally).

The fix follows the same pattern already used in `AbstractJKubeMojo` — replacing the runtime Plexus container lookup with Maven's `@Component` annotation for field injection. This also simplifies `getRegistryConfig()` by replacing the 15-line reflection-based lambda with a simple method reference (`this::decrypt`).

### How to reproduce

With Maven 3.9.13+ and a base image not cached locally:

```bash
mvn -Djkube.docker.username=testuser -Djkube.docker.password=testpass \
    clean package org.eclipse.jkube:kubernetes-maven-plugin:1.19.0:build
```

Fails with:
```
Caused by: java.util.NoSuchElementException
    at org.codehaus.plexus.DefaultPlexusContainer.lookup
```

## Test plan

- [x] New `AbstractDockerMojoTest` — verifies decrypt delegates to `SecDispatcher` and gracefully falls back on failure
- [x] All 98 existing tests in `kubernetes-maven-plugin/plugin` pass (0 failures)
- [ ] Manual verification with Maven 3.9.15 against reproducer project

🤖 Generated with [Claude Code](https://claude.com/claude-code)