### PR TITLE
fix(generator): deprecate jkube-jetty9 in favor of jkube-jetty12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Usage:
 
 ### 1.20-SNAPSHOT
 * Fix #3917: Update quickstart image references to jkube-images 0.0.28
+* Fix #3874: Deprecate `jkube-jetty9` base image in favor of `jkube-jetty12`; log a warning when `jkube.generator.webapp.server=jetty9` is explicitly selected
 * Fix #3873: Update JettyAppSeverHandler to select `jkube-jetty12` as the default Jetty image and add `jetty9` opt-in for legacy projects (potentially breaking for legacy JavaEE webapps using `javax.*`; set `jkube.generator.webapp.server=jetty9` to keep Jetty 9)
 * Fix #3918: Update documentation for jkube-images 0.0.28 changes
 * Fix #3902: Bump pack CLI from 0.34.2 to 0.40.7 and update default builder image to `paketobuildpacks/builder-jammy-base`

--- a/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/generator/_webapp.adoc
@@ -53,7 +53,7 @@ In addition to the  <<generator-options-common, common generator options>> this 
 | Element | Description | Property
 
 | *server*
-| Fix server to use in the base image. Can be either **tomcat**, **jetty**, **jetty9** or **wildfly**. Use **jetty9** to select the legacy Jetty 9 base image (`quay.io/jkube/jkube-jetty9`).
+| Fix server to use in the base image. Can be either **tomcat**, **jetty**, **jetty9** (deprecated) or **wildfly**. Use **jetty9** to select the deprecated legacy Jetty 9 base image (`quay.io/jkube/jkube-jetty9`).
 | `jkube.generator.webapp.server`
 
 | *targetDir*
@@ -109,5 +109,7 @@ endif::[]
 ==== JakartaEE and retrocompatibility with JavaEE in Jetty
 From Jetty 12, only JakartaEE compliant projects (Jakarta EE 10 / Servlet 6.x) are supported. The default Jetty base image is now `jkube-jetty12`. Legacy JavaEE projects using `javax.*` packages will not work with this image.
 
-To keep using Jetty 9, set the property `jkube.generator.webapp.server` to `jetty9`. This selects the legacy `quay.io/jkube/jkube-jetty9` base image which supports Servlet 3.x/4.x and `javax.*` packages.
+WARNING: The `jkube-jetty9` base image is *deprecated* and will be removed in a future release. Projects should migrate from `javax.*` to `jakarta.*` packages and use the default `jkube-jetty12` image.
+
+To keep using Jetty 9 temporarily, set the property `jkube.generator.webapp.server` to `jetty9`. This selects the legacy `quay.io/jkube/jkube-jetty9` base image which supports Servlet 3.x/4.x and `javax.*` packages.
 

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
@@ -96,6 +96,11 @@ public class WebAppGenerator extends BaseGenerator {
   @Override
   public List<ImageConfiguration> customize(List<ImageConfiguration> configs, boolean prePackagePhase) {
     final AppServerHandler handler = getAppServerHandler(getContext());
+    if ("jetty9".equals(handler.getName())) {
+      log.warn("The jkube-jetty9 base image is deprecated and will be removed in a future release. " +
+          "Migrate your project from javax.* to jakarta.* packages and set `jkube.generator.webapp.server=jetty` " +
+          "or remove the server property to use the default Jetty 12 image.");
+    }
     if (getContext().getRuntimeMode() == RuntimeMode.OPENSHIFT &&
         getContext().getStrategy() == JKubeBuildStrategy.s2i &&
         !prePackagePhase &&

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppSeverHandler.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/handler/Jetty9AppSeverHandler.java
@@ -17,7 +17,11 @@ import org.eclipse.jkube.generator.api.GeneratorContext;
 
 /**
  * Legacy Jetty 9 handler, opt-in only via {@code jkube.generator.webapp.server=jetty9}.
+ *
+ * @deprecated Use {@link JettyAppSeverHandler} (Jetty 12) instead. Migrate from {@code javax.*} to
+ *   {@code jakarta.*} packages and remove the {@code jkube.generator.webapp.server=jetty9} property.
  */
+@Deprecated
 public class Jetty9AppSeverHandler extends JettyAppSeverHandler {
 
   public Jetty9AppSeverHandler(GeneratorContext context) {

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
@@ -44,6 +44,11 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 class WebAppGeneratorTest {
 
@@ -265,6 +270,65 @@ class WebAppGeneratorTest {
       Map<String, String> extractedVariables = WebAppGenerator.extractEnvVariables(envConfig);
       // then
       assertThat(extractedVariables).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("Jetty 9 deprecation")
+  class Jetty9Deprecation {
+
+    @BeforeEach
+    void setUpJetty9Project() throws IOException {
+      final Path buildDirectory = Files.createDirectory(temporaryFolder.resolve("build-jetty9"));
+      Files.createFile(buildDirectory.resolve("artifact.war"));
+      generatorContext = GeneratorContext.builder()
+        .logger(spy(new KitLogger.SilentLogger()))
+        .project(JavaProject.builder().build())
+        .build();
+      generatorContext.getProject().setBuildDirectory(buildDirectory.toFile());
+      generatorContext.getProject().setBuildFinalName("artifact");
+      generatorContext.getProject().setPackaging("war");
+      generatorContext.getProject().setVersion("1.0.0");
+    }
+
+    @Test
+    @DisplayName("with server=jetty9, should log deprecation warning")
+    void withServerJetty9_shouldLogDeprecationWarning() {
+      // Given
+      final Properties projectProperties = new Properties();
+      projectProperties.put("jkube.generator.webapp.server", "jetty9");
+      generatorContext.getProject().setProperties(projectProperties);
+      // When
+      new WebAppGenerator(generatorContext).customize(new ArrayList<>(), false);
+      // Then
+      verify(generatorContext.getLogger()).warn(argThat(msg ->
+          msg.contains("deprecated") && msg.contains("javax.*") && msg.contains("jakarta.*")));
+    }
+
+    @Test
+    @DisplayName("with server=jetty9 and prePackagePhase, should still log deprecation warning")
+    void withServerJetty9AndPrePackagePhase_shouldLogDeprecationWarning() {
+      // Given
+      final Properties projectProperties = new Properties();
+      projectProperties.put("jkube.generator.webapp.server", "jetty9");
+      generatorContext.getProject().setProperties(projectProperties);
+      // When
+      new WebAppGenerator(generatorContext).customize(new ArrayList<>(), true);
+      // Then
+      verify(generatorContext.getLogger()).warn(contains("deprecated"));
+    }
+
+    @Test
+    @DisplayName("with server=jetty, should not log deprecation warning")
+    void withServerJetty_shouldNotLogDeprecationWarning() {
+      // Given
+      final Properties projectProperties = new Properties();
+      projectProperties.put("jkube.generator.webapp.server", "jetty");
+      generatorContext.getProject().setProperties(projectProperties);
+      // When
+      new WebAppGenerator(generatorContext).customize(new ArrayList<>(), false);
+      // Then
+      verify(generatorContext.getLogger(), never()).warn(contains("deprecated"));
     }
   }
 


### PR DESCRIPTION
## Summary
- Log a deprecation warning when `jkube.generator.webapp.server=jetty9` is explicitly selected, guiding users to migrate from `javax.*` to `jakarta.*` packages and switch to the default Jetty 12 image
- Mark `Jetty9AppSeverHandler` with `@Deprecated` annotation and Javadoc
- Update webapp generator documentation with deprecation notice

Fixes #3874

## Test plan
- [x] New test: `server=jetty9` triggers deprecation warning containing "deprecated", "javax.*", and "jakarta.*"
- [x] New test: `server=jetty9` with `prePackagePhase=true` still triggers deprecation warning
- [x] New test: `server=jetty` does NOT trigger deprecation warning
- [x] Full webapp generator test suite passes (67 tests, 0 failures)