### PR TITLE
test(enricher): pin version label out of controller selectors

### DIFF
--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricherTest.java
@@ -229,6 +229,35 @@ class ProjectLabelEnricherTest {
   }
 
   @Test
+  @DisplayName("StatefulSet: version stays on the (mutable) template labels but not on the (immutable) selector")
+  void createAndEnrich_statefulSet_keepsVersionOnTemplateButNotOnSelector() {
+    // Given
+    KubernetesListBuilder builder = new KubernetesListBuilder().withItems(new StatefulSetBuilder()
+        .withNewMetadata().endMetadata()
+        .withNewSpec()
+        .withNewTemplate().withNewMetadata().endMetadata().endTemplate()
+        .endSpec()
+        .build());
+
+    // When
+    projectLabelEnricher.create(PlatformMode.kubernetes, builder);
+    projectLabelEnricher.enrich(PlatformMode.kubernetes, builder);
+
+    // Then
+    StatefulSet statefulSet = (StatefulSet) builder.buildFirstItem();
+    assertThat(statefulSet)
+        .extracting(StatefulSet::getSpec)
+        .extracting(StatefulSetSpec::getSelector)
+        .extracting(LabelSelector::getMatchLabels)
+        .asInstanceOf(InstanceOfAssertFactories.MAP)
+        .containsEntry("app", "artifactId")
+        .doesNotContainKey("version");
+    assertThat(statefulSet.getSpec().getTemplate().getMetadata().getLabels())
+        .containsEntry("app", "artifactId")
+        .containsEntry("version", "version");
+  }
+
+  @Test
   @DisplayName("when labels configured via resource config's labels > all, then use configured labels")
   void create_whenProjectLabelConfiguredViaResourceConfigLabelAll_thenUseLabelsViaResourceConfig() {
     // Given

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/WellKnownLabelsEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/WellKnownLabelsEnricherTest.java
@@ -398,6 +398,14 @@ class WellKnownLabelsEnricherTest {
           .extracting(field)
           .asInstanceOf(InstanceOfAssertFactories.MAP)
           .containsEntry("app.kubernetes.io/version", "0.0.1");
+    } else {
+      // Selectors must never carry the version label: spec.selector is immutable on
+      // StatefulSet/DaemonSet, so a version bump would make the manifest rejected by the
+      // Kubernetes API (see #3925, #3926). The version belongs on template/metadata labels only.
+      assertThat(hasMetadata)
+          .extracting(field)
+          .asInstanceOf(InstanceOfAssertFactories.MAP)
+          .doesNotContainKey("app.kubernetes.io/version");
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up test coverage for #3927, which stopped the `AbstractLabelEnricher`
StatefulSet and DaemonSet visitors from adding the `version` and
`app.kubernetes.io/version` labels to `spec.selector.matchLabels`. Because
those selectors are immutable, the version label made every version bump
rejected by the Kubernetes API.

Two halves of that fix were not directly pinned by tests; this PR closes both
gaps (test-only, no production changes):

- **`app.kubernetes.io/version` absence (#3926).** `WellKnownLabelsEnricherTest`
  already parameterized over DaemonSet/StatefulSet selectors but invoked its
  assertion helper with `containsVersion=false`, which skipped the version
  check. The helper now asserts `doesNotContainKey("app.kubernetes.io/version")`
  on that path, so every controller selector is verified free of the well-known
  version label.
- **Version retained on the template.** `ProjectLabelEnricherTest` gains a
  combined `create()` + `enrich()` test asserting `version` is absent from the
  StatefulSet selector but present on `spec.template.metadata.labels`, locking
  the invariant that the selector stays a subset of the (mutable) template
  labels.

Mutation-checked: reverting a visitor to `includeVersion=true` fails the
corresponding new assertions.

Refs #3925, #3926, #3927