### PR TITLE
fix: add SHA-256 checksum verification for pack CLI binary downloads …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.21-SNAPSHOT
+* Fix #3910: Add SHA-256 checksum verification for pack CLI binary downloads to prevent MITM/integrity attacks
 
 ### 1.20.0 (2026-07-21)
 * Fix #3903: Log pack CLI stderr output via kitLogger.error on buildpacks build failure

--- a/jkube-kit/build/service/buildpacks/src/main/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCliDownloader.java
+++ b/jkube-kit/build/service/buildpacks/src/main/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCliDownloader.java
@@ -20,21 +20,26 @@ import org.eclipse.jkube.kit.common.util.PropertiesUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.eclipse.jkube.kit.common.archive.ArchiveDecompressor.extractArchive;
 import static org.eclipse.jkube.kit.common.util.EnvUtil.findBinaryFileInUserPath;
 import static org.eclipse.jkube.kit.common.util.EnvUtil.getProcessorArchitecture;
 import static org.eclipse.jkube.kit.common.util.EnvUtil.isMacOs;
 import static org.eclipse.jkube.kit.common.util.EnvUtil.isWindows;
 import static org.eclipse.jkube.kit.common.util.EnvUtil.getUserHome;
-import static org.eclipse.jkube.kit.common.util.IoUtil.downloadArchive;
+import static org.eclipse.jkube.kit.common.util.IoUtil.downloadFile;
 import static org.eclipse.jkube.kit.common.util.SemanticVersionUtil.removeBuildMetadata;
 
 public class BuildPackCliDownloader {
@@ -46,6 +51,8 @@ public class BuildPackCliDownloader {
   private static final String PACK_CLI_MACOS_ARTIFACT = "macos.artifact";
   private static final String PACK_CLI_MACOS_ARM64_ARTIFACT = "macos-arm64.artifact";
   private static final String PACK_CLI_WINDOWS_ARTIFACT = "windows.artifact";
+  private static final String SHA256_SUFFIX = ".sha256";
+  private static final String SHA256_ALGORITHM = "SHA-256";
 
   private final KitLogger kitLogger;
   private final String packCliVersion;
@@ -85,11 +92,16 @@ public class BuildPackCliDownloader {
   private void downloadPackCli() throws IOException {
     File tempDownloadDirectory = FileUtil.createTempDirectory();
     FileUtil.createDirectory(jKubeUserHomeDir);
-    URL downloadUrl = new URL(inferApplicableDownloadArtifactUrl());
+    String artifactUrlString = inferApplicableDownloadArtifactUrl();
+    URL downloadUrl = new URL(artifactUrlString);
     Path packInJKubeDir = resolveBinaryLocation();
     kitLogger.info("Downloading pack CLI %s", packCliVersion);
 
-    downloadArchive(downloadUrl, tempDownloadDirectory);
+    File downloadedArchive = new File(tempDownloadDirectory, new File(downloadUrl.getPath()).getName());
+    downloadFile(downloadUrl, downloadedArchive);
+    verifyChecksum(downloadUrl, downloadedArchive);
+
+    extractArchive(downloadedArchive, tempDownloadDirectory);
 
     File packInExtractedArchive = new File(tempDownloadDirectory, packInJKubeDir.toFile().getName());
     if (!packInExtractedArchive.exists()) {
@@ -100,6 +112,60 @@ public class BuildPackCliDownloader {
     }
     Files.copy(packInExtractedArchive.toPath(), packInJKubeDir, REPLACE_EXISTING, COPY_ATTRIBUTES);
     FileUtil.cleanDirectory(tempDownloadDirectory);
+  }
+
+  private void verifyChecksum(URL archiveUrl, File downloadedArchive) throws IOException {
+    URL checksumUrl = new URL(archiveUrl.toExternalForm() + SHA256_SUFFIX);
+    File checksumFile = new File(downloadedArchive.getParentFile(), downloadedArchive.getName() + SHA256_SUFFIX);
+    downloadFile(checksumUrl, checksumFile);
+
+    String expectedChecksum = parseExpectedChecksum(
+        new String(Files.readAllBytes(checksumFile.toPath()), StandardCharsets.UTF_8));
+    String actualChecksum = calculateSha256(downloadedArchive);
+
+    if (!expectedChecksum.equalsIgnoreCase(actualChecksum)) {
+      throw new IOException(String.format(
+          "Checksum mismatch for downloaded pack CLI archive %s: expected %s but got %s",
+          downloadedArchive.getName(), expectedChecksum, actualChecksum));
+    }
+    kitLogger.debug("Checksum verified for pack CLI archive %s", downloadedArchive.getName());
+  }
+
+  static String parseExpectedChecksum(String sha256FileContent) {
+    if (StringUtils.isBlank(sha256FileContent)) {
+      throw new IllegalStateException("Checksum file is empty");
+    }
+    String firstLine = sha256FileContent.trim().split("\\r?\\n")[0].trim();
+    String[] parts = firstLine.split("\\s+");
+    if (parts.length == 0 || StringUtils.isBlank(parts[0])) {
+      throw new IllegalStateException("Unable to parse checksum from: " + sha256FileContent);
+    }
+    return parts[0];
+  }
+
+  static String calculateSha256(File file) throws IOException {
+    MessageDigest digest;
+    try {
+      digest = MessageDigest.getInstance(SHA256_ALGORITHM);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 algorithm not available", e);
+    }
+    try (InputStream inputStream = Files.newInputStream(file.toPath())) {
+      byte[] buffer = new byte[8192];
+      int bytesRead;
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        digest.update(buffer, 0, bytesRead);
+      }
+    }
+    StringBuilder hexString = new StringBuilder();
+    for (byte b : digest.digest()) {
+      String hex = Integer.toHexString(0xff & b);
+      if (hex.length() == 1) {
+        hexString.append('0');
+      }
+      hexString.append(hex);
+    }
+    return hexString.toString();
   }
 
   private String inferApplicableDownloadArtifactUrl() {

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/AbstractBuildPackCliDownloaderTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/AbstractBuildPackCliDownloaderTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.kit.service.buildpacks;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +54,7 @@ abstract class AbstractBuildPackCliDownloaderTest {
   abstract String getInvalidApplicablePackBinary();
   abstract String getPlatform();
   abstract String getProcessorArchitecture();
+  abstract String getApplicableArtifactFileName();
 
   @BeforeEach
   void setUp() {
@@ -139,15 +141,91 @@ abstract class AbstractBuildPackCliDownloaderTest {
       @DisplayName("copy downloaded binary to user's .jkube folder and return path")
       void jKubeDirPathIsReturned() {
         assertThat(pack.toPath())
-            .isEqualTo(temporaryFolder.toPath().resolve(".jkube").resolve(getApplicablePackBinary()));
+                .isEqualTo(temporaryFolder.toPath().resolve(".jkube").resolve(getApplicablePackBinary()));
       }
 
       @Test
       @DisplayName("copied downloaded binary exists and has the right size")
       void fileExistsAndHasTheRightSize() {
         assertThat(pack)
-            .exists()
-            .satisfies(p -> assertThat(p).isNotEmpty());
+                .exists()
+                .satisfies(p -> assertThat(p).isNotEmpty());
+      }
+    }
+
+    @Nested
+    @DisplayName("checksum verification")
+    class ChecksumVerification {
+
+      @Test
+      @DisplayName("matching checksum, then download succeeds and binary is valid")
+      void givenMatchingChecksum_thenDownloadSucceeds() {
+        // Given - server already serves a correct .sha256 for every fixture artifact by default
+
+        // When
+        File pack = buildPackCliDownloader.getPackCLIIfPresentOrDownload();
+
+        // Then
+        assertThat(pack).exists();
+        assertThat(pack.toPath())
+                .isEqualTo(temporaryFolder.toPath().resolve(".jkube").resolve(getApplicablePackBinary()));
+      }
+
+      @Test
+      @DisplayName("checksum mismatch, then download fails and falls back to local binary lookup")
+      void givenChecksumMismatch_thenDownloadFailsAndFallsBackToLocal() throws IOException {
+        // Given
+        corruptChecksumFile();
+
+        // When + Then
+        assertThatIllegalStateException()
+                .isThrownBy(buildPackCliDownloader::getPackCLIIfPresentOrDownload)
+                .withMessage("No local pack binary found");
+
+        ArgumentCaptor<String> downloadFailureMessage = ArgumentCaptor.forClass(String.class);
+        verify(kitLogger).warn(downloadFailureMessage.capture());
+        assertThat(downloadFailureMessage.getValue()).contains("Checksum mismatch");
+      }
+
+      @Test
+      @DisplayName("checksum file missing (404), then download fails and falls back to local binary lookup")
+      void givenMissingChecksumFile_thenDownloadFailsAndFallsBackToLocal() throws IOException {
+        // Given
+        deleteChecksumFile();
+
+        // When + Then
+        assertThatIllegalStateException()
+                .isThrownBy(buildPackCliDownloader::getPackCLIIfPresentOrDownload)
+                .withMessage("No local pack binary found");
+
+        verify(kitLogger).warn(org.mockito.ArgumentMatchers.contains("Not able to download pack CLI"));
+      }
+
+      @Test
+      @DisplayName("checksum mismatch but valid local binary exists, then local binary is used")
+      void givenChecksumMismatchButValidLocalBinaryExists_thenLocalBinaryReturned() throws IOException {
+        // Given
+        corruptChecksumFile();
+        givenPackCliPresentOnUserPath(String.format("/%s", getApplicablePackBinary()));
+
+        // When
+        File downloadedCli = buildPackCliDownloader.getPackCLIIfPresentOrDownload();
+
+        // Then
+        assertThat(downloadedCli)
+                .isEqualTo(temporaryFolder.toPath().resolve("bin").resolve(getApplicablePackBinary()).toFile());
+      }
+
+      private void corruptChecksumFile() throws IOException {
+        File checksumFile = new File(server.getArtifactsDir(), getApplicableArtifactFileName() + ".sha256");
+        Files.write(checksumFile.toPath(),
+                ("0000000000000000000000000000000000000000000000000000000000000000  " + getApplicableArtifactFileName())
+                        .getBytes(StandardCharsets.UTF_8));
+      }
+
+      private void deleteChecksumFile() throws IOException {
+        File checksumFile = new File(server.getArtifactsDir(), getApplicableArtifactFileName() + ".sha256");
+        Files.delete(checksumFile.toPath());
       }
     }
 
@@ -190,8 +268,8 @@ abstract class AbstractBuildPackCliDownloaderTest {
       void givenNoLocalPackBinaryInUserPath_thenThrowException() {
         // When + Then
         assertThatIllegalStateException()
-            .isThrownBy(buildPackCliDownloader::getPackCLIIfPresentOrDownload)
-            .withMessage("No local pack binary found");
+                .isThrownBy(buildPackCliDownloader::getPackCLIIfPresentOrDownload)
+                .withMessage("No local pack binary found");
       }
 
       @Test
@@ -215,16 +293,16 @@ abstract class AbstractBuildPackCliDownloaderTest {
 
         // When + Then
         assertThatIllegalStateException()
-            .isThrownBy(buildPackCliDownloader::getPackCLIIfPresentOrDownload)
-            .withMessage("No local pack binary found");
+                .isThrownBy(buildPackCliDownloader::getPackCLIIfPresentOrDownload)
+                .withMessage("No local pack binary found");
       }
+    }
 
-      private void givenPackCliPresentOnUserPath(String packResource) throws IOException {
-        File bin = new File(temporaryFolder, "bin");
-        File pack = new File(Objects.requireNonNull(getClass().getResource(packResource)).getFile());
-        Files.createDirectory(bin.toPath());
-        Files.copy(pack.toPath(), bin.toPath().resolve(pack.getName()), COPY_ATTRIBUTES);
-      }
+    private void givenPackCliPresentOnUserPath(String packResource) throws IOException {
+      File bin = new File(temporaryFolder, "bin");
+      File pack = new File(Objects.requireNonNull(getClass().getResource(packResource)).getFile());
+      Files.createDirectory(bin.toPath());
+      Files.copy(pack.toPath(), bin.toPath().resolve(pack.getName()), COPY_ATTRIBUTES);
     }
   }
 

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCliDownloaderChecksumTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/BuildPackCliDownloaderChecksumTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.service.buildpacks;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+class BuildPackCliDownloaderChecksumTest {
+
+  @TempDir
+  private File temporaryFolder;
+
+  // ── parseExpectedChecksum ────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("parseExpectedChecksum: bare hex-only line returns the hash")
+  void parseExpectedChecksum_bareHash_returnsHash() {
+    String result = BuildPackCliDownloader.parseExpectedChecksum(
+        "abc123def456abc123def456abc123def456abc123def456abc123def456abc1");
+    assertThat(result).isEqualTo("abc123def456abc123def456abc123def456abc123def456abc123def456abc1");
+  }
+
+  @Test
+  @DisplayName("parseExpectedChecksum: BSD-style '<hash>  <filename>' returns the hash")
+  void parseExpectedChecksum_bsdStyleLine_returnsHash() {
+    String result = BuildPackCliDownloader.parseExpectedChecksum(
+        "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef  pack-v0.32.1-linux.tgz");
+    assertThat(result).isEqualTo("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+  }
+
+  @Test
+  @DisplayName("parseExpectedChecksum: content with trailing newline is handled")
+  void parseExpectedChecksum_trailingNewline_returnsHash() {
+    String result = BuildPackCliDownloader.parseExpectedChecksum(
+        "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe  artifact.tgz\n");
+    assertThat(result).isEqualTo("cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe");
+  }
+
+  @Test
+  @DisplayName("parseExpectedChecksum: blank content throws IllegalStateException")
+  void parseExpectedChecksum_blankContent_throwsIllegalState() {
+    assertThatIllegalStateException()
+        .isThrownBy(() -> BuildPackCliDownloader.parseExpectedChecksum("   "))
+        .withMessage("Checksum file is empty");
+  }
+
+  @Test
+  @DisplayName("parseExpectedChecksum: empty string throws IllegalStateException")
+  void parseExpectedChecksum_emptyString_throwsIllegalState() {
+    assertThatIllegalStateException()
+        .isThrownBy(() -> BuildPackCliDownloader.parseExpectedChecksum(""))
+        .withMessage("Checksum file is empty");
+  }
+
+  // ── calculateSha256 ──────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("calculateSha256: known content produces expected digest")
+  void calculateSha256_knownContent_producesExpectedDigest() throws IOException {
+    // SHA-256 of the UTF-8 bytes of "hello" is well-known
+    File file = new File(temporaryFolder, "hello.txt");
+    Files.write(file.toPath(), "hello".getBytes(StandardCharsets.UTF_8));
+
+    String digest = BuildPackCliDownloader.calculateSha256(file);
+
+    assertThat(digest).isEqualTo("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+  }
+
+  @Test
+  @DisplayName("calculateSha256: empty file produces well-known SHA-256 of empty input")
+  void calculateSha256_emptyFile_producesEmptyFileDigest() throws IOException {
+    File file = new File(temporaryFolder, "empty.txt");
+    assertThat(file.createNewFile()).isTrue();
+
+    String digest = BuildPackCliDownloader.calculateSha256(file);
+
+    // SHA-256("") == e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    assertThat(digest).isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  }
+
+  @Test
+  @DisplayName("calculateSha256: returns lowercase hex string of length 64")
+  void calculateSha256_returnsLowercaseHex64Chars() throws IOException {
+    File file = new File(temporaryFolder, "data.bin");
+    Files.write(file.toPath(), new byte[]{1, 2, 3, 4, 5});
+
+    String digest = BuildPackCliDownloader.calculateSha256(file);
+
+    assertThat(digest)
+        .hasSize(64)
+        .matches("[0-9a-f]+");
+  }
+}

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/LinuxArm64BuildPackCliDownloaderTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/LinuxArm64BuildPackCliDownloaderTest.java
@@ -37,4 +37,9 @@ public class LinuxArm64BuildPackCliDownloaderTest extends AbstractBuildPackCliDo
   String getProcessorArchitecture() {
     return "aarch64";
   }
+
+  @Override
+  String getApplicableArtifactFileName() {
+    return "pack-v0.32.1-linux-arm64.tgz";
+  }
 }

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/LinuxBuildPackCliDownloaderTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/LinuxBuildPackCliDownloaderTest.java
@@ -38,4 +38,9 @@ class LinuxBuildPackCliDownloaderTest extends AbstractBuildPackCliDownloaderTest
   String getProcessorArchitecture() {
     return "amd64";
   }
+
+  @Override
+  String getApplicableArtifactFileName() {
+    return "pack-v0.32.1-linux.tgz";
+  }
 }

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/MacOsArm64BuildPackCliDownloaderTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/MacOsArm64BuildPackCliDownloaderTest.java
@@ -37,4 +37,9 @@ public class MacOsArm64BuildPackCliDownloaderTest extends AbstractBuildPackCliDo
   String getProcessorArchitecture() {
     return "aarch64";
   }
+
+  @Override
+  String getApplicableArtifactFileName() {
+    return "pack-v0.32.1-macos-arm64.tgz";
+  }
 }

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/MacOsBuildPackCliDownloaderTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/MacOsBuildPackCliDownloaderTest.java
@@ -37,4 +37,9 @@ class MacOsBuildPackCliDownloaderTest extends AbstractBuildPackCliDownloaderTest
   String getProcessorArchitecture() {
     return "amd64";
   }
+
+  @Override
+  String getApplicableArtifactFileName() {
+    return "pack-v0.32.1-macos.tgz";
+  }
 }

--- a/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/WindowsBuildPackCliDownloaderTest.java
+++ b/jkube-kit/build/service/buildpacks/src/test/java/org/eclipse/jkube/kit/service/buildpacks/WindowsBuildPackCliDownloaderTest.java
@@ -37,4 +37,9 @@ class WindowsBuildPackCliDownloaderTest extends AbstractBuildPackCliDownloaderTe
   String getProcessorArchitecture() {
     return "amd64";
   }
+
+  @Override
+  String getApplicableArtifactFileName() {
+    return "pack-v0.32.1-windows.zip";
+  }
 }

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/IoUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/IoUtil.java
@@ -20,6 +20,7 @@ import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -84,6 +85,21 @@ public class IoUtil {
         download(downloadUrl, response -> {
             try (InputStream is = response.body()) {
                 extractArchive(is, target);
+            }
+        });
+    }
+
+    /**
+     * Download the contents of a URL and save them to a file.
+     *
+     * @param downloadUrl the URL to download from
+     * @param target the file to write the downloaded content to
+     * @throws IOException in case of error while downloading
+     */
+    public static void downloadFile(URL downloadUrl, File target) throws IOException {
+        download(downloadUrl, response -> {
+            try (InputStream is = response.body()) {
+                Files.copy(is, target.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
         });
     }

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/TestHttpBuildPacksArtifactsServer.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/TestHttpBuildPacksArtifactsServer.java
@@ -19,6 +19,10 @@ import org.eclipse.jkube.kit.common.util.FileUtil;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
 
 public class TestHttpBuildPacksArtifactsServer implements Closeable {
@@ -28,6 +32,7 @@ public class TestHttpBuildPacksArtifactsServer implements Closeable {
   private static final String MACOS_ARTIFACT = "pack-v0.32.1-macos.tgz";
   private static final String MACOS_ARM64_ARTIFACT = "pack-v0.32.1-macos-arm64.tgz";
   private static final String WINDOWS_ARTIFACT = "pack-v0.32.1-windows.zip";
+  private static final String SHA256_SUFFIX = ".sha256";
   private final File remoteBuildPackArtifactsDir;
 
   public TestHttpBuildPacksArtifactsServer() {
@@ -58,6 +63,9 @@ public class TestHttpBuildPacksArtifactsServer implements Closeable {
   public String getBaseUrl() {
     return String.format("http://localhost:%d", testHttpStaticServer.getPort());
   }
+  public File getArtifactsDir() {
+    return remoteBuildPackArtifactsDir;
+  }
 
   private String createUrlForArtifact(String artifactName) {
     return String.format("%s/%s", getBaseUrl(), artifactName);
@@ -67,15 +75,47 @@ public class TestHttpBuildPacksArtifactsServer implements Closeable {
     try {
       File artifactDir = FileUtil.createTempDirectory();
 
-      FileUtils.copyInputStreamToFile(Objects.requireNonNull(TestHttpBuildPacksArtifactsServer.class.getResourceAsStream(String.format("/buildpack-download-artifacts/%s", LINUX_ARTIFACT))), new File(artifactDir, LINUX_ARTIFACT));
-      FileUtils.copyInputStreamToFile(Objects.requireNonNull(TestHttpBuildPacksArtifactsServer.class.getResourceAsStream(String.format("/buildpack-download-artifacts/%s", LINUX_ARM64_ARTIFACT))), new File(artifactDir, LINUX_ARM64_ARTIFACT));
-      FileUtils.copyInputStreamToFile(Objects.requireNonNull(TestHttpBuildPacksArtifactsServer.class.getResourceAsStream(String.format("/buildpack-download-artifacts/%s", MACOS_ARTIFACT))), new File(artifactDir, MACOS_ARTIFACT));
-      FileUtils.copyInputStreamToFile(Objects.requireNonNull(TestHttpBuildPacksArtifactsServer.class.getResourceAsStream(String.format("/buildpack-download-artifacts/%s", MACOS_ARM64_ARTIFACT))), new File(artifactDir, MACOS_ARM64_ARTIFACT));
-      FileUtils.copyInputStreamToFile(Objects.requireNonNull(TestHttpBuildPacksArtifactsServer.class.getResourceAsStream(String.format("/buildpack-download-artifacts/%s", WINDOWS_ARTIFACT))), new File(artifactDir, WINDOWS_ARTIFACT));
+      copyArtifactWithChecksum(artifactDir, LINUX_ARTIFACT);
+      copyArtifactWithChecksum(artifactDir, LINUX_ARM64_ARTIFACT);
+      copyArtifactWithChecksum(artifactDir, MACOS_ARTIFACT);
+      copyArtifactWithChecksum(artifactDir, MACOS_ARM64_ARTIFACT);
+      copyArtifactWithChecksum(artifactDir, WINDOWS_ARTIFACT);
       return artifactDir;
     } catch (IOException ioException) {
       throw new IllegalStateException("Failure in creating build pack artifacts server : ", ioException);
     }
+  }
+
+  private void copyArtifactWithChecksum(File artifactDir, String artifactName) throws IOException {
+    File artifactFile = new File(artifactDir, artifactName);
+    FileUtils.copyInputStreamToFile(
+            Objects.requireNonNull(TestHttpBuildPacksArtifactsServer.class.getResourceAsStream(
+                    String.format("/buildpack-download-artifacts/%s", artifactName))),
+            artifactFile);
+
+    File checksumFile = new File(artifactDir, artifactName + SHA256_SUFFIX);
+    String checksum = calculateSha256(artifactFile);
+    Files.write(checksumFile.toPath(),
+            (checksum + "  " + artifactName + System.lineSeparator()).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String calculateSha256(File file) throws IOException {
+    MessageDigest digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 algorithm not available", e);
+    }
+    digest.update(Files.readAllBytes(file.toPath()));
+    StringBuilder hexString = new StringBuilder();
+    for (byte b : digest.digest()) {
+      String hex = Integer.toHexString(0xff & b);
+      if (hex.length() == 1) {
+        hexString.append('0');
+      }
+      hexString.append(hex);
+    }
+    return hexString.toString();
   }
 
   @Override

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/IoUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/IoUtilTest.java
@@ -181,4 +181,52 @@ class IoUtilTest {
         }
     }
 
+    @Test
+    void downloadFile_whenRemoteFileAvailable_thenSaveToTargetFile() throws IOException {
+        File remoteDirectory = new File(getClass().getResource("/remote-resources").getFile());
+        try (TestHttpStaticServer http = new TestHttpStaticServer(remoteDirectory)) {
+            // Given
+            URL downloadUrl = new URL(String.format("http://localhost:%d/deployment.yaml", http.getPort()));
+            File targetFile = new File(temporaryFolder, "deployment.yaml");
+
+            // When
+            IoUtil.downloadFile(downloadUrl, targetFile);
+
+            // Then
+            assertThat(targetFile).exists().isNotEmpty();
+        }
+    }
+
+    @Test
+    void downloadFile_whenRemoteFileNotAvailable_thenThrowIOException() throws IOException {
+        File remoteDirectory = new File(getClass().getResource("/remote-resources").getFile());
+        try (TestHttpStaticServer http = new TestHttpStaticServer(remoteDirectory)) {
+            // Given
+            URL downloadUrl = new URL(String.format("http://localhost:%d/does-not-exist.yaml", http.getPort()));
+            File targetFile = new File(temporaryFolder, "does-not-exist.yaml");
+
+            // When + Then
+            assertThatIOException()
+                    .isThrownBy(() -> IoUtil.downloadFile(downloadUrl, targetFile))
+                    .withMessageContaining("Got (404) while downloading from URL");
+        }
+    }
+
+    @Test
+    void downloadFile_whenTargetFileAlreadyExists_thenOverwriteIt() throws IOException {
+        File remoteDirectory = new File(getClass().getResource("/remote-resources").getFile());
+        try (TestHttpStaticServer http = new TestHttpStaticServer(remoteDirectory)) {
+            // Given
+            URL downloadUrl = new URL(String.format("http://localhost:%d/deployment.yaml", http.getPort()));
+            File targetFile = new File(temporaryFolder, "deployment.yaml");
+            assertThat(targetFile.createNewFile()).isTrue();
+
+            // When
+            IoUtil.downloadFile(downloadUrl, targetFile);
+
+            // Then
+            assertThat(targetFile).exists().isNotEmpty();
+        }
+    }
+
 }

--- a/jkube-kit/doc/src/main/asciidoc/inc/_integrations.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/_integrations.adoc
@@ -86,7 +86,10 @@ gradle {task-prefix}Build -Djkube.build.strategy=buildpacks
 endif::[]
 
 {plugin} downloads https://buildpacks.io/docs/tools/pack/[Pack CLI] to the user's `$HOME/.jkube` folder and starts the
-`pack build` process. If the download for the https://buildpacks.io/docs/tools/pack/[Pack CLI] binary fails, {plugin} looks for any locally installed https://buildpacks.io/docs/tools/pack/[Pack CLI] version.
+`pack build` process. The downloaded archive is verified against its published SHA-256 checksum to ensure integrity; the build
+fails with a clear error message if the checksums do not match. If the download or verification for the
+https://buildpacks.io/docs/tools/pack/[Pack CLI] binary fails, {plugin} looks for any locally installed
+https://buildpacks.io/docs/tools/pack/[Pack CLI] version.
 
 === Buildpack Builder Image
 - If no builder image is configured, then {plugin} uses `paketobuildpacks/builder-jammy-base` as the default builder image.


### PR DESCRIPTION
…(#3910)

The BuildPackCliDownloader previously downloaded the pack CLI archive over HTTPS without performing any integrity verification, leaving it vulnerable to MITM attacks, compromised CDN edges, or DNS hijacks.

Pack CLI publishes a .sha256 file alongside every release artifact. This change downloads that file immediately after fetching the archive, computes the SHA-256 of the local copy, and fails the build with a clear error message if the digests do not match. If verification fails, the downloader falls back to any locally installed pack binary.

Changes:
- BuildPackCliDownloader: extract archive download into downloadFile() (via new IoUtil helper), then call verifyChecksum() before unpacking; add package-private helpers parseExpectedChecksum() and calculateSha256() for unit-testability.
- IoUtil: add downloadFile(URL, File) that streams a URL response body directly to disk via Files.copy().
- TestHttpBuildPacksArtifactsServer: generate a correct .sha256 sidecar for every fixture artifact at server startup; expose getArtifactsDir() so tests can corrupt or delete individual files.
- AbstractBuildPackCliDownloaderTest: add abstract getApplicableArtifactFileName(); add ChecksumVerification nested class covering happy-path, mismatch (falls back to local binary), missing checksum file, and mismatch-with-valid-local-binary cases.
- All five concrete test subclasses (Linux, LinuxArm64, MacOs, MacOsArm64, Windows): implement getApplicableArtifactFileName() returning the correct platform artifact name.
- CHANGELOG.md: add entry for #3910 under 1.21-SNAPSHOT.
- _integrations.adoc: document SHA-256 verification step in the Buildpacks section describing pack CLI download behaviour.

Fixes: https://github.com/eclipse-jkube/jkube/issues/3910

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #3910
BuildPackCliDownloader downloaded the pack CLI binary over HTTPS with no integrity check  a compromised CDN, MITM attack, or DNS hijack could substitute a malicious binary that runs with the user's privileges.

Pack CLI publishes a .sha256 sidecar file alongside every release artifact. This PR downloads that file after fetching the archive, computes the SHA-256 of the local copy, and fails the build with a clear error if the digests do not match. If download or verification fails, the plugin falls back to any locally installed pack binary.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ x] Bug fix (non-breaking change which fixes an issue)
 - [] Feature (non-breaking change which adds functionality)
 - [] Breaking change (fix or feature that would cause existing functionality to change
 - [] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [ x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [ x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ x] My code follows the style guidelines of this project
 - [ x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [ x] I have performed a self-review of my code
 - [ x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ x] I have added tests that prove my fix is effective or that my feature works
 - [ x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
