### PR TITLE
fix(build): bump pack CLI to 0.40.7 and update default builder image (3902)

### DIFF
--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/BuildPackBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/BuildPackBuildService.java
@@ -41,7 +41,7 @@ import static org.eclipse.jkube.kit.common.util.EnvUtil.getUserHome;
 import static org.eclipse.jkube.kit.common.util.PropertiesUtil.readProperties;
 
 public class BuildPackBuildService extends AbstractImageBuildService {
-  private static final String DEFAULT_BUILDER_IMAGE = "paketobuildpacks/builder:base";
+  private static final String DEFAULT_BUILDER_IMAGE = "paketobuildpacks/builder-jammy-base";
   private static final String PACK_CONFIG_DIR = ".pack";
   private static final String PACK_CONFIG_FILE = "config.toml";
 

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/BuildPackBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/BuildPackBuildServiceTest.java
@@ -190,7 +190,7 @@ class BuildPackBuildServiceTest {
         buildPackBuildService.buildSingleImage(imageConfiguration);
 
         // Then
-        verify(kitLogger).info("[[s]]%s","build foo/bar:latest --builder paketobuildpacks/builder:base --creation-time now --path " + temporaryFolder.getAbsolutePath());
+        verify(kitLogger).info("[[s]]%s","build foo/bar:latest --builder paketobuildpacks/builder-jammy-base --creation-time now --path " + temporaryFolder.getAbsolutePath());
       }
     }
 
@@ -204,7 +204,7 @@ class BuildPackBuildServiceTest {
         buildPackBuildService.buildSingleImage(imageConfiguration);
 
         // Then
-        verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder paketobuildpacks/builder:base --creation-time now --path " + temporaryFolder.getAbsolutePath());
+        verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder paketobuildpacks/builder-jammy-base --creation-time now --path " + temporaryFolder.getAbsolutePath());
       }
 
       @Test
@@ -256,7 +256,7 @@ class BuildPackBuildServiceTest {
 
         // Then
         String expectedPullPolicyFragment = expectedPackPullPolicy != null ? " --pull-policy " + expectedPackPullPolicy : "";
-        verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder paketobuildpacks/builder:base --creation-time now" + expectedPullPolicyFragment + " --path " + temporaryFolder.getAbsolutePath());
+        verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder paketobuildpacks/builder-jammy-base --creation-time now" + expectedPullPolicyFragment + " --path " + temporaryFolder.getAbsolutePath());
       }
 
       @Test
@@ -280,7 +280,7 @@ class BuildPackBuildServiceTest {
         buildPackBuildService.buildSingleImage(imageConfiguration);
 
         // Then
-        verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder paketobuildpacks/builder:base --creation-time now --pull-policy never --path " + temporaryFolder.getAbsolutePath());
+        verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder paketobuildpacks/builder-jammy-base --creation-time now --pull-policy never --path " + temporaryFolder.getAbsolutePath());
       }
 
       @Test
@@ -292,7 +292,7 @@ class BuildPackBuildServiceTest {
         buildPackBuildService.buildSingleImage(imageConfiguration);
 
         // Then
-        verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder paketobuildpacks/builder:base --creation-time now --path " + temporaryFolder.getAbsolutePath());
+        verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder paketobuildpacks/builder-jammy-base --creation-time now --path " + temporaryFolder.getAbsolutePath());
       }
     }
   }

--- a/jkube-kit/doc/src/main/asciidoc/inc/_integrations.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/_integrations.adoc
@@ -89,7 +89,7 @@ endif::[]
 `pack build` process. If the download for the https://buildpacks.io/docs/tools/pack/[Pack CLI] binary fails, {plugin} looks for any locally installed https://buildpacks.io/docs/tools/pack/[Pack CLI] version.
 
 === Buildpack Builder Image
-- If no builder image is configured, then {plugin} uses `paketobuildpacks/builder:base` as the default builder image.
+- If no builder image is configured, then {plugin} uses `paketobuildpacks/builder-jammy-base` as the default builder image.
 - If builder image is provided in local https://buildpacks.io/docs/tools/pack/cli/pack_config/[Pack Config], {plugin} uses the https://buildpacks.io/docs/concepts/components/builder/[builder image] specified in the file.
   For example,if the user has this image set in the `$HOME/.pack/config.toml` file, {plugin} will use `testuser/buildpacks-quarkus-builder:latest` as Buildpacks builder image.:
 [source,toml,indent=2,subs="verbatim,quotes,attributes"]

--- a/jkube-kit/doc/src/main/asciidoc/inc/generator/_options_common.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/generator/_options_common.adoc
@@ -56,7 +56,7 @@ or already added by a generator which has been run previously.
 
 | *buildpacksBuilderImage*
 |  Configure https://buildpacks.io/docs/for-platform-operators/concepts/builder/[BuildPack builder] OCI image for BuildPack Build. This field is applicable only in `buildpacks` build strategy.
-Defaults to `paketobuildpacks/builder:base`
+Defaults to `paketobuildpacks/builder-jammy-base`
 | `jkube.generator.buildpacksBuilderImage`
 |===
 

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -132,7 +132,7 @@
 
     <jib-core.version>0.27.3</jib-core.version>
 
-    <pack.version>0.34.2</pack.version>
+    <pack.version>0.40.7</pack.version>
     <pack.windows.binary-extension>exe</pack.windows.binary-extension>
     <pack.linux.artifact>https://github.com/buildpacks/pack/releases/download/v${pack.version}/pack-v${pack.version}-linux.tgz</pack.linux.artifact>
     <pack.linux-arm64.artifact>https://github.com/buildpacks/pack/releases/download/v${pack.version}/pack-v${pack.version}-linux-arm64.tgz</pack.linux-arm64.artifact>


### PR DESCRIPTION
## Summary

- Bump pack CLI from `0.34.2` to `0.40.7` (12 minor versions, 2+ years of fixes)
- Change default BuildPack builder image from deprecated `paketobuildpacks/builder:base` (amd64-only, Ubuntu 18.04 Bionic) to `paketobuildpacks/builder-jammy-base` (multi-arch, Ubuntu 22.04 Jammy)
- Update documentation to reflect the new default builder image

The old builder's lifecycle binaries (compiled with `go/1.19.11/x64`) crash with a Go runtime panic (`lfstack.push`) on ARM64 hosts (Apple Silicon) under Rosetta/QEMU emulation. Both the pack CLI bump **and** the builder image change are required — the crash originates in the builder image's lifecycle, not the pack CLI itself.

Fixes #3902

## Changes

| # | File | Change |
|---|------|--------|
| 1 | `jkube-kit/parent/pom.xml` | `pack.version` 0.34.2 → 0.40.7 |
| 2 | `BuildPackBuildService.java` | `DEFAULT_BUILDER_IMAGE` → `paketobuildpacks/builder-jammy-base` |
| 3 | `BuildPackBuildServiceTest.java` | Two test expectations updated |
| 4 | `_integrations.adoc` | Doc default updated |
| 5 | `_options_common.adoc` | Doc default updated |

## Test plan

- [x] `BuildPackBuildServiceTest` — all 10 tests pass
- [x] Buildpacks module — all 71 tests pass (3 skipped: other-platform)
- [x] E2E: `mvn package k8s:build` with buildpacks strategy completes successfully on ARM64 Apple Silicon (all phases: ANALYZING → DETECTING → RESTORING → BUILDING → EXPORTING)
- [x] Pack CLI `0.40.7` downloads correctly and reports correct version
- [x] No remaining references to `paketobuildpacks/builder:base` in source
- [x] Download URLs verified for all 5 platforms (linux, linux-arm64, macos, macos-arm64, windows)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)