### PR TITLE
chore(quickstarts): update jkube-images references to 0.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.20-SNAPSHOT
+* Fix #3917: Update quickstart image references to jkube-images 0.0.28
 * Fix #3902: Bump pack CLI from 0.34.2 to 0.40.7 and update default builder image to `paketobuildpacks/builder-jammy-base`
 * Fix #3904: Bump jib-core from 0.27.3 to 0.28.1
 * Fix #3900: BuildPackBuildService honors global `imagePullPolicy` when no per-image policy is set

--- a/quickstarts/gradle/docker-file-simple/Dockerfile
+++ b/quickstarts/gradle/docker-file-simple/Dockerfile
@@ -12,7 +12,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM quay.io/jkube/jkube-java:0.0.16
+FROM quay.io/jkube/jkube-java:0.0.28
 ENV JAVA_APP_DIR=/deployments
 EXPOSE 8080 8778 9779
 COPY maven/build/libs/docker-file-simple-1.5.1.jar /deployments/

--- a/quickstarts/gradle/docker-file-simple/README.md
+++ b/quickstarts/gradle/docker-file-simple/README.md
@@ -12,7 +12,7 @@ For simple `Dockerfile` mode, your project's current directory is provided as do
 If you want to copy some files from your current directory(`build/libs/docker-file-simple.jar` in this case), you need
 to prefix project directory contents with default assembly name(i.e `maven`). So your `Dockerfile` would look like this:
 ```Dockerfile
-FROM quay.io/jkube/jkube-java:0.0.16
+FROM quay.io/jkube/jkube-java:0.0.28
 ENV JAVA_APP_DIR=/deployments
 EXPOSE 8080 8778 9779
 COPY maven/build/libs/docker-file-simple-0.0.1-SNAPSHOT.jar /deployments/
@@ -27,8 +27,8 @@ k8s: Cannot access cluster for detecting mode: Unknown host kubernetes.default.s
 k8s: Building Docker image in Kubernetes mode
 k8s: Pulling from jkube/jkube-java
 k8s: Digest: sha256:dd5c9f44a86e19438662d293e180acc8d864887cf19c165c1b24ae703b16c2d4
-k8s: Status: Image is up to date for quay.io/jkube/jkube-java:0.0.16
-k8s: Pulled quay.io/jkube/jkube-java:0.0.16 in 3 seconds
+k8s: Status: Image is up to date for quay.io/jkube/jkube-java:0.0.28
+k8s: Pulled quay.io/jkube/jkube-java:0.0.28 in 3 seconds
 k8s: [helloworld/docker-file-simple:latest]: Created docker-build.tar in 94 milliseconds
 k8s: [helloworld/docker-file-simple:latest]: Built image sha256:4b6b1
 

--- a/quickstarts/gradle/groovy-dsl-config/build.gradle
+++ b/quickstarts/gradle/groovy-dsl-config/build.gradle
@@ -47,7 +47,7 @@ kubernetes {
             name = "jkube/${project.name}:${project.version}"
             alias = "camel-service"
             build {
-                from = "quay.io/jkube/jkube-java:0.0.16"
+                from = "quay.io/jkube/jkube-java:0.0.28"
                 assembly {
                     targetDir = "/deployments"
                     layers = [{

--- a/quickstarts/gradle/micronaut-customized-image/build.gradle
+++ b/quickstarts/gradle/micronaut-customized-image/build.gradle
@@ -58,7 +58,7 @@ kubernetes {
         image {
             name = "%g/%a:${project.version}"
             build {
-                from = "quay.io/jkube/jkube-java:0.0.25"
+                from = "quay.io/jkube/jkube-java:0.0.28"
                 tags = ["latest", "${project.version}"]
                 env {
                     JAVA_APP_JAR = "${project.name}-${project.version}-all.jar"

--- a/quickstarts/gradle/plugin/app/Dockerfile
+++ b/quickstarts/gradle/plugin/app/Dockerfile
@@ -12,7 +12,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM quay.io/jkube/jkube-java:0.0.15
+FROM quay.io/jkube/jkube-java:0.0.28
 
 ENV JAVA_APP_DIR=/deployments
 

--- a/quickstarts/gradle/quarkus/README.md
+++ b/quickstarts/gradle/quarkus/README.md
@@ -29,7 +29,7 @@ $ ./gradlew build k8sResource
 
 > Task :k8sResource
 k8s: Running generator quarkus
-k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.16 as base / builder
+k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 k8s: Using resource templates from /home/anurag/Work/jkube/quickstarts/gradle/quarkus/src/main/jkube
 k8s: jkube-controller: Adding a default Deployment
 k8s: jkube-service: Adding a default service 'quarkus' with ports [8080]
@@ -48,7 +48,7 @@ $ ./gradlew k8sBuild
 
 > Task :k8sBuild
 k8s: Running generator quarkus
-k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.16 as base / builder
+k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 k8s: Building container image in Kubernetes mode
 k8s: [gradle/quarkus:1.7.0] "quarkus": Created docker-build.tar in 378 milliseconds
 k8s: [gradle/quarkus:1.7.0] "quarkus": Built image sha256:c1df2
@@ -65,7 +65,7 @@ $ ./gradlew k8sApply
 
 > Task :k8sApply
 k8s: Running generator quarkus7s]
-k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.16 as base / builder
+k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 k8s: Using Kubernetes at https://192.168.49.2:8443/ in namespace null with manifest /home/anurag/Work/jkube/quickstarts/gradle/quarkus/build/classes/java/main/META-INF/jkube/kubernetes.yml k8sApply
 k8s: Updating Service from kubernetes.yml
 k8s: Updated Service: build/jkube/applyJson/default/service-quarkus-2.json

--- a/quickstarts/gradle/webapp-jetty/README.md
+++ b/quickstarts/gradle/webapp-jetty/README.md
@@ -32,12 +32,12 @@ $ ./gradlew build k8sBuild
 
 > Task :k8sBuild
 k8s: Running generator webapp [6s]
-k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.16 as base image for webapp
+k8s: webapp: Using quay.io/jkube/jkube-jetty12:0.0.28 as base image for webapp
 k8s: Building container image in Kubernetes mode
-k8s: Pulling from jkube/jkube-jetty9
+k8s: Pulling from jkube/jkube-jetty12
 k8s: Digest: sha256:d0e6872a95a82fb80fef8e5a653baae3e4866812dc739f9fc8012514f3a52327
-k8s: Status: Downloaded newer image for quay.io/jkube/jkube-jetty9:0.0.16
-k8s: Pulled quay.io/jkube/jkube-jetty9:0.0.16 in 15 seconds 
+k8s: Status: Downloaded newer image for quay.io/jkube/jkube-jetty12:0.0.28
+k8s: Pulled quay.io/jkube/jkube-jetty12:0.0.28 in 15 seconds 
 k8s: [kubernetes/webapp-jetty:latest] "webapp": Created docker-build.tar in 41 milliseconds
 k8s: [kubernetes/webapp-jetty:latest] "webapp": Built image sha256:d0d52
 k8s: [kubernetes/webapp-jetty:latest] "webapp": Tag with latest
@@ -55,7 +55,7 @@ kubernetes/webapp-jetty                                 latest     d0d528ec103e 
 $ ./gradlew k8sResource -Djkube.domain=$(minikube ip).nip.io
 > Task :k8sResource
 k8s: Running generator webapp
-k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.16 as base image for webapp
+k8s: webapp: Using quay.io/jkube/jkube-jetty12:0.0.28 as base image for webapp
 k8s: Using resource templates from /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp-jetty/src/main/jkube
 k8s: jkube-controller: Adding a default Deployment
 k8s: jkube-service: Adding a default service 'webapp-jetty' with ports [8080]
@@ -84,7 +84,7 @@ webapp-jetty-deployment.yml  webapp-jetty-ingress.yml  webapp-jetty-service.yml
 
 > Task :k8sApply
 k8s: Running generator webapp
-k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.16 as base image for webapp
+k8s: webapp: Using quay.io/jkube/jkube-jetty12:0.0.28 as base image for webapp
 k8s: Using Kubernetes at https://192.168.99.120:8443/ in namespace null with manifest /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp-jetty/build/classes/java/main/META-INF/jkube/kubernetes.yml 
 k8s: Creating a Service from kubernetes.yml namespace default name webapp-jetty
 k8s: Created Service: build/jkube/applyJson/default/service-webapp-jetty.json

--- a/quickstarts/gradle/webapp/README.md
+++ b/quickstarts/gradle/webapp/README.md
@@ -29,7 +29,7 @@ $ ./gradlew build k8sBuild
 
 > Task :k8sBuild
 k8s: Running generator webapp
-k8s: webapp: Using quay.io/jkube/jkube-tomcat9:0.0.16 as base image for webapp
+k8s: webapp: Using quay.io/jkube/jkube-tomcat9:0.0.28 as base image for webapp
 k8s: Building container image in Kubernetes mode
 k8s: [kubernetes/webapp:latest] "webapp": Created docker-build.tar in 6 milliseconds
 k8s: [kubernetes/webapp:latest] "webapp": Built image sha256:78b98
@@ -64,7 +64,7 @@ $ ./gradlew build k8sBuild
 
 > Task :k8sBuild
 k8s: Running generator webapp
-k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.16 as base image for webapp
+k8s: webapp: Using quay.io/jkube/jkube-jetty12:0.0.28 as base image for webapp
 k8s: Building container image in Kubernetes mode
 k8s: [kubernetes/webapp:latest] "webapp": Created docker-build.tar in 5 milliseconds
 k8s: [kubernetes/webapp:latest] "webapp": Built image sha256:5e016
@@ -75,14 +75,14 @@ BUILD SUCCESSFUL in 1s
 
 ```
 
-It is now using `quay.io/jkube/jkube-jetty9:0.0.16` as base image!
+It is now using `quay.io/jkube/jkube-jetty12:0.0.28` as base image!
 
 ## Generate Kubernetes Manifests
 ```
 $ ./gradlew k8sResource -Djkube.domain=$(minikube ip).nip.io
 > Task :k8sResource
 k8s: Running generator webapp
-k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.16 as base image for webapp
+k8s: webapp: Using quay.io/jkube/jkube-jetty12:0.0.28 as base image for webapp
 k8s: Using resource templates from /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp/src/main/jkube
 k8s: jkube-controller: Adding a default Deployment
 k8s: jkube-service: Adding a default service 'webapp' with ports [8080]
@@ -111,7 +111,7 @@ webapp-deployment.yml  webapp-ingress.yml  webapp-service.yml
 
 > Task :k8sApply
 k8s: Running generator webapp
-k8s: webapp: Using quay.io/jkube/jkube-jetty9:0.0.16 as base image for webapp
+k8s: webapp: Using quay.io/jkube/jkube-jetty12:0.0.28 as base image for webapp
 k8s: Using Kubernetes at https://192.168.99.115:8443/ in namespace null with manifest /home/sunix/github/eclipse/jkube/quickstarts/gradle/webapp/build/classes/java/main/META-INF/jkube/kubernetes.yml 
 k8s: Creating a Service from kubernetes.yml namespace default name webapp
 k8s: Created Service: build/jkube/applyJson/default/service-webapp-2.json

--- a/quickstarts/kit/custom-foo-generator/app/build.gradle
+++ b/quickstarts/kit/custom-foo-generator/app/build.gradle
@@ -52,7 +52,7 @@ kubernetes {
             name = "jkube/${project.name}:${project.version}"
             alias = "foo-app"
             build {
-                from = "quay.io/jkube/jkube-java:0.0.13"
+                from = "quay.io/jkube/jkube-java:0.0.28"
                 assembly {
                     targetDir = "/deployments"
                     layers = [{
@@ -76,7 +76,7 @@ openshift {
             name = "jkube/${project.name}:${project.version}"
             alias = "foo-app"
             build {
-                from = "quay.io/jkube/jkube-java:0.0.13"
+                from = "quay.io/jkube/jkube-java:0.0.28"
                 assembly {
                     targetDir = "/deployments"
                     layers = [{

--- a/quickstarts/kit/custom-istio-enricher/README.md
+++ b/quickstarts/kit/custom-istio-enricher/README.md
@@ -32,7 +32,7 @@ app : $ mvn k8s:resource
 [INFO] --- kubernetes-maven-plugin:1.1.0-SNAPSHOT:resource (default-cli) @ eclipse-jkube-sample-custom-enricher-app ---
 [WARNING] k8s: Cannot access cluster for detecting mode: No route to host (Host unreachable)
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 [INFO] k8s: Using resource templates from /home/rohaan/work/repos/jkube/quickstarts/kit/custom-istio-enricher/app/src/main/jkube
 [INFO] k8s: jkube-service: Adding a default service 'eclipse-jkube-sample-custom-enricher-app' with ports [8080]
 [INFO] k8s: jkube-revision-history: Adding revision history limit to 2

--- a/quickstarts/maven/micronaut-customized-image/pom.xml
+++ b/quickstarts/maven/micronaut-customized-image/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <jkube.version>${project.version}</jkube.version>
-    <jkube.image.version>0.0.13</jkube.image.version>
+    <jkube.image.version>0.0.28</jkube.image.version>
     <micronaut.version>${project.parent.version}</micronaut.version>
     <exec.mainClass>org.eclipse.jkube.quickstart.micronaut.custom.Application</exec.mainClass>
   </properties>

--- a/quickstarts/maven/plugin/app/Dockerfile
+++ b/quickstarts/maven/plugin/app/Dockerfile
@@ -12,7 +12,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM quay.io/jkube/jkube-java:0.0.15
+FROM quay.io/jkube/jkube-java:0.0.28
 
 ENV JAVA_APP_DIR=/deployments
 

--- a/quickstarts/maven/quarkus/README.md
+++ b/quickstarts/maven/quarkus/README.md
@@ -38,11 +38,11 @@ $ mvn package k8s:build
 [INFO] --- kubernetes-maven-plugin:1.3.0:build (default-cli) @ quarkus ---
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator quarkus
-[INFO] k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
+[INFO] k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 [INFO] k8s: Pulling from jkube/jkube-java
 [INFO] k8s: Digest: sha256:dd5c9f44a86e19438662d293e180acc8d864887cf19c165c1b24ae703b16c2d4
-[INFO] k8s: Status: Downloaded newer image for quay.io/jkube/jkube-java:0.0.13
-[INFO] k8s: Pulled quay.io/jkube/jkube-java:0.0.13 in 21 seconds 
+[INFO] k8s: Status: Downloaded newer image for quay.io/jkube/jkube-java:0.0.28
+[INFO] k8s: Pulled quay.io/jkube/jkube-java:0.0.28 in 21 seconds 
 [INFO] k8s: [maven/quarkus:1.3.0] "quarkus": Created docker-build.tar in 241 milliseconds
 [INFO] k8s: [maven/quarkus:1.3.0] "quarkus": Built image sha256:c4e4b
 [INFO] k8s: [maven/quarkus:1.3.0] "quarkus": Removed old image sha256:3c4d4
@@ -69,7 +69,7 @@ $ mvn k8s:resource k8s:apply
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.3.0:resource (default-cli) @ quarkus ---
 [INFO] k8s: Running generator quarkus
-[INFO] k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
+[INFO] k8s: quarkus: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 [INFO] k8s: Using resource templates from /home/user/00-MN/projects/forks/jkube/quickstarts/maven/quarkus/src/main/jkube
 [INFO] k8s: jkube-controller: Adding a default Deployment
 [INFO] k8s: jkube-service: Adding a default service 'quarkus' with ports [8080]

--- a/quickstarts/maven/spring-boot-with-jib/README.md
+++ b/quickstarts/maven/spring-boot-with-jib/README.md
@@ -40,16 +40,16 @@ To build project issue this command:
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:build (default-cli) @ eclipse-jkube-sample-spring-boot-jib ---
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 [INFO] k8s: JIB image build started
-JIB> Base image 'quay.io/jkube/jkube-java:0.0.13' does not use a specific image digest - build may not be reproducible
+JIB> Base image 'quay.io/jkube/jkube-java:0.0.28' does not use a specific image digest - build may not be reproducible
 JIB> Containerizing application with the following files:                                                                    
 JIB> 	:                                                                                                                      
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/maven/eclipse-jkube-sample-spring-boot-jib/latest/build/Dockerfilek8s: 
 JIB> 	:                                                                                                                      
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/maven/eclipse-jkube-sample-spring-boot-jib/latest/build/deployments8s: 
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/maven/eclipse-jkube-sample-spring-boot-jib/latest/build/deployments/eclipse-jkube-sample-spring-boot-jib-1.0.0-SNAPSHOT.jar
-JIB> Getting manifest for base image quay.io/jkube/jkube-java:0.0.13...                                            
+JIB> Getting manifest for base image quay.io/jkube/jkube-java:0.0.28...                                            
 JIB> Building  layer...                                                                                                      
 JIB> Building  layer...                                                                                                      
 JIB> Using base image with digest: sha256:0bdf76ac67d0dc03e8d474edce515ea839810d561b9f1c799ebda1d6e6b7789e                   
@@ -93,16 +93,16 @@ Once we add this property we need to do `mvn k8s:build -PJib-Zero-Config` again 
 [WARNING] k8s: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc: Name or service not known
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 [INFO] k8s: JIB image build started
-JIB> Base image 'quay.io/jkube/jkube-java:0.0.13' does not use a specific image digest - build may not be reproducible
+JIB> Base image 'quay.io/jkube/jkube-java:0.0.28' does not use a specific image digest - build may not be reproducible
 JIB> Containerizing application with the following files:                                                                    
 JIB> 	:                                                                                                                      
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/docker.io/rohankanojia/spring-boot-with-jib/1.0.0-SNAPSHOT/build/Dockerfile
 JIB> 	:                                                                                                                      
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/docker.io/rohankanojia/spring-boot-with-jib/1.0.0-SNAPSHOT/build/deployments
 JIB> 		/home/rohaan/work/repos/jkube/quickstarts/maven/spring-boot-with-jib/target/docker/docker.io/rohankanojia/spring-boot-with-jib/1.0.0-SNAPSHOT/build/deployments/eclipse-jkube-sample-spring-boot-jib-1.0.0-SNAPSHOT.jar
-JIB> Getting manifest for base image quay.io/jkube/jkube-java:0.0.13...                                            
+JIB> Getting manifest for base image quay.io/jkube/jkube-java:0.0.28...                                            
 JIB> Building  layer...                                                                                                      
 JIB> Building  layer...                                                                                                      
 JIB> Using base image with digest: sha256:c834f2b076488a81bd4f59397712940b1187681e190f008ffe2c91ae4787290f                   
@@ -128,7 +128,7 @@ JIB> [==============================] 100.0% complete
 [WARNING] k8s: Cannot access cluster for detecting mode: Unknown host kubernetes.default.svc: Name or service not known
 [INFO] k8s: Building Docker image in Kubernetes mode
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 [INFO] k8s: This push refers to: docker.io/rohankanojia/spring-boot-with-jib:1.0.0-SNAPSHOT
 JIB> Containerizing application with the following files:                                                                    
 JIB> Retrieving registry credentials for registry-1.docker.io...                                                             
@@ -171,7 +171,7 @@ Once image has been loaded in your docker daemon. You can generate and apply man
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:resource (default-cli) @ eclipse-jkube-sample-spring-boot-jib ---
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 [INFO] k8s: jkube-controller: Adding a default Deployment
 [INFO] k8s: jkube-service: Adding a default service 'eclipse-jkube-sample-spring-boot-jib' with ports [8080]
 [INFO] k8s: jkube-healthcheck-spring-boot: Adding readiness probe on port 8080, path='/health', scheme='HTTP', with initial delay 10 seconds

--- a/quickstarts/maven/spring-boot/README.md
+++ b/quickstarts/maven/spring-boot/README.md
@@ -143,7 +143,7 @@ nginx-ingress-controller-6fc5bcc8c9-gt4mg   1/1     Running   3          4h5m
 [INFO] 
 [INFO] --- kubernetes-maven-plugin:1.0.0-SNAPSHOT:resource (default-cli) @ spring-boot ---
 [INFO] k8s: Running generator spring-boot
-[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.13 as base / builder
+[INFO] k8s: spring-boot: Using Docker image quay.io/jkube/jkube-java:0.0.28 as base / builder
 [INFO] k8s: jkube-controller: Adding a default Deployment
 [INFO] k8s: jkube-service: Adding a default service 'spring-boot' with ports [8080]
 [INFO] k8s: jkube-healthcheck-spring-boot: Adding readiness probe on port 8080, path='/actuator/health', scheme='HTTP', with initial delay 10 seconds

--- a/quickstarts/maven/xml-config/pom.xml
+++ b/quickstarts/maven/xml-config/pom.xml
@@ -174,7 +174,7 @@
               <!-- "alias" is used to correlate to the containers in the pod spec -->
               <alias>camel-service</alias>
               <build>
-                <from>quay.io/jkube/jkube-java-11:0.0.13</from>
+                <from>quay.io/jkube/jkube-java-11:0.0.28</from>
                 <assembly>
                   <targetDir>/deployments</targetDir>
                   <inline>


### PR DESCRIPTION
## Summary

- Update all hardcoded jkube-images version references in quickstart Dockerfiles, Maven POMs, Gradle build files, and README example output from stale versions (0.0.13–0.0.25) to `0.0.28`
- Rename `jkube-jetty9` to `jkube-jetty12` in webapp and webapp-jetty quickstart READMEs to match the new default from #3914
- Add changelog entry

## Test plan

- [x] Verified zero stale version references (`0.0.13`, `0.0.15`, `0.0.16`, `0.0.25`) remain in quickstarts
- [x] Verified zero `jkube-jetty9` references remain in quickstarts
- [x] Verified all 17 files now reference `0.0.28` (40 occurrences confirmed)
- [x] Verified `jkube-tomcat9` and `jkube-java-11` names preserved (only version bumped)
- [x] Verified changelog entry format matches project convention

> **Note:** This PR depends on #3914 (core version bump and Jetty 12 default). Merge #3914 first so the parent POM version matches the quickstart documentation.

Fixes #3917