### PR TITLE
chore(docs): update documentation for jkube-images 0.0.28 changes (3918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.20-SNAPSHOT
+* Fix #3918: Update documentation for jkube-images 0.0.28 changes
 * Fix #3902: Bump pack CLI from 0.34.2 to 0.40.7 and update default builder image to `paketobuildpacks/builder-jammy-base`
 * Fix #3904: Bump jib-core from 0.27.3 to 0.28.1
 * Fix #3900: BuildPackBuildService honors global `imagePullPolicy` when no per-image policy is set

--- a/gradle-plugin/doc/src/main/asciidoc/inc/examples/_groovy.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/inc/examples/_groovy.adoc
@@ -31,7 +31,7 @@ Here is an example of providing Groovy DSL configuration for a simple image:
             name = "jkube/${project.name}:${project.version}" //<1>
             alias = "camel-service" //<2>
             build {
-                from = "quay.io/jkube/jkube-java:0.0.13" //<3>
+                from = "quay.io/jkube/jkube-java:0.0.28" //<3>
                 assembly { //<4>
                     targetDir = "/deployments" //<5>
                     layers = [{ //<6>
@@ -92,7 +92,7 @@ This configuration would copy a jar file located in `build/libs/` to  `/deployme
         image {
             name = "${project.group}/${project.name}:${project.version}"
             build {
-                from = "quay.io/jkube/jkube-java:0.0.13"
+                from = "quay.io/jkube/jkube-java:0.0.28"
                 assembly {
                     targetDir = "/deployments"
                     layers = [{
@@ -121,7 +121,7 @@ This example would copy `build/dependencies` directory to `/deployments` directo
         image {
             name = "${project.group}/${project.name}:${project.version}"
             build {
-                from = "quay.io/jkube/jkube-java:0.0.13"
+                from = "quay.io/jkube/jkube-java:0.0.28"
                 assembly {
                     targetDir = "/deployments"
                     layers = [{

--- a/jkube-kit/doc/src/main/asciidoc/inc/_faq.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/_faq.adoc
@@ -20,7 +20,7 @@ spec:
 
 The above will generate an environment variable `$FOO` of value `bar`
 
-For a full list of the environments used in java base images, https://github.com/eclipse-jkube/jkube-images#available-imagesk[see this list]
+For a full list of the environments used in java base images, https://github.com/eclipse-jkube/jkube-images#available-images[see this list]
 
 === How do I define a system property?
 

--- a/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
@@ -100,7 +100,7 @@ If the project is already JakartaEE compliant, it is recommanded to set the weba
 
 To keep using Tomcat 9, set the properties:
 
-* `jkube.generator.webapp.from` to `quay.io/jkube/jkube-tomcat9:0.0.16`
+* `jkube.generator.webapp.from` to `quay.io/jkube/jkube-tomcat9:0.0.28`
 * `jkube.generator.webapp.cmd` to `/usr/local/s2i/run`
 ifdef::doc-openshift[]
 * `jkube.generator.webapp.supportsS2iBuild` to `true`

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/inc/_introduction.adoc
@@ -147,7 +147,7 @@ https://github.com/eclipse-jkube/jkube/tree/master/quickstarts/maven/zero-config
 
 This setup make some opinionated decisions for you:
 
-* As base image https://quay.io/repository/jkube/jkube-java-binary-s2i[jkube/jkube-java-binary-s2i]
+* As base image https://quay.io/repository/jkube/jkube-java[jkube/jkube-java]
   is chosen which enables https://www.jolokia.org[Jolokia] and https://github.com/prometheus/jmx_exporter[jmx_exporter].
   It also comes with a sophisticated https://github.com/jboss-openshift/cct_module/tree/master/jboss/container/java/run/bash[startup script].
 * It will create a Kubernetes http://kubernetes.io/docs/user-guide/deployments/[Deployment] and a


### PR DESCRIPTION
## Summary

Fixes #3918

- Update hardcoded `jkube-tomcat9` version from `0.0.16` to `0.0.28` in webapp generator docs
- Update hardcoded `jkube-java` version from `0.0.13` to `0.0.28` in Groovy DSL examples (3 occurrences)
- Fix typo in FAQ link anchor: `#available-imagesk` → `#available-images`
- Replace stale `jkube-java-binary-s2i` reference with `jkube-java` in introduction docs
- Add changelog entry

## Test plan

- [x] `./mvnw clean install -pl kubernetes-maven-plugin/doc -am -DskipTests` builds successfully
- [x] `./mvnw clean install -pl gradle-plugin/doc -am -DskipTests` builds successfully
- [x] Generated HTML verified: zero occurrences of `0.0.16`, `0.0.13`, `available-imagesk`, or `jkube-java-binary-s2i`
- [x] Correct occurrences of `0.0.28` in both generated HTML outputs