### PR TITLE
fix(generator): update default Jetty image to jkube-jetty12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.20-SNAPSHOT
+* Fix #3873: Update JettyAppSeverHandler to select `jkube-jetty12` as the default Jetty image and add `jetty9` opt-in for legacy projects
 * Fix #3902: Bump pack CLI from 0.34.2 to 0.40.7 and update default builder image to `paketobuildpacks/builder-jammy-base`
 * Fix #3904: Bump jib-core from 0.27.3 to 0.28.1
 * Fix #3900: BuildPackBuildService honors global `imagePullPolicy` when no per-image policy is set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Usage:
 ```
 
 ### 1.20-SNAPSHOT
-* Fix #3873: Update JettyAppSeverHandler to select `jkube-jetty12` as the default Jetty image and add `jetty9` opt-in for legacy projects
+* Fix #3873: Update JettyAppSeverHandler to select `jkube-jetty12` as the default Jetty image and add `jetty9` opt-in for legacy projects (potentially breaking for legacy JavaEE webapps using `javax.*`; set `jkube.generator.webapp.server=jetty9` to keep Jetty 9)
 * Fix #3918: Update documentation for jkube-images 0.0.28 changes
 * Fix #3902: Bump pack CLI from 0.34.2 to 0.40.7 and update default builder image to `paketobuildpacks/builder-jammy-base`
 * Fix #3904: Bump jib-core from 0.27.3 to 0.28.1

--- a/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
@@ -106,3 +106,8 @@ ifdef::doc-openshift[]
 * `jkube.generator.webapp.supportsS2iBuild` to `true`
 endif::[]
 
+==== JakartaEE and retrocompatibility with JavaEE in Jetty
+From Jetty 12, only JakartaEE compliant projects (Jakarta EE 10 / Servlet 6.x) are supported. The default Jetty base image is now `jkube-jetty12`. Legacy JavaEE projects using `javax.*` packages will not work with this image.
+
+To keep using Jetty 9, set the property `jkube.generator.webapp.server` to `jetty9`. This selects the legacy `quay.io/jkube/jkube-jetty9` base image which supports Servlet 3.x/4.x and `javax.*` packages.
+

--- a/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
@@ -53,7 +53,7 @@ In addition to the  <<generator-options-common, common generator options>> this 
 | Element | Description | Property
 
 | *server*
-| Fix server to use in the base image. Can be either **tomcat**, **jetty**, **jetty9** or **wildfly**. Use **jetty9** to select the legacy Jetty 9 base image (`quay.io/jkube/jkube-jetty9`)
+| Fix server to use in the base image. Can be either **tomcat**, **jetty**, **jetty9** or **wildfly**. Use **jetty9** to select the legacy Jetty 9 base image (`quay.io/jkube/jkube-jetty9`).
 | `jkube.generator.webapp.server`
 
 | *targetDir*

--- a/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
@@ -53,7 +53,7 @@ In addition to the  <<generator-options-common, common generator options>> this 
 | Element | Description | Property
 
 | *server*
-| Fix server to use in the base image. Can be either **tomcat**, **jetty**, **jetty9** or **wildfly**. Use **jetty9** to select the legacy Jetty 9 base image (`quay.io/jkube/jkube-jetty9`).
+| Fix server to use in the base image. Can be either **tomcat**, **jetty**, **jetty9** or **wildfly**. Use **jetty9** to select the legacy Jetty 9 base image (`quay.io/jkube/jkube-jetty9`)
 | `jkube.generator.webapp.server`
 
 | *targetDir*

--- a/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
@@ -37,8 +37,8 @@ The base images chosen are:
 | `quay.io/jkube/jkube-tomcat`
 
 | *Jetty*
-| `quay.io/jkube/jkube-jetty9`
-| `quay.io/jkube/jkube-jetty9`
+| `quay.io/jkube/jkube-jetty12`
+| `quay.io/jkube/jkube-jetty12`
 
 | *Wildfly*
 | `jboss/wildfly`
@@ -53,7 +53,7 @@ In addition to the  <<generator-options-common, common generator options>> this 
 | Element | Description | Property
 
 | *server*
-| Fix server to use in the base image. Can be either **tomcat**, **jetty** or **wildfly**.
+| Fix server to use in the base image. Can be either **tomcat**, **jetty**, **jetty9** or **wildfly**. Use **jetty9** to select the legacy Jetty 9 base image (`quay.io/jkube/jkube-jetty9`).
 | `jkube.generator.webapp.server`
 
 | *targetDir*

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/AppServerDetector.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/AppServerDetector.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.eclipse.jkube.generator.api.GeneratorContext;
+import org.eclipse.jkube.generator.webapp.handler.Jetty9AppSeverHandler;
 import org.eclipse.jkube.generator.webapp.handler.JettyAppSeverHandler;
 import org.eclipse.jkube.generator.webapp.handler.TomcatAppSeverHandler;
 import org.eclipse.jkube.generator.webapp.handler.WildFlyAppSeverHandler;
@@ -36,6 +37,7 @@ class AppServerDetector {
         defaultHandler = new TomcatAppSeverHandler(generatorContext);
         serverHandlers = Arrays.asList(
             new JettyAppSeverHandler(generatorContext),
+            new Jetty9AppSeverHandler(generatorContext),
             new WildFlyAppSeverHandler(generatorContext),
             defaultHandler
         );

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppSeverHandler.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppSeverHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.generator.webapp.handler;
+
+import org.eclipse.jkube.generator.api.GeneratorContext;
+
+/**
+ * Legacy Jetty 9 handler, opt-in only via {@code jkube.generator.webapp.server=jetty9}.
+ */
+public class Jetty9AppSeverHandler extends AbstractAppServerHandler {
+
+  public Jetty9AppSeverHandler(GeneratorContext context) {
+    super("jetty9", context);
+  }
+
+  @Override
+  public boolean isApplicable() {
+    return false;
+  }
+
+  @Override
+  public String getFrom() {
+    return imageLookup.getImageName("jetty9.upstream.docker");
+  }
+
+  @Override
+  public String getDeploymentDir() {
+    return "/deployments";
+  }
+
+  @Override
+  public String getCommand() {
+    return "/usr/local/s2i/run";
+  }
+
+  @Override
+  public boolean supportsS2iBuild() {
+    return true;
+  }
+}

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppSeverHandler.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppSeverHandler.java
@@ -18,7 +18,7 @@ import org.eclipse.jkube.generator.api.GeneratorContext;
 /**
  * Legacy Jetty 9 handler, opt-in only via {@code jkube.generator.webapp.server=jetty9}.
  */
-public class Jetty9AppSeverHandler extends AbstractAppServerHandler {
+public class Jetty9AppSeverHandler extends JettyAppSeverHandler {
 
   public Jetty9AppSeverHandler(GeneratorContext context) {
     super("jetty9", context);
@@ -32,20 +32,5 @@ public class Jetty9AppSeverHandler extends AbstractAppServerHandler {
   @Override
   public String getFrom() {
     return imageLookup.getImageName("jetty9.upstream.docker");
-  }
-
-  @Override
-  public String getDeploymentDir() {
-    return "/deployments";
-  }
-
-  @Override
-  public String getCommand() {
-    return "/usr/local/s2i/run";
-  }
-
-  @Override
-  public boolean supportsS2iBuild() {
-    return true;
   }
 }

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/handler/JettyAppSeverHandler.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/handler/JettyAppSeverHandler.java
@@ -29,7 +29,11 @@ public class JettyAppSeverHandler extends AbstractAppServerHandler {
   private static final String JETTY_MAVEN_PLUGIN_ARTIFACT_ID = "jetty-maven-plugin";
 
   public JettyAppSeverHandler(GeneratorContext context) {
-    super("jetty", context);
+    this("jetty", context);
+  }
+
+  protected JettyAppSeverHandler(String name, GeneratorContext context) {
+    super(name, context);
   }
 
   @Override

--- a/jkube-kit/generator/webapp/src/main/resources-filtered/META-INF/jkube/default-images.properties
+++ b/jkube-kit/generator/webapp/src/main/resources-filtered/META-INF/jkube/default-images.properties
@@ -16,6 +16,7 @@
 # The images with their versions are set in the parent/pom.xml
 tomcat.upstream.docker=${image.tomcat.upstream}
 jetty.upstream.docker=${image.jetty.upstream}
+jetty9.upstream.docker=${image.jetty9.upstream}
 wildfly.upstream.docker=${image.wildfly.upstream.docker}
 wildfly.upstream.s2i=${image.wildfly.upstream.s2i}
 wildfly.upstream.istag=${image.wildfly.upstream.istag}

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/AppServerAutoDetectionTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/AppServerAutoDetectionTest.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.eclipse.jkube.generator.api.GeneratorContext;
+import org.eclipse.jkube.generator.webapp.handler.Jetty9AppSeverHandler;
+import org.eclipse.jkube.generator.webapp.handler.JettyAppSeverHandler;
 import org.eclipse.jkube.generator.webapp.handler.TomcatAppSeverHandler;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.Plugin;
@@ -120,7 +122,9 @@ class AppServerAutoDetectionTest {
 
         AppServerHandler appServerHandler = new AppServerDetector(generatorContext).detect("jetty");
         assertThat(appServerHandler)
-            .hasFieldOrPropertyWithValue("name", "jetty");
+            .isInstanceOf(JettyAppSeverHandler.class)
+            .hasFieldOrPropertyWithValue("name", "jetty")
+            .satisfies(h -> assertThat(h.getFrom()).startsWith("quay.io/jkube/jkube-jetty12:"));
     }
 
     @Test
@@ -129,7 +133,9 @@ class AppServerAutoDetectionTest {
 
         AppServerHandler appServerHandler = new AppServerDetector(generatorContext).detect("jetty9");
         assertThat(appServerHandler)
-            .hasFieldOrPropertyWithValue("name", "jetty9");
+            .isInstanceOf(Jetty9AppSeverHandler.class)
+            .hasFieldOrPropertyWithValue("name", "jetty9")
+            .satisfies(h -> assertThat(h.getFrom()).startsWith("quay.io/jkube/jkube-jetty9:"));
     }
 
     @Test

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/AppServerAutoDetectionTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/AppServerAutoDetectionTest.java
@@ -115,6 +115,24 @@ class AppServerAutoDetectionTest {
     }
 
     @Test
+    void detect_withJettyServer_shouldReturnJettyHandler() {
+        GeneratorContext generatorContext = GeneratorContext.builder().project(JavaProject.builder().build()).build();
+
+        AppServerHandler appServerHandler = new AppServerDetector(generatorContext).detect("jetty");
+        assertThat(appServerHandler)
+            .hasFieldOrPropertyWithValue("name", "jetty");
+    }
+
+    @Test
+    void detect_withJetty9Server_shouldReturnJetty9Handler() {
+        GeneratorContext generatorContext = GeneratorContext.builder().project(JavaProject.builder().build()).build();
+
+        AppServerHandler appServerHandler = new AppServerDetector(generatorContext).detect("jetty9");
+        assertThat(appServerHandler)
+            .hasFieldOrPropertyWithValue("name", "jetty9");
+    }
+
+    @Test
     void detect_withNotApplicableDescriptor_shouldReturnDefaultServer() throws IOException {
       final Path descriptor = folder.resolve("webapp").resolve("META-INF").resolve("not-valid-descriptor.xml");
       final Path xxxInf = descriptor.getParent();

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppServerHandlerTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppServerHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.generator.webapp.handler;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.eclipse.jkube.generator.api.GeneratorContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class Jetty9AppServerHandlerTest {
+
+  @TempDir
+  File temporaryFolder;
+
+  private GeneratorContext generatorContext;
+
+  @BeforeEach
+  public void setUp() {
+    generatorContext = mock(GeneratorContext.class, RETURNS_DEEP_STUBS);
+  }
+
+  @Test
+  void isApplicable_shouldReturnFalse() {
+    // Given
+    when(generatorContext.getProject().getBuildDirectory()).thenReturn(temporaryFolder);
+    // When
+    final boolean result = new Jetty9AppSeverHandler(generatorContext).isApplicable();
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void handlerSettings() {
+    // When
+    final Jetty9AppSeverHandler handler = new Jetty9AppSeverHandler(generatorContext);
+    // Then
+    assertThat(handler)
+        .returns("jetty9", Jetty9AppSeverHandler::getName)
+        .satisfies(h -> assertThat(h.getFrom()).startsWith("quay.io/jkube/jkube-jetty9:"))
+        .returns(Collections.singletonList("8080"), Jetty9AppSeverHandler::exposedPorts)
+        .returns("/deployments", Jetty9AppSeverHandler::getDeploymentDir)
+        .returns("deployments", Jetty9AppSeverHandler::getAssemblyName)
+        .returns("/usr/local/s2i/run", Jetty9AppSeverHandler::getCommand)
+        .returns(null, Jetty9AppSeverHandler::getUser)
+        .returns(true, Jetty9AppSeverHandler::supportsS2iBuild);
+  }
+}

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppServerHandlerTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppServerHandlerTest.java
@@ -35,7 +35,7 @@ class Jetty9AppServerHandlerTest {
   private GeneratorContext generatorContext;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     generatorContext = mock(GeneratorContext.class, RETURNS_DEEP_STUBS);
   }
 

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppServerHandlerTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppServerHandlerTest.java
@@ -13,24 +13,18 @@
  */
 package org.eclipse.jkube.generator.webapp.handler;
 
-import java.io.File;
 import java.util.Collections;
 
 import org.eclipse.jkube.generator.api.GeneratorContext;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class Jetty9AppServerHandlerTest {
-
-  @TempDir
-  File temporaryFolder;
 
   private GeneratorContext generatorContext;
 
@@ -41,8 +35,6 @@ class Jetty9AppServerHandlerTest {
 
   @Test
   void isApplicable_shouldReturnFalse() {
-    // Given
-    when(generatorContext.getProject().getBuildDirectory()).thenReturn(temporaryFolder);
     // When
     final boolean result = new Jetty9AppSeverHandler(generatorContext).isApplicable();
     // Then

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/JettyAppServerHandlerTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/handler/JettyAppServerHandlerTest.java
@@ -106,7 +106,8 @@ class JettyAppServerHandlerTest {
     final JettyAppSeverHandler handler = new JettyAppSeverHandler(generatorContext);
     // Then
     assertThat(handler)
-        .satisfies(h -> assertThat(h.getFrom()).startsWith("quay.io/jkube/jkube-jetty9:"))
+        .returns("jetty", JettyAppSeverHandler::getName)
+        .satisfies(h -> assertThat(h.getFrom()).startsWith("quay.io/jkube/jkube-jetty12:"))
         .returns(Collections.singletonList("8080"), JettyAppSeverHandler::exposedPorts)
         .returns("/deployments", JettyAppSeverHandler::getDeploymentDir)
         .returns("deployments", JettyAppSeverHandler::getAssemblyName)

--- a/jkube-kit/parent/pom.xml
+++ b/jkube-kit/parent/pom.xml
@@ -63,7 +63,7 @@
     <version.ow2.asm>9.10.1</version.ow2.asm>
 
     <!-- =======================================================  -->
-    <version.image.jkube-images>0.0.26</version.image.jkube-images>
+    <version.image.jkube-images>0.0.28</version.image.jkube-images>
     <version.image.ubi-minimal>9.3</version.image.ubi-minimal>
     <!-- === Java base image versions for docker, s2i (istag == s2i) -->
     <!-- Upstream -->
@@ -125,7 +125,8 @@
 
     <!-- webapp -->
     <image.tomcat.upstream>quay.io/jkube/jkube-tomcat:${version.image.tomcat.upstream}</image.tomcat.upstream>
-    <image.jetty.upstream>quay.io/jkube/jkube-jetty9:${version.image.jetty.upstream}</image.jetty.upstream>
+    <image.jetty.upstream>quay.io/jkube/jkube-jetty12:${version.image.jetty.upstream}</image.jetty.upstream>
+    <image.jetty9.upstream>quay.io/jkube/jkube-jetty9:${version.image.jetty.upstream}</image.jetty9.upstream>
     <image.wildfly.upstream.docker>jboss/wildfly:${version.image.wildfly.upstream.docker}</image.wildfly.upstream.docker>
     <image.wildfly.upstream.s2i>quay.io/wildfly/wildfly-centos7:${version.image.wildfly.upstream.s2i}</image.wildfly.upstream.s2i>
     <image.wildfly.upstream.istag>wildfly:${version.image.wildfly.upstream.s2i}</image.wildfly.upstream.istag>

--- a/jkube-kit/remote-dev/src/test/java/org/eclipse/jkube/kit/remotedev/KubernetesSshServiceForwarderTest.java
+++ b/jkube-kit/remote-dev/src/test/java/org/eclipse/jkube/kit/remotedev/KubernetesSshServiceForwarderTest.java
@@ -73,7 +73,7 @@ class KubernetesSshServiceForwarderTest {
   }
 
   @Test
-  @DisplayName("deploys Pod with image: quay.io/jkube/jkube-remote-dev:0.0.26")
+  @DisplayName("deploys Pod with image: quay.io/jkube/jkube-remote-dev:0.0.28")
   void deployPodWithImage() {
     // When
     executorService.submit(kubernetesSshServiceForwarder);
@@ -89,7 +89,7 @@ class KubernetesSshServiceForwarderTest {
       .extracting(PodSpec::getContainers)
       .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
       .singleElement()
-      .hasFieldOrPropertyWithValue("image", "quay.io/jkube/jkube-remote-dev:0.0.26");
+      .hasFieldOrPropertyWithValue("image", "quay.io/jkube/jkube-remote-dev:0.0.28");
   }
   @Test
   @DisplayName("deploys Pod with port definitions")


### PR DESCRIPTION
## Summary

Fixes #3873

- Default webapp generator Jetty image changed from `jkube-jetty9` to `jkube-jetty12` (Jetty 12 / Jakarta EE 10 / Servlet 6.x)
- Legacy `jkube-jetty9` preserved as opt-in via `jkube.generator.webapp.server=jetty9` (new `Jetty9AppSeverHandler`)
- Bumped `version.image.jkube-images` from `0.0.26` to `0.0.28`
- Updated webapp generator documentation to reflect the new default and document the `jetty9` server option

## Changes

| File | Change |
|------|--------|
| `jkube-kit/parent/pom.xml` | Bump jkube-images `0.0.26` → `0.0.28`; `image.jetty.upstream` → `jkube-jetty12`; add `image.jetty9.upstream` |
| `default-images.properties` | Add `jetty9.upstream.docker` property |
| `Jetty9AppSeverHandler.java` (new) | Opt-in handler for legacy Jetty 9 (`isApplicable()=false`, name=`jetty9`) |
| `AppServerDetector.java` | Register `Jetty9AppSeverHandler` in handler list |
| `_webapp.adoc` | Update image table to `jkube-jetty12`; document `jetty9` as server option |
| `CHANGELOG.md` | Add entry for #3873 |
| `JettyAppServerHandlerTest.java` | Assert `jkube-jetty12` image + `getName()` |
| `Jetty9AppServerHandlerTest.java` (new) | Test `isApplicable()=false` and handler settings |
| `AppServerAutoDetectionTest.java` | Add tests for `detect("jetty")` and `detect("jetty9")` |

## How to test

```bash
# Run the webapp generator tests
./mvnw test -pl jkube-kit/generator/webapp

# Verify default Jetty image resolves to jkube-jetty12
./mvnw test -pl jkube-kit/generator/webapp -Dtest=JettyAppServerHandlerTest#handlerSettings

# Verify legacy Jetty 9 opt-in works
./mvnw test -pl jkube-kit/generator/webapp -Dtest=Jetty9AppServerHandlerTest
./mvnw test -pl jkube-kit/generator/webapp -Dtest=AppServerAutoDetectionTest#detect_withJetty9Server_shouldReturnJetty9Handler
```

## Follow-up

- Quickstart README files (`quickstarts/gradle/webapp/README.md`, `quickstarts/gradle/webapp-jetty/README.md`) contain hardcoded example output referencing `jkube-jetty9:0.0.16` — needs a separate pass to regenerate example output