### PR TITLE
fix: StatefulSet and DaemonSet selectors must not include version label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Usage:
 ```
 
 ### 1.20-SNAPSHOT
+* Fix #3925: StatefulSet selector.matchLabels no longer includes version label (immutable field, prevented redeploy after version bump)
+* Fix #3926: DaemonSet selector.matchLabels no longer includes version label (immutable field, prevented redeploy after version bump)
 * Fix #3917: Update quickstart image references to jkube-images 0.0.28
 * Fix #3873: Update JettyAppSeverHandler to select `jkube-jetty12` as the default Jetty image and add `jetty9` opt-in for legacy projects (potentially breaking for legacy JavaEE webapps using `javax.*`; set `jkube.generator.webapp.server=jetty9` to keep Jetty 9)
 * Fix #3918: Update documentation for jkube-images 0.0.28 changes

--- a/gradle-plugin/it/src/it/controller/expected/daemonset/kubernetes.yml
+++ b/gradle-plugin/it/src/it/controller/expected/daemonset/kubernetes.yml
@@ -20,7 +20,6 @@ items:
         matchLabels:
           app: controller
           provider: jkube
-          version: "@ignore@"
           group: org.eclipse.jkube.integration.tests.gradle
       template:
         metadata:

--- a/gradle-plugin/it/src/it/controller/expected/daemonset/openshift.yml
+++ b/gradle-plugin/it/src/it/controller/expected/daemonset/openshift.yml
@@ -23,7 +23,6 @@ items:
       matchLabels:
         app: controller
         provider: jkube
-        version: "@ignore@"
         group: org.eclipse.jkube.integration.tests.gradle
     template:
       metadata:

--- a/gradle-plugin/it/src/it/controller/expected/statefulset/kubernetes.yml
+++ b/gradle-plugin/it/src/it/controller/expected/statefulset/kubernetes.yml
@@ -21,7 +21,6 @@ items:
         matchLabels:
           app: controller
           provider: jkube
-          version: "@ignore@"
           group: org.eclipse.jkube.integration.tests.gradle
       serviceName: controller
       template:

--- a/gradle-plugin/it/src/it/controller/expected/statefulset/openshift.yml
+++ b/gradle-plugin/it/src/it/controller/expected/statefulset/openshift.yml
@@ -24,7 +24,6 @@ items:
         matchLabels:
           app: controller
           provider: jkube
-          version: "@ignore@"
           group: org.eclipse.jkube.integration.tests.gradle
       serviceName: controller
       template:

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/AbstractLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/AbstractLabelEnricher.java
@@ -104,7 +104,7 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
             .map(DaemonSetSpec::getSelector)
             .map(LabelSelector::getMatchLabels)
             .orElse(new HashMap<>()),
-          true, getResourceConfigLabels().getAll());
+          false, getResourceConfigLabels().getAll());
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }
     });
@@ -146,7 +146,7 @@ public abstract class AbstractLabelEnricher extends BaseEnricher {
             .map(StatefulSetSpec::getSelector)
             .map(LabelSelector::getMatchLabels)
             .orElse(new HashMap<>()),
-          true,
+          false,
           getResourceConfigLabels().getPod(), getResourceConfigLabels().getAll());
         builder.editOrNewSpec().editOrNewSelector().withMatchLabels(selectors).endSelector().endSpec();
       }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricherTest.java
@@ -26,6 +26,9 @@ import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.apps.DaemonSet;
+import io.fabric8.kubernetes.api.model.apps.DaemonSetBuilder;
+import io.fabric8.kubernetes.api.model.apps.DaemonSetSpec;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
@@ -182,7 +185,8 @@ class ProjectLabelEnricherTest {
   }
 
   @Test
-  void create_withNoConfiguredVersion_shouldAddDefaultVersionInSelector() {
+  @DisplayName("StatefulSet selector.matchLabels must not include version (immutable field, fails on version bump)")
+  void create_shouldNotAddVersionToStatefulSetSelector() {
     // Given
     KubernetesListBuilder builder = new KubernetesListBuilder().withItems(new StatefulSetBuilder().build());
 
@@ -196,26 +200,32 @@ class ProjectLabelEnricherTest {
         .extracting(StatefulSetSpec::getSelector)
         .extracting(LabelSelector::getMatchLabels)
         .asInstanceOf(InstanceOfAssertFactories.MAP)
-        .containsEntry("version", "version");
+        .containsEntry("group", "groupId")
+        .containsEntry("app", "artifactId")
+        .containsEntry("provider", "jkube")
+        .doesNotContainKey("version");
   }
 
   @Test
-  void create_withConfiguredVersion_shouldAddConfiguredVersionInSelector() {
+  @DisplayName("DaemonSet selector.matchLabels must not include version (immutable field, fails on version bump)")
+  void create_shouldNotAddVersionToDaemonSetSelector() {
     // Given
-    properties.setProperty("jkube.enricher.jkube-project-label.version", "0.0.1");
-    KubernetesListBuilder builder = new KubernetesListBuilder().withItems(new StatefulSetBuilder().build());
+    KubernetesListBuilder builder = new KubernetesListBuilder().withItems(new DaemonSetBuilder().build());
 
     // When
     projectLabelEnricher.create(PlatformMode.kubernetes, builder);
 
     // Then
-    StatefulSet statefulSet = (StatefulSet) builder.buildFirstItem();
-    assertThat(statefulSet)
-        .extracting(StatefulSet::getSpec)
-        .extracting(StatefulSetSpec::getSelector)
+    DaemonSet daemonSet = (DaemonSet) builder.buildFirstItem();
+    assertThat(daemonSet)
+        .extracting(DaemonSet::getSpec)
+        .extracting(DaemonSetSpec::getSelector)
         .extracting(LabelSelector::getMatchLabels)
         .asInstanceOf(InstanceOfAssertFactories.MAP)
-        .containsEntry("version", "0.0.1");
+        .containsEntry("group", "groupId")
+        .containsEntry("app", "artifactId")
+        .containsEntry("provider", "jkube")
+        .doesNotContainKey("version");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #3925 (StatefulSet) and #3926 (DaemonSet). The `AbstractLabelEnricher` visitors for these two resources pass `includeVersion=true` when populating `spec.selector.matchLabels`, which makes every version bump produce a manifest rejected by the Kubernetes API (`Forbidden: updates to statefulset spec ...` / `spec.selector: field is immutable`).

This PR aligns both visitors with `DeploymentBuilder` (`false` for the selector). `version` and `app.kubernetes.io/version` still land in `spec.template.metadata.labels` via the `ObjectMetaBuilder` visitor in `enrich()`, so template labels are unchanged.

## Audit

Every `TypedVisitor` in `AbstractLabelEnricher.create()` was checked. Only these two visitors were affected:

| Resource | Before | After |
|---|---|---|
| Service | false | false |
| Deployment | false | false |
| DeploymentConfig | false | false |
| **DaemonSet** | **true** | **false** |
| ReplicationController | false | false |
| ReplicaSet | false | false |
| **StatefulSet** | **true** | **false** |

## Test plan

- `./mvnw -pl jkube-kit/enricher/generic -am clean test` on JDK 17 (matches `build-macos.yml` / `build-windows.yml`): 299 tests pass, including the two new regression tests.
- `ProjectLabelEnricherTest.create_shouldNotAddVersionToStatefulSetSelector` covers StatefulSet.
- `ProjectLabelEnricherTest.create_shouldNotAddVersionToDaemonSetSelector` covers DaemonSet.
- Two existing tests that were locking the buggy behavior (`create_withNoConfiguredVersion_shouldAddDefaultVersionInSelector` and `create_withConfiguredVersion_shouldAddConfiguredVersionInSelector`) are replaced.

## Migration for existing deployments

`spec.selector` on StatefulSet and DaemonSet is immutable in Kubernetes, so already-deployed workloads whose selector currently contains `version` cannot be patched in place. Users will need to recreate the resource once - either `kubectl delete statefulset/daemonset --cascade=orphan <name>` followed by `mvn k8s:apply` (keeps pods running), or a plain delete + apply if brief downtime is acceptable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change
- [ ] Chore (non-breaking change which doesn't affect codebase; test, version modification, documentation, etc.)

## Checklist

- [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
- [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
- [x] My code follows the style guidelines of this project
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
- [x] I have performed a self-review of my code
- [x] I Added [CHANGELOG](../CHANGELOG.md) entry
- [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
- [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I tested my code in Kubernetes
- [ ] I tested my code in OpenShift

Closes #3925
Closes #3926