### PR TITLE
doc: clarify imagePullPolicy behavior across build strategies

### DIFF
--- a/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/_groovy-configuration.adoc
@@ -336,6 +336,8 @@ when watchMode is copy. Note that this container must be running.
 | `jkube.workDir`
 |====
 
+include::{kitdoc-path}/inc/build/_image_pull_policy_compatibility.adoc[]
+
 include::{kitdoc-path}/inc/apply/_cluster_access_configuration.adoc[]
 
 == Image Configuration

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
@@ -58,6 +58,7 @@ ifeval::["{task-prefix}" == "oc"]
 ! `s2i` ! N/A ! Use `forcePull` instead ! OpenShift-specific build strategy
 endif::[]
 !===
+
 | `jkube.docker.imagePullPolicy`
 
 | *certPath*

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
@@ -48,33 +48,14 @@ NOTE: Not all build strategies honor this property. The per-image `imagePullPoli
 [cols="1,1,1,2"]
 !===
 ! Strategy ! Global `imagePullPolicy` ! Per-image `imagePullPolicy` ! Notes
-
-! `docker`
-! Honored
-! Honored (overrides global)
-! Default build strategy
-
-! `jib`
-! Not honored
-! Not honored
-! JIB manages base image pulls through its own internal mechanisms
-
-! `buildpacks`
-! Not honored
-! Honored
-!
-
+! `docker` ! Honored ! Honored (overrides global) ! Default build strategy
+! `jib` ! Not honored ! Not honored ! JIB manages base image pulls through its own internal mechanisms
+! `buildpacks` ! Honored ! Honored (overrides global) !{nbsp}
 ifeval::["{goal-prefix}" == "oc"]
-! `s2i`
-! N/A
-! Use `forcePull` instead
-! OpenShift-specific build strategy
+! `s2i` ! N/A ! Use `forcePull` instead ! OpenShift-specific build strategy
 endif::[]
 ifeval::["{task-prefix}" == "oc"]
-! `s2i`
-! N/A
-! Use `forcePull` instead
-! OpenShift-specific build strategy
+! `s2i` ! N/A ! Use `forcePull` instead ! OpenShift-specific build strategy
 endif::[]
 !===
 | `jkube.docker.imagePullPolicy`

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
@@ -20,7 +20,7 @@ This option is only relevant for the `{task-prefix}Build` task.
 <<authentication, Authentication>> for how to do security.
 |
 
-| *autoPull*
+| *autoPull* (_deprecated_)
 a| Decide how to pull missing base images or images to start:
 
 * `on` : Automatic download any missing images (default)
@@ -28,6 +28,7 @@ a| Decide how to pull missing base images or images to start:
 * `always` : Pull images always even when they already exist locally
 * `once` : For multi-module builds images are only checked once and pulled for the whole build.
 
+Use <<image-pull-policy, imagePullPolicy>> instead.
 | `jkube.docker.autoPull`
 
 
@@ -40,6 +41,42 @@ This property can take the following values (case insensitive):
 * `Always` : Pull images always even when they already exist locally.
 
 By default, a progress meter is printed out on the console, which is omitted when using {plugin-type} in batch mode (option `-B`). A very simplified progress meter is provided when using no color output (i.e. with `-Djkube.useColor=false`).
+
+NOTE: Not all build strategies honor this property. The per-image `imagePullPolicy` (see <<config-image-build, Build configuration>>) can override this global setting for strategies that support it.
+
+.Build strategy compatibility
+[cols="1,1,1,2"]
+!===
+! Strategy ! Global `imagePullPolicy` ! Per-image `imagePullPolicy` ! Notes
+
+! `docker`
+! Honored
+! Honored (overrides global)
+! Default build strategy
+
+! `jib`
+! Not honored
+! Not honored
+! JIB manages base image pulls through its own internal mechanisms
+
+! `buildpacks`
+! Not honored
+! Honored
+!
+
+ifeval::["{goal-prefix}" == "oc"]
+! `s2i`
+! N/A
+! Use `forcePull` instead
+! OpenShift-specific build strategy
+endif::[]
+ifeval::["{task-prefix}" == "oc"]
+! `s2i`
+! N/A
+! Use `forcePull` instead
+! OpenShift-specific build strategy
+endif::[]
+!===
 | `jkube.docker.imagePullPolicy`
 
 | *certPath*

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
@@ -42,17 +42,7 @@ This property can take the following values (case insensitive):
 
 By default, a progress meter is printed out on the console, which is omitted when using {plugin-type} in batch mode (option `-B`). A very simplified progress meter is provided when using no color output (i.e. with `-Djkube.useColor=false`).
 
-NOTE: Not all build strategies honor this property. The per-image `imagePullPolicy` (see <<config-image-build, Build configuration>>) can override this global setting for strategies that support it. Build strategy compatibility:
-
-* `docker` — global and per-image honored (per-image overrides global). Default build strategy.
-* `jib` — not honored. JIB manages base image pulls through its own internal mechanisms.
-* `buildpacks` — global and per-image honored (per-image overrides global).
-ifeval::["{goal-prefix}" == "oc"]
-* `s2i` — not applicable. Use `forcePull` instead (OpenShift-specific).
-endif::[]
-ifeval::["{task-prefix}" == "oc"]
-* `s2i` — not applicable. Use `forcePull` instead (OpenShift-specific).
-endif::[]
+NOTE: Not all build strategies honor this property. See <<image-pull-policy-compatibility>> for details. The per-image `imagePullPolicy` (see <<config-image-build, Build configuration>>) can override this global setting for strategies that support it.
 
 | `jkube.docker.imagePullPolicy`
 

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
@@ -42,22 +42,17 @@ This property can take the following values (case insensitive):
 
 By default, a progress meter is printed out on the console, which is omitted when using {plugin-type} in batch mode (option `-B`). A very simplified progress meter is provided when using no color output (i.e. with `-Djkube.useColor=false`).
 
-NOTE: Not all build strategies honor this property. The per-image `imagePullPolicy` (see <<config-image-build, Build configuration>>) can override this global setting for strategies that support it.
+NOTE: Not all build strategies honor this property. The per-image `imagePullPolicy` (see <<config-image-build, Build configuration>>) can override this global setting for strategies that support it. Build strategy compatibility:
 
-.Build strategy compatibility
-[cols="1,1,1,2"]
-!===
-! Strategy ! Global `imagePullPolicy` ! Per-image `imagePullPolicy` ! Notes
-! `docker` ! Honored ! Honored (overrides global) ! Default build strategy
-! `jib` ! Not honored ! Not honored ! JIB manages base image pulls through its own internal mechanisms
-! `buildpacks` ! Honored ! Honored (overrides global) !{nbsp}
+* `docker` — global and per-image honored (per-image overrides global). Default build strategy.
+* `jib` — not honored. JIB manages base image pulls through its own internal mechanisms.
+* `buildpacks` — global and per-image honored (per-image overrides global).
 ifeval::["{goal-prefix}" == "oc"]
-! `s2i` ! N/A ! Use `forcePull` instead ! OpenShift-specific build strategy
+* `s2i` — not applicable. Use `forcePull` instead (OpenShift-specific).
 endif::[]
 ifeval::["{task-prefix}" == "oc"]
-! `s2i` ! N/A ! Use `forcePull` instead ! OpenShift-specific build strategy
+* `s2i` — not applicable. Use `forcePull` instead (OpenShift-specific).
 endif::[]
-!===
 
 | `jkube.docker.imagePullPolicy`
 

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
@@ -20,7 +20,7 @@ This option is only relevant for the `{task-prefix}Build` task.
 <<authentication, Authentication>> for how to do security.
 |
 
-| *autoPull* (_deprecated_)
+| *autoPull*
 a| Decide how to pull missing base images or images to start:
 
 * `on` : Automatic download any missing images (default)
@@ -28,7 +28,7 @@ a| Decide how to pull missing base images or images to start:
 * `always` : Pull images always even when they already exist locally
 * `once` : For multi-module builds images are only checked once and pulled for the whole build.
 
-Use <<image-pull-policy, imagePullPolicy>> instead.
+If <<image-pull-policy, imagePullPolicy>> is also set, it takes precedence over `autoPull`.
 | `jkube.docker.autoPull`
 
 

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_options.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_options.adoc
@@ -23,37 +23,4 @@ include::_build_configuration_option_entries.adoc[]
 
 |===
 
-[[image-pull-policy-compatibility]]
-.imagePullPolicy build strategy compatibility
-[cols="1,1,1,2"]
-|===
-| Strategy | Global `imagePullPolicy` | Per-image `imagePullPolicy` | Notes
-
-| `docker`
-| Honored
-| Honored (overrides global)
-| Default build strategy
-
-| `jib`
-| Not honored
-| Not honored
-| JIB manages base image pulls through its own internal mechanisms
-
-| `buildpacks`
-| Honored
-| Honored (overrides global)
-|
-
-ifeval::["{goal-prefix}" == "oc"]
-| `s2i`
-| N/A
-| Use `forcePull` instead
-| OpenShift-specific build strategy
-endif::[]
-ifeval::["{task-prefix}" == "oc"]
-| `s2i`
-| N/A
-| Use `forcePull` instead
-| OpenShift-specific build strategy
-endif::[]
-|===
+include::_image_pull_policy_compatibility.adoc[]

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_options.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_options.adoc
@@ -22,3 +22,38 @@ Global configuration parameters specify overall behavior common for all images t
 include::_build_configuration_option_entries.adoc[]
 
 |===
+
+[[image-pull-policy-compatibility]]
+.imagePullPolicy build strategy compatibility
+[cols="1,1,1,2"]
+|===
+| Strategy | Global `imagePullPolicy` | Per-image `imagePullPolicy` | Notes
+
+| `docker`
+| Honored
+| Honored (overrides global)
+| Default build strategy
+
+| `jib`
+| Not honored
+| Not honored
+| JIB manages base image pulls through its own internal mechanisms
+
+| `buildpacks`
+| Honored
+| Honored (overrides global)
+|
+
+ifeval::["{goal-prefix}" == "oc"]
+| `s2i`
+| N/A
+| Use `forcePull` instead
+| OpenShift-specific build strategy
+endif::[]
+ifeval::["{task-prefix}" == "oc"]
+| `s2i`
+| N/A
+| Use `forcePull` instead
+| OpenShift-specific build strategy
+endif::[]
+|===

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_image_pull_policy_compatibility.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_image_pull_policy_compatibility.adoc
@@ -1,0 +1,34 @@
+[[image-pull-policy-compatibility]]
+.imagePullPolicy build strategy compatibility
+[cols="1,1,1,2"]
+|===
+| Strategy | Global `imagePullPolicy` | Per-image `imagePullPolicy` | Notes
+
+| `docker`
+| Honored
+| Honored (overrides global)
+| Default build strategy
+
+| `jib`
+| Not honored
+| Not honored
+| JIB manages base image pulls through its own internal mechanisms
+
+| `buildpacks`
+| Honored
+| Honored (overrides global)
+|
+
+ifeval::["{goal-prefix}" == "oc"]
+| `s2i`
+| N/A
+| Use `forcePull` instead
+| OpenShift-specific build strategy
+endif::[]
+ifeval::["{task-prefix}" == "oc"]
+| `s2i`
+| N/A
+| Use `forcePull` instead
+| OpenShift-specific build strategy
+endif::[]
+|===


### PR DESCRIPTION
## Summary
- Add a "Build strategy compatibility" table to the global `imagePullPolicy` documentation showing which strategies honor global vs per-image settings
- Add a precedence cross-reference from `autoPull` to `imagePullPolicy`
- Extract the compatibility table into a shared include file so it renders in both Maven and Gradle docs
- s2i row conditionally rendered only in OpenShift plugin docs

Fixes #3898

## Test plan
- [x] `./mvnw compile -pl jkube-kit/doc -am -DskipTests` passes
- [x] `./mvnw package -pl kubernetes-maven-plugin/doc -am -DskipTests` generates HTML with the table
- [x] `./mvnw package -pl gradle-plugin/doc -am -DskipTests` generates HTML with no dangling `image-pull-policy-compatibility` reference
- [x] Verify rendered HTML shows the compatibility table under `imagePullPolicy`
- [x] Verify OpenShift docs include the s2i row

🤖 Generated with [Claude Code](https://claude.com/claude-code)