### PR TITLE
fix(spring-boot): use project outputDirectory for DevTools watcher paths (3947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.20-SNAPSHOT
+* Fix #3947: Spring Boot DevTools watcher resolves `application.properties` from `project.resourcesOutputDirectory` for Gradle compatibility
 * Fix #3916: Add explicit base-image JDK selection via `jkube.java.version` property for Java generators
 * Fix #3925: StatefulSet selector.matchLabels no longer includes version label (immutable field, prevented redeploy after version bump)
 * Fix #3926: DaemonSet selector.matchLabels no longer includes version label (immutable field, prevented redeploy after version bump)

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
@@ -57,6 +57,7 @@ import org.gradle.internal.deprecation.DeprecatableConfiguration;
 public class GradleUtil {
 
   private static final Path DEFAULT_CLASSES_DIR = Paths.get("classes", "java", "main");
+  private static final Path DEFAULT_RESOURCES_DIR = Paths.get("resources", "main");
 
   private GradleUtil() {}
 
@@ -83,6 +84,7 @@ public class GradleUtil {
 //        .organizationName(gradleProject.)
 //
         .outputDirectory(findClassesOutputDirectory(gradleProject))
+        .resourcesOutputDirectory(findResourcesOutputDirectory(gradleProject))
 //        .buildFinalName(gradleProject.)
         .buildDirectory(gradleProject.getBuildDir())
 //        .issueManagementSystem(gradleProject.)
@@ -187,6 +189,18 @@ public class GradleUtil {
       // No matching SourceSet was found
     }
     return gradleProject.getBuildDir().toPath().resolve(DEFAULT_CLASSES_DIR).toFile();
+  }
+
+  private static File findResourcesOutputDirectory(Project gradleProject) {
+    try {
+      final SourceSetContainer sourceSetContainer = extractSourceSets(gradleProject);
+      if (sourceSetContainer != null) {
+        return sourceSetContainer.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getResourcesDir();
+      }
+    } catch (IllegalStateException | UnknownDomainObjectException ex) {
+      // No matching SourceSet was found
+    }
+    return gradleProject.getBuildDir().toPath().resolve(DEFAULT_RESOURCES_DIR).toFile();
   }
 
   private static File findArtifact(Project gradleProject) {

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/GradleUtilTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/GradleUtilTest.java
@@ -274,6 +274,39 @@ class GradleUtilTest {
   }
 
   @Test
+  void findResourcesOutputDirectory_withNotFoundSourceSet_shouldReturnDefault() {
+    // Given
+    when(javaPlugin.getSourceSets().getByName("main")).thenThrow(new UnknownDomainObjectException("Not found"));
+    // When
+    final JavaProject result = convertGradleProject(project);
+    // Then
+    assertThat(result.getResourcesOutputDirectory())
+        .isEqualTo(folder.resolve("build").resolve("resources").resolve("main").toFile());
+  }
+
+  @Test
+  void findResourcesOutputDirectory_withValidSourceSet_shouldReturnFromSourceSet() {
+    // Given
+    when(javaPlugin.getSourceSets().getByName("main").getOutput().getResourcesDir())
+        .thenReturn(new File("resources"));
+    // When
+    final JavaProject result = convertGradleProject(project);
+    // Then
+    assertThat(result.getResourcesOutputDirectory()).isEqualTo(new File("resources"));
+  }
+
+  @Test
+  void findResourcesOutputDirectory_withNoSourceSets_shouldReturnDefault() {
+    // Given
+    when(javaPlugin.getSourceSets()).thenReturn(null);
+    // When
+    final JavaProject result = convertGradleProject(project);
+    // Then
+    assertThat(result.getResourcesOutputDirectory())
+        .isEqualTo(folder.resolve("build").resolve("resources").resolve("main").toFile());
+  }
+
+  @Test
   void findArtifact_withExistentFile_shouldReturnValidArtifact() throws IOException {
     // Given
     final Configuration c = mock(Configuration.class, RETURNS_DEEP_STUBS);

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/JavaProject.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/JavaProject.java
@@ -74,6 +74,16 @@ public class JavaProject implements Serializable {
    */
   private File outputDirectory;
   /**
+   * Directory where processed resources are located.
+   * For Maven this is the same as {@link #outputDirectory} (e.g. target/classes).
+   * For Gradle this is a separate directory (e.g. build/resources/main).
+   * Defaults to {@link #outputDirectory} when not explicitly set.
+   *
+   * @param resourcesOutputDirectory New resources output directory for the project.
+   * @return The resources output directory for the project.
+   */
+  private File resourcesOutputDirectory;
+  /**
    * Project's base directory
    *
    * @param baseDirectory New base directory for the project.
@@ -257,7 +267,8 @@ public class JavaProject implements Serializable {
   @Builder(toBuilder = true)
   public JavaProject(
       String name, String groupId, String artifactId, String version,
-      File outputDirectory, File baseDirectory, File buildDirectory, File buildPackageDirectory,
+      File outputDirectory, File resourcesOutputDirectory,
+      File baseDirectory, File buildDirectory, File buildPackageDirectory,
       Properties properties, @Singular List<String> compileClassPathElements, @Singular List<Dependency> dependencies,
       List<Dependency> dependenciesWithTransitive, @Singular List<Plugin> plugins, @Singular List<String> gradlePlugins,
       String site, String description, String organizationName, String documentationUrl, LocalDate buildDate,
@@ -270,6 +281,7 @@ public class JavaProject implements Serializable {
     this.artifactId = artifactId;
     this.version = version;
     this.outputDirectory = outputDirectory;
+    this.resourcesOutputDirectory = Optional.ofNullable(resourcesOutputDirectory).orElse(outputDirectory);
     this.baseDirectory = baseDirectory;
     this.buildDirectory = buildDirectory;
     this.properties = Optional.ofNullable(properties).orElse(new Properties());

--- a/jkube-kit/jkube-kit-spring-boot/pom.xml
+++ b/jkube-kit/jkube-kit-spring-boot/pom.xml
@@ -95,4 +95,24 @@
         </resources>
     </build>
 
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <!-- Split tests across 2 JVM forks to avoid a JVM crash caused by
+                                 cumulative classloader pressure from JaCoCo + byte-buddy instrumentation
+                                 in container environments (JDK-8254969). -->
+                            <forkCount>2</forkCount>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/SpringBootDevtoolsUtils.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/SpringBootDevtoolsUtils.java
@@ -61,12 +61,11 @@ public class SpringBootDevtoolsUtils {
 
     // We always add to application.properties, even when an application.yml exists, since both
     // files are evaluated by Spring Boot.
-    appendSecretTokenToFile(project, "target/classes/application.properties", newToken);
-    appendSecretTokenToFile(project, "src/main/resources/application.properties", newToken);
+    appendSecretTokenToFile(new File(project.getResourcesOutputDirectory(), "application.properties"), newToken);
+    appendSecretTokenToFile(new File(project.getBaseDirectory(), "src/main/resources/application.properties"), newToken);
   }
 
-  private static void appendSecretTokenToFile(JavaProject project, String path, String token) {
-    File file = new File(project.getBaseDirectory(), path);
+  private static void appendSecretTokenToFile(File file, String token) {
     try {
       FileUtil.createDirectory(file.getParentFile());
     } catch (IOException ioException) {
@@ -92,7 +91,7 @@ public class SpringBootDevtoolsUtils {
     File target = getFatJarFile(fatJarDetectResult);
     try {
       File devToolsFile = getSpringBootDevToolsJar(project);
-      File applicationPropertiesFile = new File(project.getBaseDirectory(), "target/classes/application.properties");
+      File applicationPropertiesFile = new File(project.getResourcesOutputDirectory(), "application.properties");
       copyFilesToFatJar(Collections.singletonList(devToolsFile), Collections.singletonList(applicationPropertiesFile), target);
     } catch (Exception e) {
       throw new IllegalStateException("Failed to add devtools files to fat jar " + target + ". " + e, e);

--- a/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/SpringBootDevtoolsUtilsTest.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/SpringBootDevtoolsUtilsTest.java
@@ -162,6 +162,7 @@ class SpringBootDevtoolsUtilsTest {
     assertThat(devtoolsJar.createNewFile()).isTrue();
     assertThat(outputApplicationProperties.createNewFile()).isTrue();
     JavaProject javaProject = createSpringBootJavaProject().toBuilder()
+        .outputDirectory(outputClassesDir)
         .dependency(Dependency.builder()
             .groupId("org.springframework.boot")
             .artifactId("spring-boot-devtools")
@@ -184,10 +185,85 @@ class SpringBootDevtoolsUtilsTest {
     }
   }
 
+  @Test
+  void ensureSpringDevToolSecretToken_whenGradleProject_thenAppendTokenToResourcesOutputDirectory() throws IOException {
+    // Given
+    JavaProject javaProject = createGradleSpringBootJavaProject();
+
+    // When
+    boolean result = SpringBootDevtoolsUtils.ensureSpringDevToolSecretToken(javaProject);
+
+    // Then
+    assertThat(result).isFalse();
+    Path srcApplicationProperties = temporaryFolder.toPath()
+        .resolve("src").resolve("main").resolve("resources").resolve("application.properties");
+    Path resourcesApplicationProperties = temporaryFolder.toPath()
+        .resolve("build").resolve("resources").resolve("main").resolve("application.properties");
+    assertThat(new String(Files.readAllBytes(srcApplicationProperties)))
+        .contains("# Remote secret added by jkube-kit-plugin")
+        .contains("spring.devtools.remote.secret=");
+    assertThat(new String(Files.readAllBytes(resourcesApplicationProperties)))
+        .contains("# Remote secret added by jkube-kit-plugin")
+        .contains("spring.devtools.remote.secret=");
+  }
+
+  @Test
+  void addDevToolsFilesToFatJar_whenGradleProject_thenFatJarUpdated() throws IOException {
+    // Given
+    File resourcesDir = temporaryFolder.toPath()
+        .resolve("build").resolve("resources").resolve("main").toFile();
+    assertThat(resourcesDir.mkdirs()).isTrue();
+    File resourcesApplicationProperties = new File(resourcesDir, "application.properties");
+    assertThat(resourcesApplicationProperties.createNewFile()).isTrue();
+    File buildDir = new File(temporaryFolder, "build");
+    File fatJar = new File(buildDir, "libs/fat.jar");
+    assertThat(fatJar.getParentFile().mkdirs()).isTrue();
+    assertThat(fatJar.createNewFile()).isTrue();
+    createDummyJar(fatJar);
+    File devtoolsJar = new File(temporaryFolder, "spring-boot-devtools-2.7.2.jar");
+    assertThat(devtoolsJar.createNewFile()).isTrue();
+    JavaProject javaProject = createGradleSpringBootJavaProject().toBuilder()
+        .dependency(Dependency.builder()
+            .groupId("org.springframework.boot")
+            .artifactId("spring-boot-devtools")
+            .version("2.7.2")
+            .type("jar")
+            .file(devtoolsJar)
+            .build())
+        .build();
+    FatJarDetector.Result fatJarDetectorResult = mock(FatJarDetector.Result.class);
+    when(fatJarDetectorResult.getArchiveFile()).thenReturn(fatJar);
+
+    // When
+    SpringBootDevtoolsUtils.addDevToolsFilesToFatJar(javaProject, fatJarDetectorResult);
+
+    // Then
+    assertThat(fatJar).isNotEmpty();
+    try (JarFile jarFile = new JarFile(fatJar)) {
+      assertThat(jarFile.getJarEntry("BOOT-INF/lib/spring-boot-devtools-2.7.2.jar")).isNotNull();
+      assertThat(jarFile.getJarEntry("BOOT-INF/classes/application.properties")).isNotNull();
+    }
+  }
+
   private JavaProject createSpringBootJavaProject() {
     return JavaProject.builder()
         .baseDirectory(temporaryFolder)
-        .outputDirectory(temporaryFolder.toPath().resolve("target").toFile())
+        .outputDirectory(temporaryFolder.toPath().resolve("target").resolve("classes").toFile())
+        .dependency(Dependency.builder()
+            .groupId("org.springframework.boot")
+            .artifactId("spring-boot-web")
+            .version("2.7.2")
+            .build())
+        .build();
+  }
+
+  private JavaProject createGradleSpringBootJavaProject() {
+    return JavaProject.builder()
+        .baseDirectory(temporaryFolder)
+        .outputDirectory(temporaryFolder.toPath().resolve("build").resolve("classes")
+            .resolve("java").resolve("main").toFile())
+        .resourcesOutputDirectory(temporaryFolder.toPath().resolve("build").resolve("resources")
+            .resolve("main").toFile())
         .dependency(Dependency.builder()
             .groupId("org.springframework.boot")
             .artifactId("spring-boot-web")

--- a/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/generator/SpringBootGeneratorIntegrationTest.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/generator/SpringBootGeneratorIntegrationTest.java
@@ -61,11 +61,12 @@ class SpringBootGeneratorIntegrationTest {
   void setUp(@TempDir Path temporaryFolder) throws IOException {
     properties = new Properties();
     targetDir = Files.createDirectory(temporaryFolder.resolve("target")).toFile();
+    final File classesDir = Files.createDirectory(targetDir.toPath().resolve("classes")).toFile();
     final JavaProject javaProject = JavaProject.builder()
         .baseDirectory(temporaryFolder.toFile())
         .buildDirectory(targetDir.getAbsoluteFile())
         .buildPackageDirectory(targetDir.getAbsoluteFile())
-        .outputDirectory(targetDir)
+        .outputDirectory(classesDir)
         .properties(properties)
         .version("1.0.0")
         .dependency(Dependency.builder()
@@ -292,9 +293,8 @@ class SpringBootGeneratorIntegrationTest {
     @DisplayName("with generator mode WATCH, then add Spring Boot Devtools environment variable to image")
     void withGeneratorModeWatch_shouldAddSpringBootDevtoolsSecretEnvVar() throws IOException {
       // Given
-      final Path applicationProperties = Files.createFile(
-        Files.createDirectory(targetDir.toPath().resolve("classes"))
-          .resolve("application.properties"));
+      Files.write(targetDir.toPath().resolve("classes").resolve("application.properties"),
+        "spring.devtools.remote.secret=some-secret".getBytes());
       context = context.toBuilder()
         .generatorMode(GeneratorMode.WATCH)
         .project(context.getProject().toBuilder()


### PR DESCRIPTION
## Summary
- Add `resourcesOutputDirectory` field to `JavaProject` that defaults to `outputDirectory` when not set, preserving Maven behavior where `target/classes` contains both compiled classes and processed resources
- Populate it from Gradle's `SourceSet.getOutput().getResourcesDir()` API, resolving to `build/resources/main`
- Use `resourcesOutputDirectory` in `SpringBootDevtoolsUtils` for `application.properties` resolution in both `addSecretTokenToApplicationProperties` and `addDevToolsFilesToFatJar`
- In Gradle, compiled classes (`build/classes/java/main`) and processed resources (`build/resources/main`) are in separate directories, unlike Maven which merges both into `target/classes`. The old code hardcoded `target/classes`, causing `FileNotFoundException` when running `k8sWatch`/`ocWatch` on Gradle Spring Boot projects

## Changes
| File | Change |
|------|--------|
| `JavaProject.java` | New `resourcesOutputDirectory` field with fallback to `outputDirectory` |
| `GradleUtil.java` | New `findResourcesOutputDirectory()` using `SourceSet.getOutput().getResourcesDir()` |
| `GradleUtilTest.java` | 3 new tests for resources output directory resolution |
| `SpringBootDevtoolsUtils.java` | Use `getResourcesOutputDirectory()` instead of hardcoded path |
| `SpringBootDevtoolsUtilsTest.java` | 2 new Gradle tests with realistic `build/resources/main` layout |
| `SpringBootGeneratorIntegrationTest.java` | Fix `outputDirectory` to `target/classes` (correct Maven value) |

## Test plan
- [x] `SpringBootDevtoolsUtilsTest` — 9 tests pass (7 existing + 2 new Gradle tests)
- [x] `SpringBootGeneratorIntegrationTest` — 20 tests pass
- [x] `GradleUtilTest` — 20 tests pass (17 existing + 3 new)
- [x] Full `jkube-kit-spring-boot` module — 221 tests pass

Fixes #3947