### PR TITLE
chore(deps): Bump jib-core from 0.27.3 to 0.28.1 (3904)

### DIFF
--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -130,7 +130,7 @@
     <image.wildfly.upstream.s2i>quay.io/wildfly/wildfly-centos7:${version.image.wildfly.upstream.s2i}</image.wildfly.upstream.s2i>
     <image.wildfly.upstream.istag>wildfly:${version.image.wildfly.upstream.s2i}</image.wildfly.upstream.istag>
 
-    <jib-core.version>0.27.3</jib-core.version>
+    <jib-core.version>0.28.1</jib-core.version>
 
     <pack.version>0.34.2</pack.version>
     <pack.windows.binary-extension>exe</pack.windows.binary-extension>


### PR DESCRIPTION
## Summary
- Bumps `jib-core` from `0.27.3` to `0.28.1` in `jkube-kit/parent/pom.xml`
- Adds Java 25 support (default base image, ASM 9.9, main method support)

Fixes #3904

## Test plan
- [ ] JIB build tests pass (`JibServiceTest`, `JibServiceUtilTest`)
- [ ] Full CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)