### PR TITLE
fix: log pack CLI stderr on build failure in BuildPackCliController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.20-SNAPSHOT
+* Fix #3903: Log pack CLI stderr output via kitLogger.error on buildpacks build failure
 * Fix #3923: Jetty 12 hot deployment in `k8s:watch`/`oc:watch` copy mode (`scanInterval=1` set by the Jetty handler when watch mode is `copy`)
 * Fix #3923: Gradle `k8sWatch`/`ocWatch` now resolve generators in WATCH mode (previously BUILD), activating Spring Boot DevTools wiring that was previously only functional in the Maven plugin
 * Fix #3947: Spring Boot DevTools watcher resolves `application.properties` from `project.resourcesOutputDirectory` for Gradle compatibility

--- a/jkube-kit/build/service/buildpacks/src/main/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCommand.java
+++ b/jkube-kit/build/service/buildpacks/src/main/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCommand.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 public class BuildPackCommand extends ExternalCommand {
   private final File packCli;
   private final List<String> commandLineArgs;
-  private final StringBuilder errorBuilder;
+  private final StringBuffer errorBuilder;
   private final Consumer<String> commandOutputConsumer;
 
   public BuildPackCommand(KitLogger log, File packCli, List<String> cmdArgs, Consumer<String> outputConsumer) {
@@ -32,7 +32,7 @@ public class BuildPackCommand extends ExternalCommand {
     this.packCli = packCli;
     this.commandLineArgs = cmdArgs;
     this.commandOutputConsumer = outputConsumer;
-    this.errorBuilder = new StringBuilder();
+    this.errorBuilder = new StringBuffer();
   }
 
   @Override
@@ -50,7 +50,7 @@ public class BuildPackCommand extends ExternalCommand {
 
   @Override
   public void processError(String error) {
-    errorBuilder.append(error).append(System.lineSeparator());
+    errorBuilder.append(error + System.lineSeparator());
   }
 
   public String getError() {

--- a/jkube-kit/build/service/buildpacks/src/main/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCommand.java
+++ b/jkube-kit/build/service/buildpacks/src/main/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCommand.java
@@ -50,7 +50,7 @@ public class BuildPackCommand extends ExternalCommand {
 
   @Override
   public void processError(String error) {
-    errorBuilder.append(error);
+    errorBuilder.append(error).append(System.lineSeparator());
   }
 
   public String getError() {

--- a/jkube-kit/build/service/buildpacks/src/main/java/org/eclipse/jkube/kit/service/buildpacks/controller/BuildPackCliController.java
+++ b/jkube-kit/build/service/buildpacks/src/main/java/org/eclipse/jkube/kit/service/buildpacks/controller/BuildPackCliController.java
@@ -46,6 +46,10 @@ public class BuildPackCliController implements BuildPackController {
     try {
       buildPackCommand.execute();
     } catch (IOException e) {
+      String stderr = buildPackCommand.getError();
+      if (StringUtils.isNotBlank(stderr)) {
+        kitLogger.error("%s", stderr.trim());
+      }
       throw new IllegalStateException("Process Existed With : " + buildPackCommand.getExitCode() + " [" + e.getMessage() + "]", e);
     }
   }
@@ -57,6 +61,10 @@ public class BuildPackCliController implements BuildPackController {
     try {
       versionCommand.execute();
     } catch (IOException e) {
+      String stderr = versionCommand.getError();
+      if (StringUtils.isNotBlank(stderr)) {
+        kitLogger.error("%s", stderr.trim());
+      }
       kitLogger.warn(e.getMessage());
     }
     if (StringUtils.isNotBlank(versionRef.get())) {

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCliControllerTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCliControllerTest.java
@@ -21,9 +21,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.ArgumentCaptor;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.PrintStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
@@ -32,13 +33,9 @@ import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 class BuildPackCliControllerTest {
+  private ByteArrayOutputStream out;
   private KitLogger kitLogger;
   private BuildPackCliController buildPackCliController;
   private BuildPackBuildOptions buildOptions;
@@ -49,7 +46,8 @@ class BuildPackCliControllerTest {
 
   @BeforeEach
   void setUp() throws URISyntaxException {
-    kitLogger = spy(new KitLogger.SilentLogger());
+    out = new ByteArrayOutputStream();
+    kitLogger = new KitLogger.PrintStreamLogger(new PrintStream(out));
     String validPackBinary = EnvUtil.isWindows() ? "pack.bat" : "pack";
     pack = resourceAsFile(String.format("/%s", validPackBinary));
     buildPackCliController = new BuildPackCliController(pack, kitLogger);
@@ -76,7 +74,9 @@ class BuildPackCliControllerTest {
       buildPackCliController.build(buildOptions);
 
       // Then
-      verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder foo/builder:base --creation-time now --path " + temporaryFolder.getAbsolutePath());
+      assertThat(out.toString())
+          .contains("[INFO] [[s]]build foo/bar:latest --builder foo/builder:base --creation-time now --path "
+              + temporaryFolder.getAbsolutePath());
     }
 
     @Test
@@ -93,7 +93,19 @@ class BuildPackCliControllerTest {
       // When
       buildPackCliController.build(buildOptions);
       // Then
-      verify(kitLogger).info("[[s]]%s", "build foo/bar:latest --builder foo/builder:base --creation-time now --pull-policy if-not-present --volume /tmp/volume:/platform/volume:ro --tag foo/bar:t1 --tag foo/bar:t2 --tag foo/bar:t3 --env BP_SPRING_CLOUD_BINDINGS_DISABLED=true --clear-cache --path " + temporaryFolder.getAbsolutePath());
+      assertThat(out.toString())
+          .contains("[INFO] [[s]]build foo/bar:latest --builder foo/builder:base --creation-time now --pull-policy if-not-present --volume /tmp/volume:/platform/volume:ro --tag foo/bar:t1 --tag foo/bar:t2 --tag foo/bar:t3 --env BP_SPRING_CLOUD_BINDINGS_DISABLED=true --clear-cache --path "
+              + temporaryFolder.getAbsolutePath());
+    }
+
+    @Test
+    @DisplayName("build, should not log any error")
+    void build_whenCommandSucceeds_thenNothingLoggedAsError() {
+      // When
+      buildPackCliController.build(buildOptions);
+
+      // Then
+      assertThat(out.toString()).doesNotContain("[ERROR]");
     }
 
     @Test
@@ -118,14 +130,16 @@ class BuildPackCliControllerTest {
     }
 
     @Test
-    @DisplayName("build, throws exception without logging to error when stderr is blank")
+    @DisplayName("build, throws exception and logs no empty error when pack writes nothing to stderr")
     void build_whenCommandFailed_thenThrowException() {
       // When + Then
       assertThatIllegalStateException()
           .isThrownBy(() -> buildPackCliController.build(buildOptions))
           .withMessageContaining("Process Existed With : 1");
-      // No spurious [ERROR] line when pack writes nothing to stderr
-      verify(kitLogger, never()).error(anyString(), (Object) any());
+      // Without the isNotBlank guard, a blank stderr would be rendered as an empty "[ERROR] " record.
+      // Asserting on that (rather than on the absence of any error) keeps the test independent from
+      // whatever the shell running the fixture may write to stderr on its own (locale warnings, ...).
+      assertThat(out.toString()).doesNotContain("[ERROR] " + System.lineSeparator());
     }
 
     @Test
@@ -150,23 +164,19 @@ class BuildPackCliControllerTest {
     }
 
     @Test
-    @DisplayName("build, logs stderr via kitLogger.error when pack CLI writes to stderr")
-    void build_whenCommandFailedWithStderr_thenStderrLoggedViaKitLogger() {
+    @DisplayName("build, logs the pack CLI stderr as error, preserving line boundaries")
+    void build_whenCommandFailedWithStderr_thenStderrLogged() {
       // When + Then
       assertThatIllegalStateException()
           .isThrownBy(() -> buildPackCliController.build(buildOptions))
           .withMessageContaining("Process Existed With : 1");
-
-      // Capture the argument passed to kitLogger.error to verify stderr content.
-      // Using contains() rather than exact equality keeps the assertion robust across
-      // environments (locale warnings, line-separator differences) and locks in the
-      // "%s" format-string wrapper that prevents UnknownFormatConversionException on
-      // pack output containing literal % characters.
-      ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
-      verify(kitLogger).error(anyString(), captor.capture());
-      String logged = (String) captor.getValue();
-      assertThat(logged).contains("builder image not found");
-      assertThat(logged).contains("100%");
+      // Asserting on the rendered output (rather than the format string and its arguments)
+      // also covers the "%s" wrapper: passing the stderr as the format string instead would
+      // make printf fail on the literal % below.
+      assertThat(out.toString())
+          .contains("[ERROR] ")
+          .contains("ERROR: pack CLI failed: builder image not found" + System.lineSeparator()
+              + "goroutine 1 [running]: 100% complete");
     }
   }
 }

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCliControllerTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCliControllerTest.java
@@ -21,14 +21,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -42,10 +48,10 @@ class BuildPackCliControllerTest {
   private File temporaryFolder;
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws URISyntaxException {
     kitLogger = spy(new KitLogger.SilentLogger());
     String validPackBinary = EnvUtil.isWindows() ? "pack.bat" : "pack";
-    pack = new File(Objects.requireNonNull(getClass().getResource(String.format("/%s", validPackBinary))).getFile());
+    pack = resourceAsFile(String.format("/%s", validPackBinary));
     buildPackCliController = new BuildPackCliController(pack, kitLogger);
     buildOptions = BuildPackBuildOptions.builder()
         .imageName("foo/bar:latest")
@@ -53,6 +59,11 @@ class BuildPackCliControllerTest {
         .creationTime("now")
         .path(temporaryFolder.getAbsolutePath())
         .build();
+  }
+
+  private File resourceAsFile(String resourcePath) throws URISyntaxException {
+    URL url = Objects.requireNonNull(getClass().getResource(resourcePath));
+    return new File(url.toURI());
   }
 
   @Nested
@@ -100,19 +111,21 @@ class BuildPackCliControllerTest {
   @DisplayName("pack command fails")
   class CommandFails {
     @BeforeEach
-    void setUp() {
+    void setUp() throws URISyntaxException {
       String invalidPackBinary = EnvUtil.isWindows() ? "invalid-pack.bat" : "invalid-pack";
-      pack = new File(Objects.requireNonNull(BuildPackCliControllerTest.class.getResource(String.format("/%s", invalidPackBinary))).getFile());
+      pack = resourceAsFile(String.format("/%s", invalidPackBinary));
       buildPackCliController = new BuildPackCliController(pack, kitLogger);
     }
 
     @Test
-    @DisplayName("build, throws exception")
+    @DisplayName("build, throws exception without logging to error when stderr is blank")
     void build_whenCommandFailed_thenThrowException() {
       // When + Then
       assertThatIllegalStateException()
           .isThrownBy(() -> buildPackCliController.build(buildOptions))
           .withMessageContaining("Process Existed With : 1");
+      // No spurious [ERROR] line when pack writes nothing to stderr
+      verify(kitLogger, never()).error(anyString(), (Object) any());
     }
 
     @Test
@@ -123,6 +136,37 @@ class BuildPackCliControllerTest {
 
       // Then
       assertThat(version).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("pack command fails with stderr output")
+  class CommandFailsWithStderr {
+    @BeforeEach
+    void setUp() throws URISyntaxException {
+      String invalidPackBinaryWithError = EnvUtil.isWindows() ? "invalid-pack-with-error.bat" : "invalid-pack-with-error";
+      pack = resourceAsFile(String.format("/%s", invalidPackBinaryWithError));
+      buildPackCliController = new BuildPackCliController(pack, kitLogger);
+    }
+
+    @Test
+    @DisplayName("build, logs stderr via kitLogger.error when pack CLI writes to stderr")
+    void build_whenCommandFailedWithStderr_thenStderrLoggedViaKitLogger() {
+      // When + Then
+      assertThatIllegalStateException()
+          .isThrownBy(() -> buildPackCliController.build(buildOptions))
+          .withMessageContaining("Process Existed With : 1");
+
+      // Capture the argument passed to kitLogger.error to verify stderr content.
+      // Using contains() rather than exact equality keeps the assertion robust across
+      // environments (locale warnings, line-separator differences) and locks in the
+      // "%s" format-string wrapper that prevents UnknownFormatConversionException on
+      // pack output containing literal % characters.
+      ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+      verify(kitLogger).error(anyString(), captor.capture());
+      String logged = (String) captor.getValue();
+      assertThat(logged).contains("builder image not found");
+      assertThat(logged).contains("100%");
     }
   }
 }

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCommandTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCommandTest.java
@@ -15,11 +15,16 @@ package org.eclipse.jkube.kit.service.buildpacks;
 
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -63,6 +68,56 @@ class BuildPackCommandTest {
     // When
     buildPackCommand.processError("Failure in running pack Cli");
     // Then
-    assertThat(buildPackCommand.getError()).isEqualTo("Failure in running pack Cli");
+    assertThat(buildPackCommand.getError()).isEqualTo("Failure in running pack Cli" + System.lineSeparator());
+  }
+
+  @Test
+  @DisplayName("processError is invoked from the stderr pump thread while the caller thread may "
+      + "read getError(), so the accumulated error must not lose or interleave lines")
+  void processError_whenInvokedConcurrently_shouldNotLoseOrCorruptLines() throws InterruptedException {
+    // Given
+    AtomicReference<String> version = new AtomicReference<>();
+    BuildPackCommand buildPackCommand = new BuildPackCommand(kitLogger, packCli, Collections.singletonList("--version"), version::set);
+    String line = "ERROR: failed with status code: 2";
+    int threads = 8;
+    int linesPerThread = 500;
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(threads);
+    ExecutorService executor = Executors.newFixedThreadPool(threads);
+    // When
+    try {
+      for (int t = 0; t < threads; t++) {
+        executor.submit(() -> {
+          start.await();
+          for (int i = 0; i < linesPerThread; i++) {
+            buildPackCommand.processError(line);
+          }
+          done.countDown();
+          return null;
+        });
+      }
+      start.countDown();
+      assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      executor.shutdownNow();
+    }
+    // Then
+    assertThat(buildPackCommand.getError().split(System.lineSeparator()))
+        .hasSize(threads * linesPerThread)
+        .containsOnly(line);
+  }
+
+  @Test
+  void processError_whenInvokedForEachLine_shouldPreserveLineBoundaries() {
+    // Given
+    AtomicReference<String> version = new AtomicReference<>();
+    BuildPackCommand buildPackCommand = new BuildPackCommand(kitLogger, packCli, Collections.singletonList("--version"), version::set);
+    // When
+    buildPackCommand.processError("ERROR: failed to build: executing lifecycle");
+    buildPackCommand.processError("ERROR: failed with status code: 2");
+    // Then
+    assertThat(buildPackCommand.getError())
+        .isEqualTo("ERROR: failed to build: executing lifecycle" + System.lineSeparator()
+            + "ERROR: failed with status code: 2" + System.lineSeparator());
   }
 }

--- a/jkube-kit/build/service/buildpacks/src/test/resources/invalid-pack-with-error
+++ b/jkube-kit/build/service/buildpacks/src/test/resources/invalid-pack-with-error
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "ERROR: pack CLI failed: builder image not found" >&2
+echo "goroutine 1 [running]: 100% complete" >&2
+exit 1

--- a/jkube-kit/build/service/buildpacks/src/test/resources/invalid-pack-with-error.bat
+++ b/jkube-kit/build/service/buildpacks/src/test/resources/invalid-pack-with-error.bat
@@ -1,0 +1,5 @@
+@echo off
+echo ERROR: pack CLI failed: builder image not found>&2
+echo goroutine 1 [running]: 100%% complete>&2
+EXIT /b 1
+


### PR DESCRIPTION
## Description

Fixes #3903

When a buildpacks build fails, the pack CLI stderr was silently discarded.
Users only saw a generic `Process Existed With : 1` message, making it
impossible to diagnose the actual failure (e.g. missing builder image,
architecture mismatch, Go runtime panic) without manual debugging.

**Root cause:** `BuildPackCommand` captures stderr into a buffer but never
logs it, and `BuildPackCliController` caught the `IOException` from
`execute()` without ever calling `buildPackCommand.getError()`. The
`getError()` method had no production caller at all.

**Changes:**

* `BuildPackCliController.build()` reads `getError()` in the catch block and
  forwards it to `kitLogger.error("%s", ...)` before rethrowing, so the actual
  failure reason appears in the build output. The stderr is passed as a format
  *argument* rather than as the format string: pack output routinely contains
  literal `%` (progress percentages), which would otherwise blow up
  `String.format`/`printf` inside the error handler.
* `BuildPackCliController.version()` gets the same treatment, so a failing
  `pack --version` (wrong-architecture binary, missing shared library) no
  longer loses its diagnostic either.
* `BuildPackCommand.processError()` now terminates each captured line with
  `System.lineSeparator()`. `ExternalCommand` dispatches stderr line by line
  with the terminator already stripped, so without this the multi-line
  lifecycle stack traces that motivated this issue were concatenated into a
  single unreadable run-on line. The line and its separator are appended in a
  single operation on a `StringBuffer`, because `processError` runs on the
  stderr pump thread while the caller thread reads `getError()`.

**Tests:**

* New `invalid-pack-with-error` / `invalid-pack-with-error.bat` fixtures emit
  two stderr lines, one of them containing a literal `%`, and exit non-zero.
* `BuildPackCliControllerTest` no longer uses Mockito spies on `KitLogger`; it
  captures the rendered output via `KitLogger.PrintStreamLogger` over a
  `ByteArrayOutputStream` and asserts on it with AssertJ, matching the pattern
  used elsewhere in the codebase. This also means the `%`-in-stderr case is
  genuinely exercised through `printf` rather than only inspected as an
  argument.
* Coverage added for the paths that previously had none: successful build logs
  no error, failed build with blank stderr logs no empty `[ERROR]` record, and
  concurrent `processError` invocations neither lose nor interleave lines.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
- [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
- [x] My code follows the style guidelines of this project
- [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
- [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
- [x] I have performed a self-review of my code
- [x] I Added [CHANGELOG](../CHANGELOG.md) entry
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I tested my code in Kubernetes
- [ ] I tested my code in OpenShift
